### PR TITLE
Detach methods for OCCA memory objects

### DIFF
--- a/include/occa/CUDA.hpp
+++ b/include/occa/CUDA.hpp
@@ -205,7 +205,13 @@ namespace occa {
   void memory_t<CUDA>::mappedFree();
 
   template <>
+  void memory_t<CUDA>::mappedDetach();
+
+  template <>
   void memory_t<CUDA>::free();
+
+  template <>
+  void memory_t<CUDA>::detach();
   //==================================
 
 

--- a/include/occa/HSA.hpp
+++ b/include/occa/HSA.hpp
@@ -161,7 +161,13 @@ namespace occa {
   void memory_t<HSA>::mappedFree();
 
   template <>
+  void memory_t<HSA>::mappedDetach();
+
+  template <>
   void memory_t<HSA>::free();
+
+  template <>
+  void memory_t<HSA>::detach();
   //==================================
 
 

--- a/include/occa/HSAV2.hpp
+++ b/include/occa/HSAV2.hpp
@@ -213,7 +213,13 @@ namespace occa {
   void memory_t<HSA>::mappedFree();
 
   template <>
+  void memory_t<HSA>::mappedDetach();
+
+  template <>
   void memory_t<HSA>::free();
+
+  template <>
+  void memory_t<HSA>::detach();
   //==================================
 
 

--- a/include/occa/OpenCL.hpp
+++ b/include/occa/OpenCL.hpp
@@ -212,7 +212,13 @@ namespace occa {
   void memory_t<OpenCL>::mappedFree();
 
   template <>
+  void memory_t<OpenCL>::mappedDetach();
+
+  template <>
   void memory_t<OpenCL>::free();
+
+  template <>
+  void memory_t<OpenCL>::detach();
   //==================================
 
 

--- a/include/occa/OpenMP.hpp
+++ b/include/occa/OpenMP.hpp
@@ -156,7 +156,13 @@ namespace occa {
   void memory_t<OpenMP>::mappedFree();
 
   template <>
+  void memory_t<OpenMP>::mappedDetach();
+
+  template <>
   void memory_t<OpenMP>::free();
+
+  template <>
+  void memory_t<OpenMP>::detach();
   //==================================
 
 

--- a/include/occa/Pthreads.hpp
+++ b/include/occa/Pthreads.hpp
@@ -213,7 +213,13 @@ namespace occa {
   void memory_t<Pthreads>::mappedFree();
 
   template <>
+  void memory_t<Pthreads>::mappedDetach();
+
+  template <>
   void memory_t<Pthreads>::free();
+
+  template <>
+  void memory_t<Pthreads>::detach();
   //====================================
 
 

--- a/include/occa/Serial.hpp
+++ b/include/occa/Serial.hpp
@@ -70,6 +70,34 @@ namespace occa {
     std::string getFieldFrom(const std::string &command,
                              const std::string &field);
 
+    ///
+    /// Filter output lines from a shell command to extract
+    /// a field/property value (string). Any whitespace
+    /// surrounding the value is clipped. The first match
+    /// is returned (the filter scan terminates).
+    ///
+    /// The returned string is the <value> in this line-match
+    /// pattern:
+    ///
+    ///    ^[WS]*<field>[WS]*<delim>[WS]*<value>[WS]*$
+    ///
+    ///
+    /// If no match is found, the empty string "" is returned.
+    ///
+    std::string getField(const std::string &shell_cmd,
+			 const std::string &field,
+			 bool ignoreCase = false,
+			 char delimiter = ':');
+
+    ///
+    /// Get value for CPU info field.
+    ///
+    /// This is essentially only valid for Linux, which
+    /// has /proc/cpuinfo.
+    ///
+    std::string getCPUINFOField(const std::string &field,
+				bool ignoreCase = false);
+
     std::string getProcessorName();
     int getCoreCount();
     int getProcessorFrequency();
@@ -218,7 +246,13 @@ namespace occa {
   void memory_t<Serial>::mappedFree();
 
   template <>
+  void memory_t<Serial>::mappedDetach();
+
+  template <>
   void memory_t<Serial>::free();
+
+  template <>
+  void memory_t<Serial>::detach();
   //==================================
 
 

--- a/include/occa/base.hpp
+++ b/include/occa/base.hpp
@@ -684,7 +684,11 @@ namespace occa {
 
     virtual void mappedFree() = 0;
 
+    virtual void mappedDetach() = 0;
+
     virtual void free() = 0;
+
+    virtual void detach() = 0;
 
     //---[ Friend Functions ]---------------------
 
@@ -776,7 +780,11 @@ namespace occa {
 
     void mappedFree();
 
+    void mappedDetach();
+
     void free();
+
+    void detach();
   };
 
 
@@ -818,6 +826,21 @@ namespace occa {
     void* textureArg2() const;
 
     void* getMappedPointer();
+
+    ///
+    /// Get the memory handle.
+    ///
+    /// The memory handle is a pointer that resides in host local
+    /// memory that is used to access the device memory encapsulated
+    /// by this memory object.
+    ///
+    /// What it points to depends on the OCCA device associated with
+    /// this memory object. For example, if the device is OpenCL,
+    /// then the handle is a pointer to a cl_mem. If the device is
+    /// CUDA, then the handle is a pointer to a CUdeviceptr. If the
+    /// device is Serial, OpenMP, or threads, then the handle is a
+    /// direct memory pointer to a byte(s) in host local memory.
+    ///
     void* getMemoryHandle();
     void* getTextureHandle();
 
@@ -867,7 +890,17 @@ namespace occa {
                      const uintptr_t destOffset = 0,
                      const uintptr_t srcOffset = 0);
 
+    ///
+    /// Free the memory object including its encapsulated device
+    /// memory.
+    ///
     void free();
+
+    ///
+    /// Free the memory object without freeing its encapsulated
+    /// device memory.
+    ///
+    void detach();
   };
 
 
@@ -1476,6 +1509,8 @@ namespace occa {
   void free(stream s);
   void free(kernel k);
   void free(memory m);
+
+  void detach(memory m);
   //   =================================
 
   //---[ KernelArg ]------------------------------

--- a/src/CUDA.cpp
+++ b/src/CUDA.cpp
@@ -916,11 +916,20 @@ namespace occa {
   }
 
   template <>
+  void memory_t<CUDA>::mappedDetach(){
+    if(isMapped()){
+      delete (CUdeviceptr*) handle;
+
+      size = 0;
+    }
+  }
+
+  template <>
   void memory_t<CUDA>::free(){
     if(!isATexture()){
       cuMemFree(*((CUdeviceptr*) handle));
       delete (CUdeviceptr*) handle;
-    }
+   }
     else{
       CUarray &array        = ((CUDATextureData_t*) handle)->array;
       CUsurfObject &surface = ((CUDATextureData_t*) handle)->surface;
@@ -930,7 +939,26 @@ namespace occa {
 
       delete (CUDATextureData_t*) handle;
       delete (CUaddress_mode*)    textureInfo.arg;
+      textureInfo.arg = NULL;
     }
+
+    handle = NULL;
+
+    size = 0;
+  }
+
+  template <>
+  void memory_t<CUDA>::detach(){
+    if(!isATexture()){
+      delete (CUdeviceptr*) handle;
+    }
+    else{
+      delete (CUDATextureData_t*) handle;
+      delete (CUaddress_mode*)    textureInfo.arg;
+      textureInfo.arg = NULL;
+    }
+
+    handle = NULL;
 
     size = 0;
   }

--- a/src/HSA.cpp
+++ b/src/HSA.cpp
@@ -116,10 +116,10 @@ namespace occa {
   memory_t<HSA>::~memory_t(){}
 
   template <>
-  void* memory_t<HSA>::getMemoryHandle(){}
+  void* memory_t<HSA>::getMemoryHandle(){ return NULL; }
 
   template <>
-  void* memory_t<HSA>::getTextureHandle(){}
+  void* memory_t<HSA>::getTextureHandle(){ return NULL; }
 
   template <>
   void memory_t<HSA>::copyFrom(const void *src,
@@ -169,7 +169,13 @@ namespace occa {
   void memory_t<HSA>::mappedFree(){}
 
   template <>
+  void memory_t<HSA>::mappedDetach(){}
+
+  template <>
   void memory_t<HSA>::free(){}
+
+  template <>
+  void memory_t<HSA>::detach(){}
   //==================================
 
 

--- a/src/HSAV2.cpp
+++ b/src/HSAV2.cpp
@@ -512,12 +512,29 @@ namespace occa {
   }
 
   template <>
+  void memory_t<HSA>::mappedDetach(){
+    if(isMapped()){
+      delete (CUdeviceptr*) handle;
+
+      size = 0;
+    }
+  }
+
+  template <>
   void memory_t<HSA>::free(){
     //    cuMemFree(*((CUdeviceptr*) handle));
     hsa_memory_free((HSAdeviceptr*) handle);
     
-    if(!isAWrapper())
-      delete (CUdeviceptr*) handle;
+    delete (CUdeviceptr*) handle;
+    handle = NULL;
+
+    size = 0;
+  }
+
+  template <>
+  void memory_t<HSA>::detach(){
+    delete (CUdeviceptr*) handle;
+    handle = NULL;
 
     size = 0;
   }

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -1090,15 +1090,36 @@ namespace occa {
   }
 
   template <>
+  void memory_t<OpenCL>::mappedDetach(){
+    delete (cl_mem*) handle;
+    handle = NULL;
+  }
+
+  template <>
   void memory_t<OpenCL>::free(){
     clReleaseMemObject(*((cl_mem*) handle));
 
     delete (cl_mem*) handle;
+    handle = NULL;
 
     if(isATexture()){
       clReleaseSampler( *((cl_sampler*) textureInfo.arg) );
 
       delete (cl_sampler*) textureInfo.arg;
+      textureInfo.arg = NULL;
+    }
+
+    size = 0;
+  }
+
+  template <>
+  void memory_t<OpenCL>::detach(){
+    delete (cl_mem*) handle;
+    handle = NULL;
+
+    if(isATexture()){
+      delete (cl_sampler*) textureInfo.arg;
+      textureInfo.arg = NULL;
     }
 
     size = 0;
@@ -1482,6 +1503,8 @@ namespace occa {
     mem->size    = bytes;
     mem->handle  = new cl_mem;
     ::memcpy(mem->handle, handle_, sizeof(cl_mem));
+
+    mem->memInfo |= memFlag::isAWrapper;
 
     return mem;
   }

--- a/src/OpenMP.cpp
+++ b/src/OpenMP.cpp
@@ -573,6 +573,14 @@ namespace occa {
   }
 
   template <>
+  void memory_t<OpenMP>::mappedDetach(){
+    handle    = NULL;
+    mappedPtr = NULL;
+
+    size = 0;
+  }
+
+  template <>
   void memory_t<OpenMP>::free(){
     if(isATexture()){
       cpu::free(textureInfo.arg);
@@ -580,6 +588,19 @@ namespace occa {
     }
     else{
       cpu::free(handle);
+      handle = NULL;
+    }
+
+    size = 0;
+  }
+
+  template <>
+  void memory_t<OpenMP>::detach(){
+    if(isATexture()){
+      cpu::free(textureInfo.arg);
+      textureInfo.arg = NULL;
+    }
+    else{
       handle = NULL;
     }
 

--- a/src/Pthreads.cpp
+++ b/src/Pthreads.cpp
@@ -588,6 +588,14 @@ namespace occa {
   }
 
   template <>
+  void memory_t<Pthreads>::mappedDetach(){
+    handle    = NULL;
+    mappedPtr = NULL;
+
+    size = 0;
+  }
+
+  template <>
   void memory_t<Pthreads>::free(){
     if(isATexture()){
       cpu::free(textureInfo.arg);
@@ -595,6 +603,18 @@ namespace occa {
     }
     else{
       cpu::free(handle);
+      handle = NULL;
+    }
+
+    size = 0;
+  }
+
+  template <>
+  void memory_t<Pthreads>::detach(){
+    if(isATexture()){
+      textureInfo.arg = NULL;
+    }
+    else{
       handle = NULL;
     }
 

--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -86,25 +86,41 @@ namespace occa {
       while(fgets(buffer,bufferSize,fp)) {
 	// find line that matches "^[WS}*field[WS]*:"
 	str = buffer;
-	while(*str && isspace(*str)) ++str;
-	if (!*str) continue;
+	while(*str && isspace(*str)) {
+	  ++str;
+	}
+	if (!*str) {
+	  continue;
+	}
 	if (ignoreCase ?
 	    strncasecmp(str,field_str,field_len) :
-	    strncmp(str,field_str,field_len)) continue;
+	    strncmp(str,field_str,field_len)) {
+	  continue;
+	}
 	ptr = str + field_len;
-	while(*ptr && isspace(*ptr)) ++ptr;
-	if (*ptr != delimiter) continue;
+	while(*ptr && isspace(*ptr)) {
+	  ++ptr;
+	}
+	if (*ptr != delimiter) {
+	  continue;
+	}
 
 	// line found, now get value after clipping surrounding
 	// whitespace, per "[WS]*value[WS]*$"
 	++ptr;
-	while(*ptr && isspace(*ptr)) ++ptr;
+	while(*ptr && isspace(*ptr)) {
+	  ++ptr;
+	}
 	str = ptr;
 	// clip trailing whitespace
 	if (*str) {
-	  while(*ptr) ++ptr;
+	  while(*ptr) {
+	    ++ptr;
+	  }
 	  --ptr;  // now points to last char in string
-	  while(ptr != str  &&  isspace(*ptr)) *ptr-- = '\0';
+	  while(ptr != str  &&  isspace(*ptr)) {
+	    *ptr-- = '\0';
+	  }
 	}
 
 	// done

--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -1,14 +1,20 @@
 #include "occa/Serial.hpp"
 
+#include <fstream>
+
+#include <strings.h>
+
 namespace occa {
   //---[ Helper Functions ]-----------
   namespace cpu {
     std::string getFieldFrom(const std::string &command,
                              const std::string &field){
-#if (OCCA_OS & LINUX)
+#if (OCCA_OS & LINUX_OS)
       std::string shellToolsFile = sys::getFilename("[occa]/scripts/shellTools.sh");
 
       if(!sys::fileExists(shellToolsFile)){
+	// TODO: enable this when getCachedScript() is defined!!!
+#if 0
         sys::mkpath(getFileDirectory(shellToolsFile));
 
         std::ofstream fs2;
@@ -17,6 +23,9 @@ namespace occa {
         fs2 << getCachedScript("shellTools.sh");
 
         fs2.close();
+#else
+	return "";
+#endif
       }
 
       std::stringstream ss;
@@ -52,9 +61,80 @@ namespace occa {
 #endif
     }
 
+    std::string getField(const std::string &shell_cmd,
+			 const std::string &field,
+			 bool ignoreCase,
+			 char delimiter){
+      // popen(), fgets(). strncasecmp() and isspace() are
+      // all available on Linux, BSD/OSX, CygWin and MinGW,
+      // assuming we're not compiling __STRICT_ANSI__
+#if (OCCA_OS & (LINUX_OS | WINUX_OS | OSX_OS))
+      FILE *fp;
+      fp = popen(shell_cmd.c_str(), "r");
+
+      const int bufferSize = 4096;
+      char *buffer = new char[bufferSize];
+
+      int field_len = field.size();
+
+      const char *field_str = field.c_str();
+      char *ptr;
+      char *str;
+
+      std::string ret = "";
+
+      while(fgets(buffer,bufferSize,fp)) {
+	// find line that matches "^[WS}*field[WS]*:"
+	str = buffer;
+	while(*str && isspace(*str)) ++str;
+	if (!*str) continue;
+	if (ignoreCase ?
+	    strncasecmp(str,field_str,field_len) :
+	    strncmp(str,field_str,field_len)) continue;
+	ptr = str + field_len;
+	while(*ptr && isspace(*ptr)) ++ptr;
+	if (*ptr != delimiter) continue;
+
+	// line found, now get value after clipping surrounding
+	// whitespace, per "[WS]*value[WS]*$"
+	++ptr;
+	while(*ptr && isspace(*ptr)) ++ptr;
+	str = ptr;
+	// clip trailing whitespace
+	if (*str) {
+	  while(*ptr) ++ptr;
+	  --ptr;  // now points to last char in string
+	  while(ptr != str  &&  isspace(*ptr)) *ptr-- = '\0';
+	}
+
+	// done
+	ret = str;
+	break;
+      }
+
+      pclose(fp);
+
+      delete [] buffer;
+     
+      return ret;
+#else
+      return "";
+#endif
+    }
+
+    std::string getCPUINFOField(const std::string &field,
+				bool ignoreCase){
+#if (OCCA_OS & LINUX_OS)
+      return getField("cat /proc/cpuinfo", field, ignoreCase, ':');
+#else
+      return "";
+#endif
+    }
+
     std::string getProcessorName(){
 #if   (OCCA_OS & LINUX_OS)
-      return getFieldFrom("getCPUINFOField", "model name");
+//    return getFieldFrom("getCPUINFOField", "model name");
+      return getCPUINFOField("model name");
 #elif (OCCA_OS == OSX_OS)
       size_t bufferSize = 100;
       char buffer[100];
@@ -89,7 +169,8 @@ namespace occa {
       std::stringstream ss;
       int freq;
 
-      ss << getFieldFrom("getCPUINFOField", "cpu MHz");
+//    ss << getFieldFrom("getCPUINFOField", "cpu MHz");
+      ss << getCPUINFOField("cpu MHz");
 
       ss >> freq;
 
@@ -123,7 +204,8 @@ namespace occa {
 
       field << " cache";
 
-      return getFieldFrom("getLSCPUField", field.str());
+//    return getFieldFrom("getLSCPUField", field.str());
+      return getField("lscpu", field.str(), false, ':');
 #elif (OCCA_OS == OSX_OS)
       std::stringstream ss;
       ss << "hw.l" << level;
@@ -990,6 +1072,14 @@ namespace occa {
   }
 
   template <>
+  void memory_t<Serial>::mappedDetach(){
+    handle    = NULL;
+    mappedPtr = NULL;
+
+    size = 0;
+  }
+
+  template <>
   void memory_t<Serial>::free(){
     if(isATexture()){
       cpu::free(textureInfo.arg);
@@ -997,6 +1087,18 @@ namespace occa {
     }
     else{
       cpu::free(handle);
+      handle = NULL;
+    }
+
+    size = 0;
+  }
+
+  template <>
+  void memory_t<Serial>::detach(){
+    if(isATexture()){
+      textureInfo.arg = NULL;
+    }
+    else{
       handle = NULL;
     }
 

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -1581,7 +1581,8 @@ namespace occa {
       // CPU case where memory is shared
       if(mHandle->uvaPtr != mHandle->handle) {
         uvaMap.erase(mHandle->handle);
-        mHandle->dHandle->uvaMap.erase(mHandle->uvaPtr);
+//        mHandle->dHandle->uvaMap.erase(mHandle->uvaPtr);
+        mHandle->dHandle->uvaMap.erase(mHandle->handle);
 
         ::free(mHandle->uvaPtr);
         mHandle->uvaPtr = NULL;
@@ -1592,6 +1593,34 @@ namespace occa {
       mHandle->free();
     else
       mHandle->mappedFree();
+
+    delete mHandle;
+    mHandle = NULL;
+  }
+
+  void memory::detach() {
+    checkIfInitialized();
+
+    mHandle->dHandle->bytesAllocated -= (mHandle->size);
+
+    if(mHandle->uvaPtr) {
+      uvaMap.erase(mHandle->uvaPtr);
+      mHandle->dHandle->uvaMap.erase(mHandle->uvaPtr);
+
+      // CPU case where memory is shared
+      if(mHandle->uvaPtr != mHandle->handle) {
+        uvaMap.erase(mHandle->handle);
+        mHandle->dHandle->uvaMap.erase(mHandle->handle);
+
+        ::free(mHandle->uvaPtr);
+        mHandle->uvaPtr = NULL;
+      }
+    }
+
+    if(!mHandle->isMapped())
+      mHandle->detach();
+    else
+      mHandle->mappedDetach();
 
     delete mHandle;
     mHandle = NULL;
@@ -2522,6 +2551,10 @@ namespace occa {
 
   void free(memory m) {
     m.free();
+  }
+
+  void detach(memory m) {
+    m.detach();
   }
   //   =================================
 

--- a/src/cBase.cpp
+++ b/src/cBase.cpp
@@ -1052,6 +1052,12 @@ void OCCA_RFUNC occaMemoryFree(occaMemory memory) {
   memory_.free();
   delete memory;
 }
+
+void OCCA_RFUNC occaMemoryDetach(occaMemory memory) {
+  occa::memory memory_ = occa::_typeToMemory(memory);
+  memory_.detach();
+  delete memory;
+}
 //====================================
 
 OCCA_END_EXTERN_C


### PR DESCRIPTION
1. Added memory::detach() and memory::mappedDetach() methods that free the OCCA memory object without freeing the encapsulated device memory. This is a missing piece of OCCA interoperability for those cases when the user desires to recover and use the encapsulated device memory outside of OCCA without having to worry about scope or lifetime of the original OCCA memory object. Note the existing getMemoryHandle() method is used to access the encapsulated device memory before detaching.

2. Added some doxygen comments in header files. In particular, added description for memory::getMemoryHandle() to document what is actually returned for various OCCA devices, in order to facilitate the interoperability scenario.

3. Fixed problem with nonsense CPU frequency value displayed by occainfo on Linux. This includes a new cpu::getField() method that directly parses the output of a shell command (in this case, "cat /proc/cpuinfo") for a property (field) value, instead of relying on indirectly parsing it via invocation of scripts/shellTools.sh. The getField() method is valid for Linux, OSX, CygWin and MinGW, and is intended as a replacement for the Linux-pnly cpu::getFieldFrom() method that was broken and causing the problem with CPU frequency.
