### PR TITLE
Temporary workaround to avoid the malloc/free calls in linalg::dot

### DIFF
--- a/include/occa/array/linalg.tpp
+++ b/include/occa/array/linalg.tpp
@@ -200,7 +200,9 @@ namespace occa {
     template <class TM>
     occa::memory deviceReductionBuffer(occa::device device,
                                        const int size) {
-      return device.malloc(size * sizeof(TM));
+      const dim_t bytes = size * sizeof(TM);
+      occa::memory mem(device.getReductionBuffer(bytes));
+      return mem.slice(0, bytes);
     }
 
     template <class VTYPE, class RETTYPE>

--- a/include/occa/device.hpp
+++ b/include/occa/device.hpp
@@ -61,6 +61,8 @@ namespace occa {
 
     cachedKernelMap cachedKernels;
 
+    occa::modeMemory_t *reductionBuffer;
+
     modeDevice_t(const occa::properties &properties_);
 
     //---[ Virtual Methods ]------------
@@ -146,6 +148,7 @@ namespace occa {
     void assertInitialized() const;
     void setModeDevice(modeDevice_t *modeDevice_);
     void removeRef();
+    void setReductionBuffer();
 
   public:
     void dontUseRefs();
@@ -176,6 +179,7 @@ namespace occa {
 
     udim_t memorySize() const;
     udim_t memoryAllocated() const;
+    occa::modeMemory_t *getReductionBuffer(const dim_t bytes);
 
     void finish();
 


### PR DESCRIPTION
<!-- Thank you for contributing!! :) -->

### Description

The reduction buffer is now part of the `occa::modeDevice_t` object with (re)allocations done by methods in `occa::device`.

### Checks
- [x] Nothing got committed into `./lib` and `./obj`
- [x] MIT License copyright in new files
