### PR TITLE
Add /opt/cuda to include and library search paths

### DIFF
--- a/scripts/shellTools.sh
+++ b/scripts/shellTools.sh
@@ -106,6 +106,7 @@ function defaultIncludePath {
     mergedPaths+=":/Developer/NVIDIA/CUDA*/include"
     mergedPaths+=":/usr/local/cuda*/targets/*/include/"
     mergedPaths+=":/usr/include"
+    mergedPaths+=":/opt/cuda*/include/"
 
     echo "${mergedPaths}"
 }
@@ -121,6 +122,7 @@ function defaultLibraryPath {
     mergedPaths+=":/usr/local/cuda*/lib*/stubs"
     mergedPaths+=":/lib:/usr/lib:/usr/lib32:/usr/lib64:"
     mergedPaths+=":/usr/lib/*-gnu/"
+    mergedPaths+=":/opt/cuda*/lib*"
 
     echo "${mergedPaths}"
 }


### PR DESCRIPTION
Arch Linux (and possibly other Linux distros) put all the CUDA files in `/opt/cuda`, so add those to the list.