### PR TITLE
Fix an issue in `linalg::getTiledKernel`

### DIFF
--- a/include/occa/array/linalg.hpp
+++ b/include/occa/array/linalg.hpp
@@ -44,12 +44,13 @@ namespace occa {
     inline occa::kernel getTiledKernel(kernelBuilderVector &builders,
                                        occa::device dev,
                                        const int tileSize) {
-      for (int i = 0; i < usedTileSizeCount; ++i) {
-        if (usedTileSizes[i] <= tileSize) {
-          return builders[i].build(dev);
+      int i;
+      for (i = 1; i < usedTileSizeCount; ++i) {
+        if (usedTileSizes[i] > tileSize) {
+          break;
         }
       }
-      return builders[usedTileSizeCount - 1].build(dev);
+      return builders[i-1].build(dev);
     }
 
     template <class VTYPE, class RETTYPE>


### PR DESCRIPTION

<!-- Thank you for contributing!! :) -->

### Description

Fix an issue in `linalg::getTiledKernel` which causes a tile size of 32 to be selected when the input parameter `tileSize  >= 32`; otherwise a tile size of 512 is selected.

The new behaviour is to pick the largest tile size in `linalg::usedTileSizes` that does not exceed `tileSize`.

### Checks
- [x] Nothing got committed into `./lib` and `./obj`
- [x] MIT License copyright in new files
