### PR TITLE
Fix the mode parameter in appendAvailableDevices

### DIFF
--- a/src/CUDA.cpp
+++ b/src/CUDA.cpp
@@ -1117,7 +1117,7 @@ namespace occa {
 
     for(int i = 0; i < deviceCount; ++i){
       device d;
-      d.setup("CUDA", i, 0);
+      d.setup("mode = CUDA", i, 0);
 
       dList.push_back(d);
     }

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -1254,7 +1254,7 @@ namespace occa {
 
       for(int d = 0; d < deviceCount; ++d){
         device dev;
-        dev.setup("OpenCL", p, d);
+        dev.setup("mode = OpenCL", p, d);
 
         dList.push_back(dev);
       }

--- a/src/OpenMP.cpp
+++ b/src/OpenMP.cpp
@@ -796,7 +796,7 @@ namespace occa {
   template <>
   void device_t<OpenMP>::appendAvailableDevices(std::vector<device> &dList){
     device d;
-    d.setup("OpenMP");
+    d.setup("mode = OpenMP");
 
     dList.push_back(d);
   }

--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -1303,7 +1303,7 @@ namespace occa {
   template <>
   void device_t<Serial>::appendAvailableDevices(std::vector<device> &dList){
     device d;
-    d.setup("Serial");
+    d.setup("mode = Serial");
 
     dList.push_back(d);
   }


### PR DESCRIPTION
We were getting an error when calling `occa::getDeviceList()`. It printed out an error saying
mode is not defined. So we made these changes. But still, `mode = OpenCL` and `mode = CUDA`
fails. `mode = Serial` works.