### PR TITLE
Update travis to use address sanitizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
   - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers gcc-4.8 g++-4.8 gfortran-4.8
+  - export CXX=g++-4.8
+  - export CC=gcc-4.8
 script:
   - make -j
   - cd $OCCA_DIR/examples/addVectors/

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,5 @@ script:
 notifications:
   email:
     recipients:
-      - dmed256@gmail.com
-      - spam.warburton@gmail.com
     on_success: [never]
     on_failure: [always]

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   global:
     - OCCA_DIR=$TRAVIS_BUILD_DIR
     - OMP_NUM_THREADS=4
+    - ASAN_OPTIONS=detect_leaks=1
     - FC=gfortran-4.9
     - OCCA_FORTRAN_ENABLED=1
     - LD_LIBRARY_PATH=$OCCA_DIR/lib:$LD_LIBRARY_PATH
@@ -15,18 +16,40 @@ before_install:
   - export CXX=g++-4.9
   - export CC=gcc-4.9
 script:
-  - make -j
+  - echo 'with library address sanitizer'
+  - make -j CXXFLAGS='-fsanitize=address -fno-omit-frame-pointer -g' FCFLAGS='-fsanitize=address -fno-omit-frame-pointer -g'
   - cd $OCCA_DIR/examples/addVectors/
-  - make -j
+  - make -j CXXFLAGS='-fsanitize=address -fno-omit-frame-pointer -g' FCFLAGS='-fsanitize=address -fno-omit-frame-pointer -g'
   - ./main
   - ./main_c
   - ./main_f90
+  - make clean
   - cd $OCCA_DIR/examples/reduction/
-  - make -j
+  - make -j CXXFLAGS='-fsanitize=address -fno-omit-frame-pointer -g' FCFLAGS='-fsanitize=address -fno-omit-frame-pointer -g'
   - ./main
+  - make clean
   - cd $OCCA_DIR/examples/usingArrays/
-  - make -j
+  - make -j CXXFLAGS='-fsanitize=address -fno-omit-frame-pointer -g' FCFLAGS='-fsanitize=address -fno-omit-frame-pointer -g'
   - ./main
+  - make clean
+  - echo 'without library address sanitizer'
+  - cd $OCCA_DIR
+  - make clean
+  - make -j CXXFLAGS='-fno-omit-frame-pointer -g' FCFLAGS='-fno-omit-frame-pointer -g'
+  - cd $OCCA_DIR/examples/addVectors/
+  - make -j CXXFLAGS='-fsanitize=address -fno-omit-frame-pointer -g' FCFLAGS='-fsanitize=address -fno-omit-frame-pointer -g'
+  - ./main
+  - ./main_c
+  - ./main_f90
+  - make clean
+  - cd $OCCA_DIR/examples/reduction/
+  - make -j CXXFLAGS='-fsanitize=address -fno-omit-frame-pointer -g' FCFLAGS='-fsanitize=address -fno-omit-frame-pointer -g'
+  - ./main
+  - make clean
+  - cd $OCCA_DIR/examples/usingArrays/
+  - make -j CXXFLAGS='-fsanitize=address -fno-omit-frame-pointer -g' FCFLAGS='-fsanitize=address -fno-omit-frame-pointer -g'
+  - ./main
+  - make clean
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,15 @@ env:
   global:
     - OCCA_DIR=$TRAVIS_BUILD_DIR
     - OMP_NUM_THREADS=4
-    - CXX=g++-4.8
-    - FC=gfortran-4.8
+    - FC=gfortran-4.9
     - OCCA_FORTRAN_ENABLED=1
     - LD_LIBRARY_PATH=$OCCA_DIR/lib:$LD_LIBRARY_PATH
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
-  - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers gcc-4.8 g++-4.8 gfortran-4.8
-  - export CXX=g++-4.8
-  - export CC=gcc-4.8
+  - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers gcc-4.9 g++-4.9 gfortran-4.9
+  - export CXX=g++-4.9
+  - export CC=gcc-4.9
 script:
   - make -j
   - cd $OCCA_DIR/examples/addVectors/


### PR DESCRIPTION
I updated the travis build to using [address-sanitizer](https://code.google.com/p/address-sanitizer/) (which is available in gcc-4.9 and later).

It shows that there are some addressing issues and memory leaks in the occa library. Some of the leaks will grow with time, i.e., every time a kernel is called and/or new kernels is built/loaded.

You can preview the new travis output [here](https://travis-ci.org/jkozdon/occa)