### PR TITLE
Heap Alignment

### DIFF
--- a/include/occa/tools.hpp
+++ b/include/occa/tools.hpp
@@ -50,6 +50,7 @@ namespace occa {
     extern std::string PATH, LD_LIBRARY_PATH;
 
     extern std::string OCCA_DIR, OCCA_CACHE_DIR;
+    extern size_t OCCA_HEAP_MEM_ALIGN;
     extern stringVector_t OCCA_INCLUDE_PATH;
 
     void initialize();

--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -500,10 +500,13 @@ namespace occa {
     void* malloc(uintptr_t bytes){
       void* ptr;
 
+      const size_t align
+        = (env::OCCA_HEAP_MEM_ALIGN)?env::OCCA_HEAP_MEM_ALIGN:OCCA_MEM_ALIGN;
+
 #if   (OCCA_OS & LINUX_OS)
-      ignoreResult( posix_memalign(&ptr, OCCA_MEM_ALIGN, bytes) );
+      ignoreResult( posix_memalign(&ptr, align, bytes) );
 #elif (OCCA_OS == OSX_OS)
-      ignoreResult( posix_memalign(&ptr, OCCA_MEM_ALIGN, bytes) );
+      ignoreResult( posix_memalign(&ptr, align, bytes) );
 #elif (OCCA_OS == WINDOWS_OS)
       ptr = ::malloc(bytes);
 #endif

--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -503,7 +503,7 @@ namespace occa {
 #if   (OCCA_OS & LINUX_OS)
       ignoreResult( posix_memalign(&ptr, OCCA_MEM_ALIGN, bytes) );
 #elif (OCCA_OS == OSX_OS)
-      ptr = ::malloc(bytes);
+      ignoreResult( posix_memalign(&ptr, OCCA_MEM_ALIGN, bytes) );
 #elif (OCCA_OS == WINDOWS_OS)
       ptr = ::malloc(bytes);
 #endif

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #include "occa/tools.hpp"
 #include "occa/base.hpp"
 
@@ -12,6 +14,7 @@ namespace occa {
     std::string PATH, LD_LIBRARY_PATH;
 
     std::string OCCA_DIR, OCCA_CACHE_DIR;
+    size_t OCCA_HEAP_MEM_ALIGN;
     stringVector_t OCCA_INCLUDE_PATH;
 
     void initialize(){
@@ -40,6 +43,21 @@ namespace occa {
 
       endDirWithSlash(OCCA_DIR);
       endDirWithSlash(OCCA_CACHE_DIR);
+
+      if(sys::echo("OCCA_HEAP_MEM_ALIGN").size() > 0){
+        OCCA_HEAP_MEM_ALIGN =
+          (size_t) std::atoi(sys::echo("OCCA_HEAP_MEM_ALIGN").c_str());
+
+        // Bit twiddling from
+        // http://www.exploringbinary.com/ten-ways-to-check-if-an-integer-is-a-power-of-two-in-c/
+        OCCA_CHECK(((OCCA_HEAP_MEM_ALIGN != 0) &&
+                    ((OCCA_HEAP_MEM_ALIGN &
+                      (~OCCA_HEAP_MEM_ALIGN + 1)) == OCCA_HEAP_MEM_ALIGN)),
+                   "Environment variable [OCCA_HEAP_MEM_ALIGN]"
+                   " is not a power of two");
+      }
+      else
+        OCCA_HEAP_MEM_ALIGN = 0;
 
       isInitialized = true;
     }


### PR DESCRIPTION
These changes align heap memory on OS X and add an environment variable `OCCA_HEAP_MEM_ALIGN` so the alignment can be specified at runtime.