### PR TITLE
[HIP/OpenCL] Updates for HIP backend and updating deprecated OpenCL APIs

### DIFF
--- a/include/occa/modes/hip/device.hpp
+++ b/include/occa/modes/hip/device.hpp
@@ -4,7 +4,7 @@
 #  ifndef OCCA_MODES_HIP_DEVICE_HEADER
 #  define OCCA_MODES_HIP_DEVICE_HEADER
 
-#include <occa/core/device.hpp>
+#include <occa/core/launchedDevice.hpp>
 
 #include <hip/hip_runtime_api.h>
 
@@ -12,7 +12,7 @@ namespace occa {
   namespace hip {
     class kernel;
 
-    class device : public occa::modeDevice_t {
+    class device : public occa::launchedModeDevice_t {
       friend class kernel;
 
     private:
@@ -23,7 +23,7 @@ namespace occa {
       bool p2pEnabled;
 
       hipDevice_t hipDevice;
-      hipCtx_t hipContext;
+      int deviceID;
 
       device(const occa::properties &properties_);
       virtual ~device();
@@ -41,10 +41,12 @@ namespace occa {
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::properties &props);
 
-      virtual streamTag tagStream() const;
-      virtual void waitFor(streamTag tag) const;
+      virtual streamTag tagStream();
+      virtual void waitFor(streamTag tag);
       virtual double timeBetween(const streamTag &startTag,
-                                 const streamTag &endTag) const;
+                                 const streamTag &endTag);
+
+      hipStream_t& getHipStream() const;
       //================================
 
       //---[ Kernel ]-------------------
@@ -63,7 +65,7 @@ namespace occa {
 
       void compileKernel(const std::string &hashDir,
                          const std::string &kernelName,
-                         occa::properties &kernelProps,
+                         const occa::properties &kernelProps,
                          io::lock_t &lock);
 
       modeKernel_t* buildOKLKernelFromBinary(const hash_t kernelHash,

--- a/include/occa/modes/hip/kernel.hpp
+++ b/include/occa/modes/hip/kernel.hpp
@@ -6,21 +6,19 @@
 
 #include <hip/hip_runtime_api.h>
 
-#include <occa/core/kernel.hpp>
+#include <occa/core/launchedKernel.hpp>
 
 namespace occa {
   namespace hip {
     class device;
 
-    class kernel : public occa::modeKernel_t {
+    class kernel : public occa::launchedModeKernel_t {
       friend class device;
 
     private:
       hipModule_t hipModule;
       hipFunction_t hipFunction;
 
-      occa::modeKernel_t *launcherKernel;
-      std::vector<kernel*> hipKernels;
       mutable std::vector<void*> vArgs;
 
     public:
@@ -37,6 +35,8 @@ namespace occa {
              const occa::properties &properties_);
 
       ~kernel();
+
+      hipStream_t& getHipStream() const;
 
       int maxDims() const;
       dim maxOuterDims() const;

--- a/include/occa/modes/hip/memory.hpp
+++ b/include/occa/modes/hip/memory.hpp
@@ -14,6 +14,7 @@ namespace occa {
 
     class memory : public occa::modeMemory_t {
       friend class hip::device;
+
       friend occa::memory wrapMemory(occa::device device,
                                      void *ptr,
                                      const udim_t bytes,
@@ -29,6 +30,8 @@ namespace occa {
              udim_t size_,
              const occa::properties &properties_ = occa::properties());
       ~memory();
+
+      hipStream_t& getHipStream() const;
 
       kernelArg makeKernelArg() const;
 

--- a/include/occa/modes/hip/stream.hpp
+++ b/include/occa/modes/hip/stream.hpp
@@ -1,0 +1,27 @@
+#include <occa/defines.hpp>
+
+#if OCCA_HIP_ENABLED
+#  ifndef OCCA_MODES_HIP_STREAM_HEADER
+#  define OCCA_MODES_HIP_STREAM_HEADER
+
+#include <hip/hip_runtime.h>
+
+#include <occa/core/stream.hpp>
+
+namespace occa {
+  namespace hip {
+    class stream : public occa::modeStream_t {
+    public:
+      hipStream_t hipStream;
+
+      stream(modeDevice_t *modeDevice_,
+             const occa::properties &properties_,
+             hipStream_t hipStream_);
+
+      virtual ~stream();
+    };
+  }
+}
+
+#  endif
+#endif

--- a/include/occa/modes/hip/streamTag.hpp
+++ b/include/occa/modes/hip/streamTag.hpp
@@ -1,0 +1,26 @@
+#include <occa/defines.hpp>
+
+#if OCCA_HIP_ENABLED
+#  ifndef OCCA_MODES_HIP_STREAMTAG_HEADER
+#  define OCCA_MODES_HIP_STREAMTAG_HEADER
+
+#include <hip/hip_runtime.h>
+
+#include <occa/core/streamTag.hpp>
+
+namespace occa {
+  namespace hip {
+    class streamTag : public occa::modeStreamTag_t {
+    public:
+      hipEvent_t hipEvent;
+
+      streamTag(modeDevice_t *modeDevice_,
+                hipEvent_t hipEvent_);
+
+      virtual ~streamTag();
+    };
+  }
+}
+
+#  endif
+#endif

--- a/include/occa/modes/hip/utils.hpp
+++ b/include/occa/modes/hip/utils.hpp
@@ -72,21 +72,13 @@ namespace occa {
                   const dim_t bytes,
                   occa::device device);
 
-    hipCtx_t getContext(occa::device device);
-
-    void* getMappedPtr(occa::memory mem);
-
     occa::device wrapDevice(hipDevice_t device,
-                            hipCtx_t context,
                             const occa::properties &props = occa::properties());
 
     occa::memory wrapMemory(occa::device device,
                             void *ptr,
                             const udim_t bytes,
                             const occa::properties &props = occa::properties());
-
-    hipEvent_t& event(streamTag &tag);
-    const hipEvent_t& event(const streamTag &tag);
 
     void warn(hipError_t errorCode,
               const std::string &filename,

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -304,6 +304,7 @@ ifdef OCCA_HIP_ENABLED
     ifeq ($(usingLinux),1)
       linkerFlags += -lhip_hcc
     endif
+    compilerFlags += -std=c++11
   endif
 else
   hipIncFlags = $(call includeFlagsFor,hip/hip_runtime_api.h)
@@ -324,6 +325,7 @@ else
       paths += $(hipconfig)
       paths += $(hipIncFlags)
       linkerFlags += $(hipLibFlags)
+      compilerFlags += -std=c++11
     endif
   endif
 endif

--- a/src/modes/hip/kernel.cpp
+++ b/src/modes/hip/kernel.cpp
@@ -37,6 +37,10 @@ namespace occa {
       }
     }
 
+    hipStream_t& kernel::getHipStream() const {
+      return ((device*) modeDevice)->getHipStream();
+    }
+
     int kernel::maxDims() const {
       return 3;
     }
@@ -71,7 +75,7 @@ namespace occa {
       // HIP expects kernel arguments to be byte-aligned so we add padding to arguments
       char *dataPtr = (char*) &(vArgs[0]);
       int padding = 0;
-      for (int i = 0; i < kArgCount; ++i) {
+      for (int i = 0; i < args; ++i) {
         const kernelArgData &arg = arguments[i];
 
         size_t bytes;
@@ -101,7 +105,7 @@ namespace occa {
                      hipModuleLaunchKernel(hipFunction,
                                            outerDims.x, outerDims.y, outerDims.z,
                                            innerDims.x, innerDims.y, innerDims.z,
-                                           0, *((hipStream_t*) modeDevice->currentStream),
+                                           0, getHipStream(),
                                            NULL, (void**) &config));
     }
   }

--- a/src/modes/hip/memory.cpp
+++ b/src/modes/hip/memory.cpp
@@ -28,10 +28,14 @@ namespace occa {
                        hipHostFree(mappedPtr));
         mappedPtr = NULL;
       } else if (hipPtr) {
-        hipHostFree(hipPtr);
+        hipFree(hipPtr);
         hipPtr = 0;
       }
       size = 0;
+    }
+
+    hipStream_t& memory::getHipStream() const {
+      return ((device*) modeDevice)->getHipStream();
     }
 
     kernelArg memory::makeKernelArg() const {
@@ -60,7 +64,6 @@ namespace occa {
                           const udim_t bytes,
                           const udim_t offset,
                           const occa::properties &props) {
-      const hipStream_t &stream = *((hipStream_t*) modeDevice->currentStream);
       const bool async = props.get("async", false);
 
       if (!async) {
@@ -73,7 +76,7 @@ namespace occa {
                        hipMemcpyHtoDAsync((char*) hipPtr + offset,
                                           const_cast<void*>(src),
                                           bytes,
-                                          stream) );
+                                          getHipStream()) );
       }
     }
 
@@ -82,7 +85,6 @@ namespace occa {
                           const udim_t destOffset,
                           const udim_t srcOffset,
                           const occa::properties &props) {
-      const hipStream_t &stream = *((hipStream_t*) modeDevice->currentStream);
       const bool async = props.get("async", false);
 
       if (!async) {
@@ -95,7 +97,7 @@ namespace occa {
                        hipMemcpyDtoDAsync((char*) hipPtr + destOffset,
                                           (char*) ((memory*) src)->hipPtr + srcOffset,
                                           bytes,
-                                          stream) );
+                                          getHipStream()) );
       }
     }
 
@@ -110,7 +112,6 @@ namespace occa {
                         const udim_t bytes,
                         const udim_t offset,
                         const occa::properties &props) const {
-      const hipStream_t &stream = *((hipStream_t*) modeDevice->currentStream);
       const bool async = props.get("async", false);
 
       if (!async) {
@@ -123,7 +124,7 @@ namespace occa {
                        hipMemcpyDtoHAsync(dest,
                                           (char*) hipPtr + offset,
                                           bytes,
-                                          stream) );
+                                          getHipStream()) );
       }
     }
 

--- a/src/modes/hip/stream.cpp
+++ b/src/modes/hip/stream.cpp
@@ -1,0 +1,23 @@
+#include <occa/defines.hpp>
+
+#if OCCA_HIP_ENABLED
+
+#include <occa/modes/hip/stream.hpp>
+#include <occa/modes/hip/utils.hpp>
+
+namespace occa {
+  namespace hip {
+    stream::stream(modeDevice_t *modeDevice_,
+                   const occa::properties &properties_,
+                   hipStream_t hipStream_) :
+      modeStream_t(modeDevice_, properties_),
+      hipStream(hipStream_) {}
+
+    stream::~stream() {
+      OCCA_HIP_ERROR("Device: freeStream",
+                      hipStreamDestroy(hipStream));
+    }
+  }
+}
+
+#endif

--- a/src/modes/hip/streamTag.cpp
+++ b/src/modes/hip/streamTag.cpp
@@ -1,0 +1,22 @@
+#include <occa/defines.hpp>
+
+#if OCCA_HIP_ENABLED
+
+#include <occa/modes/hip/streamTag.hpp>
+#include <occa/modes/hip/utils.hpp>
+
+namespace occa {
+  namespace hip {
+    streamTag::streamTag(modeDevice_t *modeDevice_,
+                         hipEvent_t hipEvent_) :
+      modeStreamTag_t(modeDevice_),
+      hipEvent(hipEvent_) {}
+
+    streamTag::~streamTag() {
+      OCCA_HIP_ERROR("streamTag: Freeing hipEvent_t",
+                      hipEventDestroy(hipEvent));
+    }
+  }
+}
+
+#endif

--- a/src/modes/hip/utils.cpp
+++ b/src/modes/hip/utils.cpp
@@ -156,7 +156,7 @@ namespace occa {
 
       occa::properties allProps;
       allProps["mode"]     = "HIP";
-      allProps["deviceID"] = -1;
+      allProps["device_id"] = -1;
       allProps["wrapped"]  = true;
       allProps += props;
 

--- a/src/modes/opencl/device.cpp
+++ b/src/modes/opencl/device.cpp
@@ -91,10 +91,19 @@ namespace occa {
     //---[ Stream ]---------------------
     modeStream_t* device::createStream(const occa::properties &props) {
       cl_int error;
+#ifdef CL_VERSION_2_0
+      cl_queue_properties clProps[] = {CL_QUEUE_PROPERTIES,
+                                       CL_QUEUE_PROFILING_ENABLE, 0};
+      cl_command_queue commandQueue = clCreateCommandQueueWithProperties(clContext,
+                                                           clDevice,
+                                                           clProps,
+                                                           &error);
+#else
       cl_command_queue commandQueue = clCreateCommandQueue(clContext,
                                                            clDevice,
                                                            CL_QUEUE_PROFILING_ENABLE,
                                                            &error);
+#endif
       OCCA_OPENCL_ERROR("Device: createStream", error);
 
       return new stream(this, props, commandQueue);


### PR DESCRIPTION
<!-- Thank you for contributing!! :) -->

### Description

Updating the HIP backend to be in sync with CUDA backend support. Also added an OpenCL v2.0 check to avoid using deprecated `clCreateCommandQueue` (AMD's OpenCL complains about this). 

Side note: While testing the  @ restrict keyword in OpenCL mode, I noticed both Nvidia and AMD targets seem to want the restrict key word to be `__restrict__`, which means I had to change [line 21 of src/lang/modes/opencl.cpp](https://github.com/libocca/occa/blob/022b76829d43cbe20b719e6d5a54c9aff8fa178c/src/lang/modes/opencl.cpp#L21). I'm not sure if other platforms also need this keyword so I haven't included that change. 

### Checks
- [x] Nothing got committed into `./lib` and `./obj`
- [ ] MIT License copyright in new files
