### PR TITLE
XL compiler requires user to include cstdlib for system atof()

### DIFF
--- a/include/occa/tools/string.hpp
+++ b/include/occa/tools/string.hpp
@@ -28,6 +28,7 @@
 #include <sstream>
 
 #include <cstring>
+#include <cstdlib>
 
 #include <occa/defines.hpp>
 #include <occa/types.hpp>


### PR DESCRIPTION
<!-- Thank you for contributing!! :) -->

Small bug fix: XL compiler requires user to include cstdlib for system atof().