### PR TITLE
Add ispc addVectors example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ benchmarks/
 scripts/occaBenchmark.cpp
 
 *.pyc
+/examples/addVectors/ispc/tasksys.cpp

--- a/examples/addVectors/ispc/addVectors.ispc
+++ b/examples/addVectors/ispc/addVectors.ispc
@@ -1,0 +1,40 @@
+#define WGDIM0 16
+#define WGDIM1 1
+#define WGDIM2 1
+
+task void addVectors_kernel(const uniform int dims[],
+                            const uniform int &entries,
+                            const uniform float a[],
+                            const uniform float b[],
+                                  uniform float ab[]) {
+  const int ntasks = dims[2] * dims[1] * dims[0];
+  const int wgsize = WGDIM0 * WGDIM1 * WGDIM2;
+  const int taskidx = taskIndex0 + dims[2] * taskIndex1 + dims[2] * dims[3] * taskIndex2;
+
+  foreach (i2 = 0 ... WGDIM2, i1 = 0 ... WGDIM1, i0 = 0 ... WGDIM0)
+  {
+    int wgindex = i0 + WGDIM0 * i1 + WGDIM1 * WGDIM0 * i2;
+
+    for (int i = taskidx * wgsize + wgindex; i < entries; i += ntasks * wgsize)
+    {
+      // print("%\n", i);
+      ab[i] = a[i] + b[i];
+    }
+  }
+}
+
+export void addVectors(const uniform int dims[],
+                       const uniform int o1,
+                       const uniform int o2,
+                       const uniform int o3,
+                       const uniform int &entries,
+                       const uniform float a[],
+                       const uniform float b[],
+                             uniform float ab[])
+{
+  assert(dims[5] == WGDIM0);
+  assert(dims[4] == WGDIM1);
+  assert(dims[3] == WGDIM2);
+
+  launch[dims[2], dims[1], dims[0]] addVectors_kernel(dims, entries, a, b, ab);
+}

--- a/examples/addVectors/ispc/addVectors.occa
+++ b/examples/addVectors/ispc/addVectors.occa
@@ -1,0 +1,24 @@
+occaFunction void addVectors_kernel(occaFunctionInfoarg,
+                                    occaConst int occaVariable entries,
+                                    occaConst occaPointer float a[],
+                                    occaConst occaPointer float b[],
+                                    occaPointer float ab[]) {
+
+
+  occaInnerFor{
+    for (int i = occaGlobalId; i < entries; i += occaGlobalDim)
+    {
+      ab[i] = a[i] + b[i];
+    }
+  }
+}
+
+occaKernel void addVectors(occaKernelInfoArg,
+                           occaConst int occaVariable entries,
+                           occaConst occaPointer float a[],
+                           occaConst occaPointer float b[],
+                           occaPointer float ab[])
+{
+  occaOuterFor
+    addVectors_kernel(occaFunctionInfo, entries, a, b, ab);
+}

--- a/examples/addVectors/ispc/addVectors.occa
+++ b/examples/addVectors/ispc/addVectors.occa
@@ -1,5 +1,13 @@
-occaFunction void addVectors_kernel(occaFunctionInfoarg,
-                                    occaConst int occaVariable entries,
+#undef occaInnerDim0
+#undef occaInnerDim1
+#undef occaInnerDim2
+
+#define occaInnerDim0 16
+#define occaInnerDim1 1
+#define occaInnerDim2 1
+
+occaFunction void addVectors_kernel(occaFunctionInfoArg,
+                                    occaConst occaPointer int &entries,
                                     occaConst occaPointer float a[],
                                     occaConst occaPointer float b[],
                                     occaPointer float ab[]) {
@@ -14,7 +22,7 @@ occaFunction void addVectors_kernel(occaFunctionInfoarg,
 }
 
 occaKernel void addVectors(occaKernelInfoArg,
-                           occaConst int occaVariable entries,
+                           occaConst occaPointer int &entries,
                            occaConst occaPointer float a[],
                            occaConst occaPointer float b[],
                            occaPointer float ab[])

--- a/examples/addVectors/ispc/main.cpp
+++ b/examples/addVectors/ispc/main.cpp
@@ -21,9 +21,9 @@ std::string ispcCreateSourceFileFrom(const std::string &filename,
   fs.open(cached_filename.c_str());
 
   if(filename.substr(filename.find_last_of(".") + 1) != "ispc"){
-    fs << "#include \"" << info.getModeHeaderFilename() << "\"\n"
+    //    fs << "#include \"" << info.getModeHeaderFilename() << "\"\n"
        //<< "#include \"" << occa::sys::getFilename("[occa]/primitives.hpp") << "\"\n"
-       << occa::readFile("patchISPC.hpp");
+      fs << occa::readFile("patchISPC.hpp");
   }
 
   fs << info.header
@@ -57,12 +57,14 @@ int main(int argc, char **argv){
 
   device.setup("mode = Serial");
   info.mode = occa::Serial;
+  info.addDefine("OCCA_SERIAL_DEFINES_HEADER", 1);
 
   o_a  = device.malloc(entries*sizeof(float));
   o_b  = device.malloc(entries*sizeof(float));
   o_ab = device.malloc(entries*sizeof(float));
 
-  std::string ispc_file = "addVectors.ispc";
+  //  std::string ispc_file = "addVectors.ispc";
+  std::string ispc_file = "addVectors.occa";
 
   // Note the following is not working yet;  The right headers need developed
   // to get this occa file to compile with ispc.

--- a/examples/addVectors/ispc/main.cpp
+++ b/examples/addVectors/ispc/main.cpp
@@ -1,0 +1,113 @@
+#include <iostream>
+
+#include "occa.hpp"
+#include "occa/tools.hpp"
+
+int main(int argc, char **argv){
+  occa::printAvailableDevices();
+
+  int entries = 37;
+
+  float *a  = new float[entries];
+  float *b  = new float[entries];
+  float *ab = new float[entries];
+
+  for(int i = 0; i < entries; ++i){
+    a[i]  = i;
+    b[i]  = 1 - i;
+    ab[i] = 0;
+  }
+
+  occa::device device;
+  occa::kernel addVectors;
+  occa::memory o_a, o_b, o_ab;
+
+  device.setup("mode = Serial");
+
+  o_a  = device.malloc(entries*sizeof(float));
+  o_b  = device.malloc(entries*sizeof(float));
+  o_ab = device.malloc(entries*sizeof(float));
+
+  std::string ispc_file = "addVectors.ispc";
+  std::string ispc_flags = " -g -O2 --pic";
+  std::string hash = occa::getFileContentHash(ispc_file, ispc_flags);
+  std::string ispc_object =
+    occa::sys::getFilename("[ispc]/" + ispc_file + "_" + hash + ".o");
+  std::string ispc_sharedobject =
+    occa::sys::getFilename("[ispc]/" + ispc_file + "_" + hash + ".so");
+
+  if(!occa::haveHash(hash)){
+    occa::waitForHash(hash);
+  }
+
+  if(std::system("test -f tasksys.cpp")){
+    occa::releaseHash(hash, 0);
+    OCCA_CHECK(false, "The required ispc tasksys.cpp file not found;"
+               " you can download it with:\n     curl -O "
+               "https://raw.githubusercontent.com/ispc/ispc/master/examples/tasksys.cpp");
+  }
+
+  if(!occa::sys::fileExists(ispc_object)){
+    // Hack to make sure the ispc directory exists.  TODO figure out the occa
+    // way to do this?
+    if(std::system("mkdir -p ~/._occa/libraries/ispc")){
+      occa::releaseHash(hash, 0);
+      OCCA_CHECK(false, "problems making ispc dir");
+    }
+
+    std::string command =
+      "ispc " + ispc_flags + " " + ispc_file + " -o " + ispc_object;
+
+    std::cout << "Compiling [" << ispc_file << "]\n" << command << "\n";
+
+    if(std::system(command.c_str())){
+      occa::releaseHash(hash, 0);
+      OCCA_CHECK(false, "ispc compilation error");
+    }
+    std::string sharedcommand = "g++ -Wl,-E -g -pipe -O2 -pipe -fPIC " +
+      ispc_object + " tasksys.cpp -shared -o " + ispc_sharedobject;
+    std::cout << "Creating shared object [" << ispc_file << "]\n" <<
+      sharedcommand << "\n";
+
+    if(std::system(sharedcommand.c_str())){
+      occa::releaseHash(hash, 0);
+      OCCA_CHECK(false, "ispc compilation error");
+    }
+  }
+
+  addVectors = device.buildKernelFromBinary(ispc_sharedobject, "addVectors");
+  occa::releaseHash(hash);
+
+  int dims = 1;
+  int itemsPerGroup = 16;
+  int groups((entries + itemsPerGroup - 1)/itemsPerGroup);
+
+  addVectors.setWorkingDims(dims, itemsPerGroup, groups);
+
+  o_a.copyFrom(a);
+  o_b.copyFrom(b);
+
+  addVectors(entries, o_a, o_b, o_ab);
+
+  o_ab.copyTo(ab);
+
+  for(int i = 0; i < entries; ++i)
+    std::cout << i << ": " << ab[i] << '\n';
+
+  for(int i = 0; i < entries; ++i){
+    if(ab[i] != (a[i] + b[i]))
+      throw 1;
+  }
+
+  delete [] a;
+  delete [] b;
+  delete [] ab;
+
+  addVectors.free();
+  o_a.free();
+  o_b.free();
+  o_ab.free();
+  device.free();
+
+  return 0;
+}

--- a/examples/addVectors/ispc/makefile
+++ b/examples/addVectors/ispc/makefile
@@ -1,0 +1,26 @@
+ifndef OCCA_DIR
+ERROR:
+	@echo "Error, environment variable [OCCA_DIR] is not set"
+endif
+
+include ${OCCA_DIR}/scripts/makefile
+
+#---[ COMPILATION ]-------------------------------
+headers = $(wildcard $(iPath)/*.hpp) $(wildcard $(iPath)/*.tpp)
+sources = $(wildcard $(sPath)/*.cpp)
+
+objects = $(subst $(sPath)/,$(oPath)/,$(sources:.cpp=.o))
+
+main: $(objects) $(headers) main.cpp tasksys.cpp
+	$(compiler) $(compilerFlags) -o main $(flags) $(objects) main.cpp $(paths) $(links)
+
+$(oPath)/%.o:$(sPath)/%.cpp $(wildcard $(subst $(sPath)/,$(iPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(sPath)/,$(iPath)/,$(<:.cpp=.tpp)))
+	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<
+
+tasksys.cpp:
+	curl -O https://raw.githubusercontent.com/ispc/ispc/master/examples/tasksys.cpp
+
+clean:
+	rm -f $(oPath)/*;
+	rm -f main
+#=================================================

--- a/examples/addVectors/ispc/patchISPC.hpp
+++ b/examples/addVectors/ispc/patchISPC.hpp
@@ -1,34 +1,67 @@
-#undef  occaInnerFor
+// variable macros
+#define occaPointer uniform
+#define occaVariable &
+#define occaConst const
+#define occaRestrict 
+
+// function macros
+#define occaFunction task
+
+#define occaFunctionInfoArg const uniform int occaRestrict const occaKernelArgs[] 
+#define occaFunctionInfo                             occaKernelArgs
+
+// kernel info macros
+#define occaKernelInfoArg   const uniform int occaRestrict const occaKernelArgs[], uniform int occaInnerIdA, uniform int occaInnerIdB, uniform int occaInnerIdC
+
+#define occaKernel export
+
+// outer indices read from ISPC
+#define occaOuterId0 taskIndex0
+#define occaOuterId1 taskIndex1
+#define occaOuterId2 taskIndex2
+
+
+// parallel for loop macros
 #define occaInnerFor foreach(occaInnerId0 = 0 ... occaInnerDim0, occaInnerId1 = 0 ... occaInnerDim1, occaInnerId2 = 0 ... occaInnerDim2) 
 
-#undef  occaInnerFor0
 #define occaInnerFor0 foreach(occaInnerId0 = 0 ... occaInnerDim0)
 
-// not sure what to do with these
-#undef occaInnerFor1
 #define occaInnerFor1
 
-#undef occaInnerFor2
 #define occaInnerFor2
 
 // use occaOuterFor to launch
-#undef occaOuterFor
-#define occaOuterFor launch [ occaOuterFor0, occaOuterFor1, occaOuterFor2 ]
+#define occaOuterFor launch [ occaOuterDim0, occaOuterDim1, occaOuterDim2 ]
 
-#undef occaOuterFor0
 #define occaOuterFor0 occaOuterFor
 
-#undef occaOuterFor1
 #define occaOuterFor1
 
-#undef occaOuterFor2
 #define occaOuterFor2
 
-#undef occaParallelFor
 #define occaParallelFor
 
-#undef occaKernel
-#define occaKernel export
+//---[ Loop Info ]--------------------------------
+#define occaOuterDim2 occaKernelArgs[0]
+#define occaOuterDim1 occaKernelArgs[1]
+#define occaOuterDim0 occaKernelArgs[2]
+// - - - - - - - - - - - - - - - - - - - - - - - -
+
+#define occaInnerDim2 occaKernelArgs[3]
+#define occaInnerDim1 occaKernelArgs[4]
+#define occaInnerDim0 occaKernelArgs[5]
+
+// - - - - - - - - - - - - - - - - - - - - - - - -
+#define occaGlobalDim2 (occaInnerDim2 * occaOuterDim2)
+#define occaGlobalId2  (occaOuterId2*occaInnerDim2 + occaInnerId2)
+
+#define occaGlobalDim1 (occaInnerDim1 * occaOuterDim1)
+#define occaGlobalId1  (occaOuterId1*occaInnerDim1 + occaInnerId1)
+
+#define occaGlobalDim0 (occaInnerDim0 * occaOuterDim0)
+#define occaGlobalId0  (occaOuterId0*occaInnerDim0 + occaInnerId0)
+//================================================
+
 
 // useful macros
 #define occaGlobalId  (occaInnerId0 + occaInnerDim0*(occaInnerId1 + occaInnerDim1*(occaInnerId2 + occaOuterDim0*(occaOuterId0 + occaOuterDim1*(occaOuterId1 + occaOuterDim2*occaOuterId2)))))

--- a/examples/addVectors/ispc/patchISPC.hpp
+++ b/examples/addVectors/ispc/patchISPC.hpp
@@ -1,0 +1,35 @@
+#undef  occaInnerFor
+#define occaInnerFor foreach(occaInnerId0 = 0 ... occaInnerDim0, occaInnerId1 = 0 ... occaInnerDim1, occaInnerId2 = 0 ... occaInnerDim2) 
+
+#undef  occaInnerFor0
+#define occaInnerFor0 foreach(occaInnerId0 = 0 ... occaInnerDim0)
+
+// not sure what to do with these
+#undef occaInnerFor1
+#define occaInnerFor1
+
+#undef occaInnerFor2
+#define occaInnerFor2
+
+// use occaOuterFor to launch
+#undef occaOuterFor
+#define occaOuterFor launch [ occaOuterFor0, occaOuterFor1, occaOuterFor2 ]
+
+#undef occaOuterFor0
+#define occaOuterFor0 occaOuterFor
+
+#undef occaOuterFor1
+#define occaOuterFor1
+
+#undef occaOuterFor2
+#define occaOuterFor2
+
+#undef occaParallelFor
+#define occaParallelFor
+
+#undef occaKernel
+#define occaKernel export
+
+// useful macros
+#define occaGlobalId  (occaInnerId0 + occaInnerDim0*(occaInnerId1 + occaInnerDim1*(occaInnerId2 + occaOuterDim0*(occaOuterId0 + occaOuterDim1*(occaOuterId1 + occaOuterDim2*occaOuterId2)))))
+#define occaGlobalDim (occaOuterDim0*occaOuterDim1*occaOuterDim2)


### PR DESCRIPTION
This is a work in progress example.  I need to refactor the ISPC bits into a function call.

This adds the ispc addVectors example and does not include `tasksys.cpp` per @dmed256's instructions.

I have also included the `ISPCpatch.hpp` from @tcew but unfortunately I could not get it to work.  The ispc compiler doesn't like the `Serial.hpp` headers.  So we are going to have to develop a full set of headers for ispc to get it to work.