### PR TITLE
Don't count mapped allocations

### DIFF
--- a/src/base.cpp
+++ b/src/base.cpp
@@ -1588,7 +1588,8 @@ namespace occa {
   void memory::free() {
     checkIfInitialized();
 
-    mHandle->dHandle->bytesAllocated -= (mHandle->size);
+    if(!mHandle->isMapped())
+      mHandle->dHandle->bytesAllocated -= (mHandle->size);
 
     if(mHandle->uvaPtr) {
       uvaMap.erase(mHandle->uvaPtr);
@@ -1617,7 +1618,8 @@ namespace occa {
   void memory::detach() {
     checkIfInitialized();
 
-    mHandle->dHandle->bytesAllocated -= (mHandle->size);
+    if(!mHandle->isMapped())
+      mHandle->dHandle->bytesAllocated -= (mHandle->size);
 
     if(mHandle->uvaPtr) {
       uvaMap.erase(mHandle->uvaPtr);
@@ -2259,8 +2261,6 @@ namespace occa {
 
     mem.mHandle          = dHandle->mappedAlloc(bytes, src);
     mem.mHandle->dHandle = dHandle;
-
-    dHandle->bytesAllocated += bytes;
 
     return mem;
   }


### PR DESCRIPTION
Mapped allocations don't use device memory, so we will not count them
with the device memory counter.