### PR TITLE
[Parser] Fixed register variables being migrated in OpenCL mode

### DIFF
--- a/src/lang/modes/opencl.cpp
+++ b/src/lang/modes/opencl.cpp
@@ -242,8 +242,13 @@ namespace occa {
         statementExprMap::iterator it = exprMap.begin();
         while (it != exprMap.end()) {
           declarationStatement &declSmnt = *((declarationStatement*) it->first);
-          declSmnt.removeFromParent();
-          kernelSmnt.addFirst(declSmnt);
+
+          variable_t *var = declSmnt.declarations[0].variable;
+
+          if (var->hasAttribute("shared")) {
+            declSmnt.removeFromParent();
+            kernelSmnt.addFirst(declSmnt);
+          }
           ++it;
         }
       }


### PR DESCRIPTION

<!-- Thank you for contributing!! :) -->

### Description

Fixed an issue where my recent change to the OpenCL parser was mistakenly migrating statements. The old code searched for variable declarations with the "shared" in a kernel function and migrated them to the top of the kernel. However this would mistakenly migrate statements like 
`double r_q = s_q[i];`
when `s_q` was a shared array. This patch now checks if the variables being declared in the statement have the "shared" attribute themselves before migrating.

### Checks
- [x] Nothing got committed into `./lib` and `./obj`
- [x] MIT License copyright in new files
