### PR TITLE
[HIP] Fixes to HIP backend. 

### DIFF
--- a/include/occa/mode/hip/device.hpp
+++ b/include/occa/mode/hip/device.hpp
@@ -81,6 +81,8 @@ namespace occa {
                                         const hash_t kernelHash,
                                         const occa::properties &props);
 
+      void setArchCompilerFlags(occa::properties &kernelProps);
+
       void compileKernel(const std::string &hashDir,
                          const std::string &kernelName,
                          occa::properties &kernelProps,

--- a/include/occa/mode/hip/memory.hpp
+++ b/include/occa/mode/hip/memory.hpp
@@ -41,6 +41,8 @@ namespace occa {
                                      const udim_t bytes,
                                      const occa::properties &props);
 
+      friend void* getMappedPtr(occa::memory mem);
+
     public:
       hipDeviceptr_t hipPtr;
       char *mappedPtr;

--- a/include/occa/mode/hip/utils.hpp
+++ b/include/occa/mode/hip/utils.hpp
@@ -96,6 +96,8 @@ namespace occa {
 
     hipCtx_t getContext(occa::device device);
 
+    void* getMappedPtr(occa::memory mem);
+
     occa::device wrapDevice(hipDevice_t device,
                             hipCtx_t context,
                             const occa::properties &props = occa::properties());

--- a/src/mode/hip/device.cpp
+++ b/src/mode/hip/device.cpp
@@ -56,7 +56,7 @@ namespace occa {
                        hipCtxCreate(&hipContext, 0, hipDevice));
 
         OCCA_HIP_ERROR("Getting device properties",
-                      hipGetDeviceProperties(&props, deviceID));
+                       hipGetDeviceProperties(&props, deviceID));
       }
 
       p2pEnabled = false;
@@ -86,8 +86,8 @@ namespace occa {
 
       archMajorVersion = properties.get("hip/arch/major", archMajorVersion);
       archMinorVersion = properties.get("hip/arch/minor", archMinorVersion);
-      properties["kernel/target"] = toString(props.gcnArch);
 
+      properties["kernel/target"]  = toString(props.gcnArch);
       properties["kernel/verbose"] = properties.get("verbose", false);
     }
 

--- a/src/mode/hip/kernel.cpp
+++ b/src/mode/hip/kernel.cpp
@@ -100,18 +100,20 @@ namespace occa {
           continue;
         }
         for (int ai = 0; ai < argCount; ++ai) {
-          size_t Nbytes;
-          if (rem+iArgs[ai].size<=sizeof(void*)) {
-            Nbytes = iArgs[ai].size;
+          size_t bytes;
+          if (rem+iArgs[ai].size <= sizeof(void*)) {
+            bytes = iArgs[ai].size;
             rem = sizeof(void*) - rem - iArgs[ai].size;
           } else {
-            Nbytes = sizeof(void*);
-            argc+=rem;
+            bytes = sizeof(void*);
+            argc += rem;
             rem = 0;
           }
 
-          memcpy((char*) vArgs.data() + argc,&(iArgs[ai].data.int64_), Nbytes);
-          argc += Nbytes;
+          memcpy((char*) vArgs.data() + argc,
+                 &(iArgs[ai].data.int64_),
+                 bytes);
+          argc += bytes;
         }
       } 
 

--- a/src/mode/hip/kernel.cpp
+++ b/src/mode/hip/kernel.cpp
@@ -92,7 +92,8 @@ namespace occa {
       const int kArgCount = (int) arguments.size();
 
       int argc = 0;
-      int rem = 0;
+      // HIP expects kernel arguments to be byte-aligned so we add padding to arguments
+      int padding = 0;
       for (int i = 0; i < kArgCount; ++i) {
         const kArgVector &iArgs = arguments[i].args;
         const int argCount = (int) iArgs.size();
@@ -101,13 +102,13 @@ namespace occa {
         }
         for (int ai = 0; ai < argCount; ++ai) {
           size_t bytes;
-          if (rem+iArgs[ai].size <= sizeof(void*)) {
+          if ((padding + iArgs[ai].size) <= sizeof(void*)) {
             bytes = iArgs[ai].size;
-            rem = sizeof(void*) - rem - iArgs[ai].size;
+            padding = sizeof(void*) - padding - iArgs[ai].size;
           } else {
             bytes = sizeof(void*);
-            argc += rem;
-            rem = 0;
+            argc += padding;
+            padding = 0;
           }
 
           memcpy((char*) vArgs.data() + argc,
@@ -115,18 +116,21 @@ namespace occa {
                  bytes);
           argc += bytes;
         }
-      } 
+      }
 
-      size_t size = vArgs.size()*sizeof(vArgs[0]);
-      void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &(vArgs[0]), HIP_LAUNCH_PARAM_BUFFER_SIZE, &size,
-                        HIP_LAUNCH_PARAM_END};
+      size_t size = vArgs.size() * sizeof(vArgs[0]);
+      void* config[] = {
+        HIP_LAUNCH_PARAM_BUFFER_POINTER, &(vArgs[0]),
+        HIP_LAUNCH_PARAM_BUFFER_SIZE, &size,
+        HIP_LAUNCH_PARAM_END
+      };
 
       OCCA_HIP_ERROR("Launching Kernel",
                      hipModuleLaunchKernel(hipFunction,
                                            outerDims.x, outerDims.y, outerDims.z,
                                            innerDims.x, innerDims.y, innerDims.z,
                                            0, *((hipStream_t*) modeDevice->currentStream),
-                                           NULL, (void**)&config));
+                                           NULL, (void**) &config));
     }
 
     void kernel::launcherRun() const {

--- a/src/mode/hip/registration.cpp
+++ b/src/mode/hip/registration.cpp
@@ -52,7 +52,7 @@ namespace occa {
 
           section
             .add("Device ID"  ,  toString(i))
-            .add("Arch"       , "gfx"+toString(props.gcnArch))
+            .add("Arch"       , "gfx" + toString(props.gcnArch))
             .add("Device Name",  deviceName)
             .add("Memory"     ,  bytesStr)
             .addDivider();

--- a/src/mode/hip/registration.cpp
+++ b/src/mode/hip/registration.cpp
@@ -52,7 +52,7 @@ namespace occa {
 
           section
             .add("Device ID"  ,  toString(i))
-            .add("Arch"  , "gfx"+toString(props.gcnArch))
+            .add("Arch"       , "gfx"+toString(props.gcnArch))
             .add("Device Name",  deviceName)
             .add("Memory"     ,  bytesStr)
             .addDivider();

--- a/src/mode/hip/registration.cpp
+++ b/src/mode/hip/registration.cpp
@@ -52,6 +52,7 @@ namespace occa {
 
           section
             .add("Device ID"  ,  toString(i))
+            .add("Arch"  , "gfx"+toString(props.gcnArch))
             .add("Device Name",  deviceName)
             .add("Memory"     ,  bytesStr)
             .addDivider();

--- a/src/mode/hip/utils.cpp
+++ b/src/mode/hip/utils.cpp
@@ -177,6 +177,11 @@ namespace occa {
       return ((hip::device*) device.getModeDevice())->hipContext;
     }
 
+    void* getMappedPtr(occa::memory mem) {
+      hip::memory *handle = (hip::memory*) mem.getMHandle();
+      return handle ? handle->mappedPtr : NULL;
+    }
+
     occa::device wrapDevice(hipDevice_t device,
                             hipCtx_t context,
                             const occa::properties &props) {


### PR DESCRIPTION
<!-- Thank you for contributing!! :) -->

### Description

- Fixed a subtle issue where HIP expects packed kernel arguments to be byte-aligned. 
- Added a target architecture, e.g. '-t gfx900' compiler flag to the hipcc calls to speed up kernel compilation and reduce binary sizes. 
- Forwarded changed to getMappedPtr to HIP backend.  

### Checks
- [x] Nothing got committed into `./lib` and `./obj`
- [x] MIT License copyright in new files
