### PR TITLE
[Core] fixing library build with mpi wrappers

### DIFF
--- a/scripts/shellTools.sh
+++ b/scripts/shellTools.sh
@@ -226,16 +226,9 @@ function resolveRelativePath {
 }
 
 function manualReadlink {
-    if [[ $(command -v readlink) == "" ]]; then
-        pushd `dirname $1` > /dev/null
-        SCRIPTPATH=`pwd -P`
-        popd > /dev/null
-    else
-        case "$(uname)" in
-            Darwin) readlink    $1;;
-            *)      readlink -f $1;;
-        esac
-    fi
+    pushd `dirname $1` > /dev/null
+    SCRIPTPATH=`pwd -P`
+    popd > /dev/null
 }
 
 function manualWhich {


### PR DESCRIPTION
I do not think that `readlink` does what you want it to. To get `occa` to build when using mpi compiler wrappers I needed to revert changes from 9e30f5e029740b9733963e47bf2f44098f65ef6d.

This was true on both Mac and Linux.