### PR TITLE
initSignalHandling: do not attempt to catch SIGKILL

### DIFF
--- a/src/tools/env.cpp
+++ b/src/tools/env.cpp
@@ -91,7 +91,6 @@ namespace occa {
       ::signal(SIGINT , env::signalExit);
       ::signal(SIGABRT, env::signalExit);
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_OSX_OS))
-      ::signal(SIGKILL, env::signalExit);
       ::signal(SIGQUIT, env::signalExit);
       ::signal(SIGUSR1, env::signalExit);
       ::signal(SIGUSR2, env::signalExit);


### PR DESCRIPTION
SIGKILL cannot be caught so there is no point attempting to register
actions, which generates warnings in certain environments, such as
Valgrind:

  ==31674== Warning: ignored attempt to set SIGKILL handler in sigaction();
  ==31674==          the SIGKILL signal is uncatchable