### PR TITLE
Silence warnings about multiplying bools

### DIFF
--- a/include/occa/defines/vector.hpp
+++ b/include/occa/defines/vector.hpp
@@ -16,6 +16,8 @@
 namespace occa {
 #  endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
 //---[ bool2 ]--------------------------
 #define OCCA_BOOL2 bool2
 class bool2{
@@ -1605,6 +1607,7 @@ inline std::ostream& operator << (std::ostream &out, const bool16& a){
 //======================================
 
 
+#pragma GCC diagnostic pop
 //---[ char2 ]--------------------------
 #if (defined(OCCA_IN_KERNEL) && OCCA_USING_CUDA)
 #  define OCCA_CHAR2 make_char2

--- a/scripts/setupVectorDefines.py
+++ b/scripts/setupVectorDefines.py
@@ -263,7 +263,12 @@ def define_all_types():
     define += '#  endif\n\n'
 
     for type_ in types:
+        if type_ == 'bool':
+            define += '#pragma GCC diagnostic push\n'
+            define += '#pragma GCC diagnostic ignored "-Wint-in-bool-context"\n'
         define += define_type(type_)
+        if type_ == 'bool':
+            define += '#pragma GCC diagnostic pop\n'
 
     define += '#  ifndef OCCA_IN_KERNEL\n'
     define += '}\n'


### PR DESCRIPTION
Previously when compiling with -Wall vector.hpp would generate a large number of
warnings of the form:

```
occa/include/occa/defines/vector.hpp:1461:9: warning: ‘*’ in boolean context, suggest ‘&&’ instead [-Wint-in-bool-context]
   a.s15 *= b.s15;
```

This commit silences those warnings using GCC pragmas which will work with both
GCC and the mpic/mpic++ compilers.