### PR TITLE
Fix memory leaks

### DIFF
--- a/examples/addVectors/main.c
+++ b/examples/addVectors/main.c
@@ -77,6 +77,7 @@ int main(int argc, char **argv){
   free(b);
   free(ab);
 
+  occaKernelInfoFree(info);
   occaKernelFree(addVectors);
   occaMemoryFree(o_a);
   occaMemoryFree(o_b);

--- a/include/occa/cBase.hpp
+++ b/include/occa/cBase.hpp
@@ -296,6 +296,7 @@ OCCA_LFUNC void OCCA_RFUNC occaDeviceWaitForTag(occaDevice device,
 OCCA_LFUNC double OCCA_RFUNC occaDeviceTimeBetweenTags(occaDevice device,
                                                        occaStreamTag startTag, occaStreamTag endTag);
 
+OCCA_LFUNC void OCCA_RFUNC occaGetStreamFree(occaStream stream);
 OCCA_LFUNC void OCCA_RFUNC occaStreamFree(occaStream stream);
 OCCA_LFUNC void OCCA_RFUNC occaDeviceFree(occaDevice device);
 //====================================

--- a/scripts/setupKernelOperators.py
+++ b/scripts/setupKernelOperators.py
@@ -306,6 +306,7 @@ def cOperatorDefinition(N):
             '        }\n'                                                         + \
             '        else {\n'                                                    + \
             '          kernel_.addArgument(i, occa::kernelArg(arg.value));\n'     + \
+            '          delete (occaType_t*) args[i];\n'                           + \
             '        }\n'                                                         + \
             '      }\n'                                                           + \
             '      \n'                                                            + \

--- a/src/CUDA.cpp
+++ b/src/CUDA.cpp
@@ -503,6 +503,8 @@ namespace occa {
 
     OCCA_CUDA_CHECK("Kernel (" + name + ") : Unloading Module",
                     cuModuleUnload(data_.module));
+
+    delete (CUDAKernelData_t*) this->data;
   }
   //==================================
 

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -744,6 +744,8 @@ namespace occa {
 
     OCCA_CL_CHECK("Kernel: Free",
                   clReleaseKernel(data_.kernel));
+
+    delete (OpenCLKernelData_t*) this->data;
   }
   //==================================
 

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -1093,6 +1093,8 @@ namespace occa {
     error = clReleaseMemObject(*((cl_mem*) handle));
 
     OCCA_CL_CHECK("Mapped Free: clReleaseMemObject", error);
+
+    delete (cl_mem*) handle;
   }
 
   template <>

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -1099,7 +1099,7 @@ namespace occa {
   void memory_t<OpenCL>::free(){
     clReleaseMemObject(*((cl_mem*) handle));
 
-    if(isAWrapper())
+    if(!isAWrapper())
       delete (cl_mem*) handle;
 
     if(isATexture()){

--- a/src/cBase.cpp
+++ b/src/cBase.cpp
@@ -961,6 +961,7 @@ void OCCA_RFUNC occaKernelRun_(occaKernel kernel,
     }
     else {
       kernel_.addArgument(i, occa::kernelArg(arg.value));
+      delete (occaType_t*) list_.argv[i];
     }
   }
 

--- a/src/cBase.cpp
+++ b/src/cBase.cpp
@@ -1157,6 +1157,7 @@ void OCCA_RFUNC occaMemoryFree(occaMemory memory){
   occa::memory memory_((occa::memory_v*) memory->value.data.void_);
 
   memory_.free();
+  delete (occaType_t *)memory;
 }
 //====================================
 

--- a/src/cBase.cpp
+++ b/src/cBase.cpp
@@ -816,6 +816,10 @@ double OCCA_RFUNC occaDeviceTimeBetweenTags(occaDevice device,
   return device_.timeBetween(startTag_, endTag_);
 }
 
+void OCCA_RFUNC occaGetStreamFree(occaStream stream){
+  delete (occa::stream*) stream;
+}
+
 void OCCA_RFUNC occaStreamFree(occaStream stream){
   ((occa::stream*) stream)->free();
   delete (occa::stream*) stream;

--- a/src/cBase.cpp
+++ b/src/cBase.cpp
@@ -818,6 +818,7 @@ double OCCA_RFUNC occaDeviceTimeBetweenTags(occaDevice device,
 
 void OCCA_RFUNC occaStreamFree(occaStream stream){
   ((occa::stream*) stream)->free();
+  delete (occa::stream*) stream;
 }
 
 void OCCA_RFUNC occaDeviceFree(occaDevice device){

--- a/src/operators/cKernelOperators.cpp
+++ b/src/operators/cKernelOperators.cpp
@@ -18,6 +18,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -45,6 +46,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -72,6 +74,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -100,6 +103,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -128,6 +132,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -156,6 +161,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -185,6 +191,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -214,6 +221,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -243,6 +251,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -273,6 +282,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -303,6 +313,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -333,6 +344,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -364,6 +376,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -395,6 +408,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -426,6 +440,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -458,6 +473,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -490,6 +506,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -522,6 +539,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -555,6 +573,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -588,6 +607,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -621,6 +641,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -655,6 +676,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -689,6 +711,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -723,6 +746,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -758,6 +782,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -793,6 +818,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -828,6 +854,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -864,6 +891,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -900,6 +928,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -936,6 +965,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -973,6 +1003,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1010,6 +1041,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1047,6 +1079,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1085,6 +1118,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1123,6 +1157,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1161,6 +1196,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1200,6 +1236,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1239,6 +1276,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1278,6 +1316,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1318,6 +1357,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1358,6 +1398,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1398,6 +1439,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1439,6 +1481,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1480,6 +1523,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1521,6 +1565,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1563,6 +1608,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1605,6 +1651,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1647,6 +1694,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1690,6 +1738,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       
@@ -1733,6 +1782,7 @@
         }
         else {
           kernel_.addArgument(i, occa::kernelArg(arg.value));
+          delete (occaType_t*) args[i];
         }
       }
       


### PR DESCRIPTION
Here are some changes to (hopefully) fix memory leaks in OpenCL, CUDA, and the C bindings.  I can use the address sanitizer in gcc to test the changes to OpenCL and the C bindings but not for CUDA.