### PR TITLE
`occaDeviceBuildKernelFromString` with MPI bug

### DIFF
--- a/examples/addVectors/c/main.c
+++ b/examples/addVectors/c/main.c
@@ -43,6 +43,19 @@ int main(int argc, char **argv){
   addVectors = occaDeviceBuildKernel(device,
                                      "addVectors.okl", "addVectors",
                                      info);
+  const char* knl_str = " \n"
+    "kernel void addVectors(const int entries, \n"
+    "                       const float *a, \n"
+    "                       const float *b, \n"
+    "                       float *ab){ \n"
+    " \n"
+    "  for(int i = 0; i < entries; ++i; tile(16)){ \n"
+    "    if(i < entries) \n"
+    "      ab[i] = a[i] + b[i]; \n"
+    "  } \n"
+    "}";
+  addVectors =
+    occaDeviceBuildKernelFromString(device, knl_str, "addVectors", occaNoKernelInfo, (1 << 0));
 
   /* addVectors = occaBuildKernelFromSource(device, */
   /*                                        "addVectors.occa", "addVectors", */

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -2010,11 +2010,8 @@ namespace occa {
     else
       sourceFilename += "stringSource.occa";
 
-    if(!haveHash(hash, 1)) {
+    if(!haveHash(hash, 1))
       waitForHash(hash, 1);
-      return buildKernelFromBinary(hashDir + dHandle->fixBinaryName(kc::binaryFile),
-                                   functionName);
-    }
 
     writeToFile(sourceFilename, content);
 


### PR DESCRIPTION
There is a bug with at least the Serial and OpenMP modes that doesn't
allow for `buildKernelFromBinary` to be called from two processes on the
same kernel running at the same time (e.g., running the code with
`mpicc`).

These changes illustrate the bug and seem to fix it.
