### PR TITLE
#236 Hash kernel dependencies

### DIFF
--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -101,7 +101,7 @@ namespace occa {
     void writeKernelBuildFile(const std::string &filename,
                               const hash_t &kernelHash,
                               const occa::properties &kernelProps,
-                              const lang::kernelMetadataMap &metadataMap) const;
+                              const lang::sourceMetadata_t &metadataMap) const;
 
     std::string getKernelHash(const std::string &fullHash,
                               const std::string &kernelName);

--- a/include/occa/core/kernel.hpp
+++ b/include/occa/core/kernel.hpp
@@ -66,7 +66,7 @@ namespace occa {
                       const int count);
     void pushArgument(const kernelArg &arg);
 
-    void setMetadata(lang::parser_t &parser);
+    void setSourceMetadata(lang::parser_t &parser);
 
     void setupRun();
 

--- a/include/occa/core/kernel.hpp
+++ b/include/occa/core/kernel.hpp
@@ -44,7 +44,7 @@ namespace occa {
     // Requirements to launch kernel
     dim outerDims, innerDims;
     std::vector<kernelArgData> arguments;
-    lang::kernelMetadata metadata;
+    lang::kernelMetadata_t metadata;
 
     // References
     gc::ring_t<kernel> kernelRing;
@@ -77,7 +77,7 @@ namespace occa {
     virtual dim maxOuterDims() const = 0;
     virtual dim maxInnerDims() const = 0;
 
-    virtual const lang::kernelMetadata& getMetadata() const = 0;
+    virtual const lang::kernelMetadata_t& getMetadata() const = 0;
 
     virtual void run() const = 0;
     //==================================

--- a/include/occa/core/launchedDevice.hpp
+++ b/include/occa/core/launchedDevice.hpp
@@ -19,8 +19,8 @@ namespace occa {
                    const std::string &outputFile,
                    const std::string &launcherOutputFile,
                    const occa::properties &kernelProps,
-                   lang::kernelMetadataMap &launcherMetadata,
-                   lang::kernelMetadataMap &deviceMetadata);
+                   lang::sourceMetadata_t &launcherMetadata,
+                   lang::sourceMetadata_t &deviceMetadata);
 
     virtual modeKernel_t* buildKernel(const std::string &filename,
                                       const std::string &kernelName,
@@ -36,11 +36,11 @@ namespace occa {
     modeKernel_t* buildLauncherKernel(const hash_t kernelHash,
                                       const std::string &hashDir,
                                       const std::string &kernelName,
-                                      lang::kernelMetadata_t &launcherMetadata);
+                                      lang::sourceMetadata_t sourceMetadata);
 
     orderedKernelMetadata getLaunchedKernelsMetadata(
       const std::string &kernelName,
-      lang::kernelMetadataMap &deviceMetadata
+      lang::sourceMetadata_t &deviceMetadata
     );
 
     //---[ Virtual Methods ]------------
@@ -53,8 +53,8 @@ namespace occa {
       const std::string &sourceFilename,
       const std::string &binaryFilename,
       const bool usingOkl,
-      lang::kernelMetadataMap &launcherMetadata,
-      lang::kernelMetadataMap &deviceMetadata,
+      lang::sourceMetadata_t &launcherMetadata,
+      lang::sourceMetadata_t &deviceMetadata,
       const occa::properties &kernelProps,
       io::lock_t lock
     ) = 0;
@@ -63,8 +63,8 @@ namespace occa {
       const hash_t kernelHash,
       const std::string &hashDir,
       const std::string &kernelName,
-      lang::kernelMetadataMap &launcherMetadata,
-      lang::kernelMetadataMap &deviceMetadata,
+      lang::sourceMetadata_t &launcherMetadata,
+      lang::sourceMetadata_t &deviceMetadata,
       const occa::properties &kernelProps,
       io::lock_t lock
     ) = 0;

--- a/include/occa/core/launchedDevice.hpp
+++ b/include/occa/core/launchedDevice.hpp
@@ -9,7 +9,7 @@
 #include <occa/tools/properties.hpp>
 
 namespace occa {
-  typedef std::vector<lang::kernelMetadata> orderedKernelMetadata;
+  typedef std::vector<lang::kernelMetadata_t> orderedKernelMetadata;
 
   class launchedModeDevice_t : public modeDevice_t {
   public:
@@ -36,7 +36,7 @@ namespace occa {
     modeKernel_t* buildLauncherKernel(const hash_t kernelHash,
                                       const std::string &hashDir,
                                       const std::string &kernelName,
-                                      lang::kernelMetadata &launcherMetadata);
+                                      lang::kernelMetadata_t &launcherMetadata);
 
     orderedKernelMetadata getLaunchedKernelsMetadata(
       const std::string &kernelName,

--- a/include/occa/core/launchedKernel.hpp
+++ b/include/occa/core/launchedKernel.hpp
@@ -21,7 +21,7 @@ namespace occa {
 
     ~launchedModeKernel_t();
 
-    const lang::kernelMetadata& getMetadata() const;
+    const lang::kernelMetadata_t& getMetadata() const;
 
     void run() const;
     void launcherRun() const;

--- a/include/occa/defines/occa.hpp
+++ b/include/occa/defines/occa.hpp
@@ -11,9 +11,9 @@
 
 #define OKL_MAJOR_VERSION 1
 #define OKL_MINOR_VERSION 0
-#define OKL_PATCH_VERSION 11
-#define OKL_VERSION       10011
-#define OKL_VERSION_STR   "1.0.11"
+#define OKL_PATCH_VERSION 12
+#define OKL_VERSION       10012
+#define OKL_VERSION_STR   "1.0.12"
 
 #define OCCA_MAX_ARGS 50
 

--- a/include/occa/lang/kernelMetadata.hpp
+++ b/include/occa/lang/kernelMetadata.hpp
@@ -6,9 +6,9 @@
 
 namespace occa {
   namespace lang {
-    class kernelMetadata;
+    class kernelMetadata_t;
 
-    typedef std::map<std::string, kernelMetadata> kernelMetadataMap;
+    typedef std::map<std::string, kernelMetadata_t> kernelMetadataMap;
 
     class argMetadata_t {
     public:
@@ -28,19 +28,19 @@ namespace occa {
       json toJson() const;
     };
 
-    class kernelMetadata {
+    class kernelMetadata_t {
     public:
       bool initialized;
       std::string name;
       std::vector<argMetadata_t> arguments;
 
-      kernelMetadata();
+      kernelMetadata_t();
 
       bool isInitialized() const;
 
-      kernelMetadata& operator += (const argMetadata_t &argInfo);
+      kernelMetadata_t& operator += (const argMetadata_t &argInfo);
 
-      static kernelMetadata fromJson(const json &j);
+      static kernelMetadata_t fromJson(const json &j);
       json toJson() const;
     };
 

--- a/include/occa/lang/kernelMetadata.hpp
+++ b/include/occa/lang/kernelMetadata.hpp
@@ -10,21 +10,21 @@ namespace occa {
 
     typedef std::map<std::string, kernelMetadata> kernelMetadataMap;
 
-    class argumentInfo {
+    class argMetadata_t {
     public:
       bool isConst;
       bool isPtr;
       dtype_t dtype;
       std::string name;
 
-      argumentInfo();
+      argMetadata_t();
 
-      argumentInfo(const bool isConst_,
+      argMetadata_t(const bool isConst_,
                    const bool isPtr_,
                    const dtype_t &dtype_,
                    const std::string &name_);
 
-      static argumentInfo fromJson(const json &j);
+      static argMetadata_t fromJson(const json &j);
       json toJson() const;
     };
 
@@ -32,13 +32,13 @@ namespace occa {
     public:
       bool initialized;
       std::string name;
-      std::vector<argumentInfo> arguments;
+      std::vector<argMetadata_t> arguments;
 
       kernelMetadata();
 
       bool isInitialized() const;
 
-      kernelMetadata& operator += (const argumentInfo &argInfo);
+      kernelMetadata& operator += (const argMetadata_t &argInfo);
 
       static kernelMetadata fromJson(const json &j);
       json toJson() const;

--- a/include/occa/lang/kernelMetadata.hpp
+++ b/include/occa/lang/kernelMetadata.hpp
@@ -1,6 +1,7 @@
 #ifndef OCCA_LANG_KERNELMETADATA_HEADER
 #define OCCA_LANG_KERNELMETADATA_HEADER
 
+#include <occa/tools/hash.hpp>
 #include <occa/tools/json.hpp>
 #include <occa/dtype.hpp>
 
@@ -9,6 +10,7 @@ namespace occa {
     class kernelMetadata_t;
 
     typedef std::map<std::string, kernelMetadata_t> kernelMetadataMap;
+    typedef std::map<std::string, hash_t> strHashMap;
 
     class argMetadata_t {
     public:
@@ -44,7 +46,15 @@ namespace occa {
       json toJson() const;
     };
 
-    kernelMetadataMap getBuildFileMetadata(const std::string &filename);
+    class sourceMetadata_t {
+     public:
+      kernelMetadataMap kernelsMetadata;
+      strHashMap dependencyHashes;
+
+      sourceMetadata_t();
+
+      static sourceMetadata_t fromBuildFile(const std::string &filename);
+    };
   }
 }
 

--- a/include/occa/lang/kernelMetadata.hpp
+++ b/include/occa/lang/kernelMetadata.hpp
@@ -53,6 +53,9 @@ namespace occa {
 
       sourceMetadata_t();
 
+      json getKernelMetadataJson() const;
+      json getDependencyJson() const;
+
       static sourceMetadata_t fromBuildFile(const std::string &filename);
     };
   }

--- a/include/occa/lang/parser.hpp
+++ b/include/occa/lang/parser.hpp
@@ -85,7 +85,7 @@ namespace occa {
 
       void writeToFile(const std::string &filename) const;
 
-      void setMetadata(kernelMetadataMap &metadataMap) const;
+      void setSourceMetadata(sourceMetadata_t &sourceMetadata) const;
       //================================
 
       //---[ Setup ]--------------------

--- a/include/occa/lang/preprocessor.hpp
+++ b/include/occa/lang/preprocessor.hpp
@@ -114,6 +114,8 @@ namespace occa {
                            const std::string &value);
 
       void removeSourceDefine(const std::string &name);
+
+      strVector getDependencyFilenames() const;
       //================================
 
       void expandMacro(identifierToken &source,

--- a/include/occa/modes/cuda/device.hpp
+++ b/include/occa/modes/cuda/device.hpp
@@ -54,8 +54,8 @@ namespace occa {
                                                    const std::string &sourceFilename,
                                                    const std::string &binaryFilename,
                                                    const bool usingOkl,
-                                                   lang::kernelMetadataMap &launcherMetadata,
-                                                   lang::kernelMetadataMap &deviceMetadata,
+                                                   lang::sourceMetadata_t &launcherMetadata,
+                                                   lang::sourceMetadata_t &deviceMetadata,
                                                    const occa::properties &kernelProps,
                                                    io::lock_t lock);
 
@@ -69,8 +69,8 @@ namespace occa {
       modeKernel_t* buildOKLKernelFromBinary(const hash_t kernelHash,
                                              const std::string &hashDir,
                                              const std::string &kernelName,
-                                             lang::kernelMetadataMap &launcherMetadata,
-                                             lang::kernelMetadataMap &deviceMetadata,
+                                             lang::sourceMetadata_t &launcherMetadata,
+                                             lang::sourceMetadata_t &deviceMetadata,
                                              const occa::properties &kernelProps,
                                              io::lock_t lock);
 

--- a/include/occa/modes/hip/device.hpp
+++ b/include/occa/modes/hip/device.hpp
@@ -53,8 +53,8 @@ namespace occa {
                                                    const std::string &sourceFilename,
                                                    const std::string &binaryFilename,
                                                    const bool usingOkl,
-                                                   lang::kernelMetadataMap &launcherMetadata,
-                                                   lang::kernelMetadataMap &deviceMetadata,
+                                                   lang::sourceMetadata_t &launcherMetadata,
+                                                   lang::sourceMetadata_t &deviceMetadata,
                                                    const occa::properties &kernelProps,
                                                    io::lock_t lock);
 
@@ -68,8 +68,8 @@ namespace occa {
       modeKernel_t* buildOKLKernelFromBinary(const hash_t kernelHash,
                                              const std::string &hashDir,
                                              const std::string &kernelName,
-                                             lang::kernelMetadataMap &launcherMetadata,
-                                             lang::kernelMetadataMap &deviceMetadata,
+                                             lang::sourceMetadata_t &launcherMetadata,
+                                             lang::sourceMetadata_t &deviceMetadata,
                                              const occa::properties &kernelProps,
                                              io::lock_t lock);
 

--- a/include/occa/modes/metal/device.hpp
+++ b/include/occa/modes/metal/device.hpp
@@ -48,8 +48,8 @@ namespace occa {
                                                    const std::string &sourceFilename,
                                                    const std::string &binaryFilename,
                                                    const bool usingOkl,
-                                                   lang::kernelMetadataMap &launcherMetadata,
-                                                   lang::kernelMetadataMap &deviceMetadata,
+                                                   lang::sourceMetadata_t &launcherMetadata,
+                                                   lang::sourceMetadata_t &deviceMetadata,
                                                    const occa::properties &kernelProps,
                                                    io::lock_t lock);
 
@@ -61,8 +61,8 @@ namespace occa {
       modeKernel_t* buildOKLKernelFromBinary(const hash_t kernelHash,
                                              const std::string &hashDir,
                                              const std::string &kernelName,
-                                             lang::kernelMetadataMap &launcherMetadata,
-                                             lang::kernelMetadataMap &deviceMetadata,
+                                             lang::sourceMetadata_t &launcherMetadata,
+                                             lang::sourceMetadata_t &deviceMetadata,
                                              const occa::properties &kernelProps,
                                              io::lock_t lock);
 

--- a/include/occa/modes/opencl/device.hpp
+++ b/include/occa/modes/opencl/device.hpp
@@ -51,16 +51,16 @@ namespace occa {
                                                    const std::string &sourceFilename,
                                                    const std::string &binaryFilename,
                                                    const bool usingOkl,
-                                                   lang::kernelMetadataMap &launcherMetadata,
-                                                   lang::kernelMetadataMap &deviceMetadata,
+                                                   lang::sourceMetadata_t &launcherMetadata,
+                                                   lang::sourceMetadata_t &deviceMetadata,
                                                    const occa::properties &kernelProps,
                                                    io::lock_t lock);
 
       modeKernel_t* buildOKLKernelFromBinary(const hash_t kernelHash,
                                              const std::string &hashDir,
                                              const std::string &kernelName,
-                                             lang::kernelMetadataMap &launcherMetadata,
-                                             lang::kernelMetadataMap &deviceMetadata,
+                                             lang::sourceMetadata_t &launcherMetadata,
+                                             lang::sourceMetadata_t &deviceMetadata,
                                              const occa::properties &kernelProps,
                                              io::lock_t lock);
 
@@ -69,8 +69,8 @@ namespace occa {
                                              const hash_t kernelHash,
                                              const std::string &hashDir,
                                              const std::string &kernelName,
-                                             lang::kernelMetadataMap &launcherMetadata,
-                                             lang::kernelMetadataMap &deviceMetadata,
+                                             lang::sourceMetadata_t &launcherMetadata,
+                                             lang::sourceMetadata_t &deviceMetadata,
                                              const occa::properties &kernelProps,
                                              io::lock_t lock);
 

--- a/include/occa/modes/openmp/device.hpp
+++ b/include/occa/modes/openmp/device.hpp
@@ -20,7 +20,7 @@ namespace occa {
       virtual bool parseFile(const std::string &filename,
                              const std::string &outputFile,
                              const occa::properties &kernelProps,
-                             lang::kernelMetadataMap &metadata);
+                             lang::sourceMetadata_t &metadata);
 
       virtual modeKernel_t* buildKernel(const std::string &filename,
                                         const std::string &kernelName,

--- a/include/occa/modes/serial/device.hpp
+++ b/include/occa/modes/serial/device.hpp
@@ -34,7 +34,7 @@ namespace occa {
       virtual bool parseFile(const std::string &filename,
                              const std::string &outputFile,
                              const occa::properties &kernelProps,
-                             lang::kernelMetadataMap &metadata);
+                             lang::sourceMetadata_t &metadata);
 
       virtual modeKernel_t* buildKernel(const std::string &filename,
                                         const std::string &kernelName,

--- a/include/occa/modes/serial/device.hpp
+++ b/include/occa/modes/serial/device.hpp
@@ -58,7 +58,7 @@ namespace occa {
       virtual modeKernel_t* buildKernelFromBinary(const std::string &filename,
                                                   const std::string &kernelName,
                                                   const occa::properties &kernelProps,
-                                                  lang::kernelMetadata &metadata);
+                                                  lang::kernelMetadata_t &metadata);
       //================================
 
       //---[ Memory ]-------------------

--- a/include/occa/modes/serial/kernel.hpp
+++ b/include/occa/modes/serial/kernel.hpp
@@ -30,7 +30,7 @@ namespace occa {
       dim maxOuterDims() const;
       dim maxInnerDims() const;
 
-      const lang::kernelMetadata& getMetadata() const;
+      const lang::kernelMetadata_t& getMetadata() const;
 
       void run() const;
 

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -86,7 +86,7 @@ namespace occa {
   void modeDevice_t::writeKernelBuildFile(const std::string &filename,
                                           const hash_t &kernelHash,
                                           const occa::properties &kernelProps,
-                                          const lang::kernelMetadataMap &metadataMap) const {
+                                          const lang::sourceMetadata_t &sourceMetadata) const {
     occa::properties infoProps;
 
     infoProps["device"]       = properties;
@@ -94,9 +94,11 @@ namespace occa {
     infoProps["kernel/props"] = kernelProps;
     infoProps["kernel/hash"]  = kernelHash.getFullString();
 
+    const lang::kernelMetadataMap &kernelsMetadata = sourceMetadata.kernelsMetadata;
+
     json &metadataJson = infoProps["kernel/metadata"].asArray();
-    lang::kernelMetadataMap::const_iterator kIt = metadataMap.begin();
-    while (kIt != metadataMap.end()) {
+    lang::kernelMetadataMap::const_iterator kIt = kernelsMetadata.begin();
+    while (kIt != kernelsMetadata.end()) {
       metadataJson += (kIt->second).toJson();
       ++kIt;
     }

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -93,15 +93,8 @@ namespace occa {
     infoProps["device/hash"]  = versionedHash().getFullString();
     infoProps["kernel/props"] = kernelProps;
     infoProps["kernel/hash"]  = kernelHash.getFullString();
-
-    const lang::kernelMetadataMap &kernelsMetadata = sourceMetadata.kernelsMetadata;
-
-    json &metadataJson = infoProps["kernel/metadata"].asArray();
-    lang::kernelMetadataMap::const_iterator kIt = kernelsMetadata.begin();
-    while (kIt != kernelsMetadata.end()) {
-      metadataJson += (kIt->second).toJson();
-      ++kIt;
-    }
+    infoProps["kernel/metadata"] = sourceMetadata.getKernelMetadataJson();
+    infoProps["kernel/dependencies"] = sourceMetadata.getDependencyJson();
 
     io::writeBuildFile(filename, kernelHash, infoProps);
   }

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -386,10 +386,56 @@ namespace occa {
     kernelProps = kernelProperties() + props;
     kernelProps["mode"] = mode();
 
-    kernelHash = (hash()
-                  ^ modeDevice->kernelHash(kernelProps)
-                  ^ kernelHeaderHash(kernelProps)
-                  ^ sourceHash);
+    kernelHash = (
+      hash()
+      ^ modeDevice->kernelHash(kernelProps)
+      ^ kernelHeaderHash(kernelProps)
+      ^ sourceHash
+    );
+
+    // Check if the build.json exists to compare dependencies
+    const std::string buildFile = io::hashDir(kernelHash) + kc::buildFile;
+    if (!io::exists(buildFile)) {
+      return;
+    }
+
+    json buildJson = json::read(buildFile);
+    json dependenciesJson = buildJson["kernel/dependencies"];
+    if (!dependenciesJson.isInitialized()) {
+      return;
+    }
+
+    bool foundDependencyChanges = false;
+    // If all dependencies are somehow gone, the original hash will stay the same
+    // Add an additional hash to prevent reusing the original hash in case something changed
+    hash_t dependenciesHash = occa::hash("Something in the dependencies changed");
+
+    jsonObject dependencyHashes = dependenciesJson.object();
+    jsonObject::iterator it = dependencyHashes.begin();
+    while (it != dependencyHashes.end()) {
+      const std::string &dependency = it->first;
+      const hash_t dependencyHash = hash_t::fromString(it->second);
+
+      if (io::exists(dependency)) {
+        // Check whether the dependency changed
+        hash_t newDependencyHash = hashFile(dependency);
+        dependenciesHash ^= newDependencyHash;
+
+        if (dependencyHash != newDependencyHash) {
+          foundDependencyChanges = true;
+        }
+      } else {
+        // Dependency is missing so something changed
+        dependenciesHash ^= dependencyHash;
+        foundDependencyChanges = true;
+      }
+
+      ++it;
+    }
+
+    if (foundDependencyChanges) {
+      kernelHash ^= dependenciesHash;
+    }
   }
 
   kernel device::buildKernel(const std::string &filename,

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -503,7 +503,7 @@ namespace occa {
         buildKernel(sourceFilename,
                     hash,
                     kernelProps,
-                    lang::kernelMetadata::fromJson(metadataArray[k]));
+                    lang::kernelMetadata_t::fromJson(metadataArray[k]));
       }
     }
 

--- a/src/core/kernel.cpp
+++ b/src/core/kernel.cpp
@@ -104,7 +104,7 @@ namespace occa {
       // TODO: Get original arg #
       for (int i = 0; i < argc; ++i) {
         kernelArgData &arg = arguments[i];
-        lang::argumentInfo &argInfo = metadata.arguments[i];
+        lang::argMetadata_t &argInfo = metadata.arguments[i];
 
         modeMemory_t *mem = arg.getModeMemory();
         bool isPtr = (bool) mem;

--- a/src/core/kernelBuilder.cpp
+++ b/src/core/kernelBuilder.cpp
@@ -94,12 +94,12 @@ namespace occa {
 
     // Get argument metadata
     const lang::kernelMetadata &metadata = kernel.getModeKernel()->getMetadata();
-    const std::vector<lang::argumentInfo> &arguments = metadata.arguments;
+    const std::vector<lang::argMetadata_t> &arguments = metadata.arguments;
 
     // Insert arguments in the proper order
     const int argCount = (int) arguments.size();
     for (int i = 0; i < argCount; ++i) {
-      const lang::argumentInfo &arg = arguments[i];
+      const lang::argMetadata_t &arg = arguments[i];
       kernel.pushArg(scope.getArg(arg.name));
     }
 

--- a/src/core/kernelBuilder.cpp
+++ b/src/core/kernelBuilder.cpp
@@ -93,7 +93,7 @@ namespace occa {
     kernel.clearArgs();
 
     // Get argument metadata
-    const lang::kernelMetadata &metadata = kernel.getModeKernel()->getMetadata();
+    const lang::kernelMetadata_t &metadata = kernel.getModeKernel()->getMetadata();
     const std::vector<lang::argMetadata_t> &arguments = metadata.arguments;
 
     // Insert arguments in the proper order

--- a/src/core/launchedDevice.cpp
+++ b/src/core/launchedDevice.cpp
@@ -202,7 +202,7 @@ namespace occa {
     const hash_t kernelHash,
     const std::string &hashDir,
     const std::string &kernelName,
-    lang::kernelMetadata &launcherMetadata
+    lang::kernelMetadata_t &launcherMetadata
   ) {
     const std::string launcherOutputFile = hashDir + kc::launcherSourceFile;
 
@@ -226,7 +226,7 @@ namespace occa {
     const std::string &kernelName,
     lang::kernelMetadataMap &deviceMetadata
   ) {      // Find device kernels
-    typedef std::map<int, lang::kernelMetadata> kernelOrderMap;
+    typedef std::map<int, lang::kernelMetadata_t> kernelOrderMap;
     kernelOrderMap kernelMetadataMap;
 
     const std::string prefix = "_occa_" + kernelName + "_";
@@ -234,7 +234,7 @@ namespace occa {
     lang::kernelMetadataMap::iterator it = deviceMetadata.begin();
     while (it != deviceMetadata.end()) {
       const std::string &name = it->first;
-      lang::kernelMetadata &metadata = it->second;
+      lang::kernelMetadata_t &metadata = it->second;
       ++it;
       if (!startsWith(name, prefix)) {
         continue;

--- a/src/core/launchedKernel.cpp
+++ b/src/core/launchedKernel.cpp
@@ -24,7 +24,7 @@ namespace occa {
     deviceKernels.clear();
   }
 
-  const lang::kernelMetadata& launchedModeKernel_t::getMetadata() const {
+  const lang::kernelMetadata_t& launchedModeKernel_t::getMetadata() const {
     return deviceKernels[0]->metadata;
   }
 

--- a/src/lang/kernelMetadata.cpp
+++ b/src/lang/kernelMetadata.cpp
@@ -75,22 +75,26 @@ namespace occa {
       return j;
     }
 
-    kernelMetadataMap getBuildFileMetadata(const std::string &filename) {
-      kernelMetadataMap metadataMap;
+    sourceMetadata_t::sourceMetadata_t() {}
+
+    sourceMetadata_t sourceMetadata_t::fromBuildFile(const std::string &filename) {
+      sourceMetadata_t metadata;
+
       if (!io::exists(filename)) {
-        return metadataMap;
+        return metadata;
       }
 
       properties props = properties::read(filename);
-      jsonArray &metadata = props["kernel/metadata"].array();
+      jsonArray &kernelMetadata = props["kernel/metadata"].array();
 
-      const int kernelCount = (int) metadata.size();
+      kernelMetadataMap &metadataMap = metadata.kernelsMetadata;
+      const int kernelCount = (int) kernelMetadata.size();
       for (int i = 0; i < kernelCount; ++i) {
-        kernelMetadata_t kernel = kernelMetadata_t::fromJson(metadata[i]);
+        kernelMetadata_t kernel = kernelMetadata_t::fromJson(kernelMetadata[i]);
         metadataMap[kernel.name] = kernel;
       }
 
-      return metadataMap;
+      return metadata;
     }
   }
 }

--- a/src/lang/kernelMetadata.cpp
+++ b/src/lang/kernelMetadata.cpp
@@ -4,28 +4,28 @@
 
 namespace occa {
   namespace lang {
-    argumentInfo::argumentInfo() :
-      isConst(false),
-      isPtr(false),
-      dtype(dtype::byte) {}
+    argMetadata_t::argMetadata_t() :
+        isConst(false),
+        isPtr(false),
+        dtype(dtype::byte) {}
 
-    argumentInfo::argumentInfo(const bool isConst_,
-                               const bool isPtr_,
-                               const dtype_t &dtype_,
-                               const std::string &name_) :
-      isConst(isConst_),
-      isPtr(isPtr_),
-      dtype(dtype_),
-      name(name_) {}
+    argMetadata_t::argMetadata_t(const bool isConst_,
+                                 const bool isPtr_,
+                                 const dtype_t &dtype_,
+                                 const std::string &name_) :
+        isConst(isConst_),
+        isPtr(isPtr_),
+        dtype(dtype_),
+        name(name_) {}
 
-    argumentInfo argumentInfo::fromJson(const json &j) {
-      return argumentInfo((bool) j["const"],
-                          (bool) j["ptr"],
-                          dtype_t::fromJson(j["dtype"]),
-                          (std::string) j["name"]);
+    argMetadata_t argMetadata_t::fromJson(const json &j) {
+      return argMetadata_t((bool) j["const"],
+                           (bool) j["ptr"],
+                           dtype_t::fromJson(j["dtype"]),
+                           (std::string) j["name"]);
     }
 
-    json argumentInfo::toJson() const {
+    json argMetadata_t::toJson() const {
       json j;
       j["const"] = isConst;
       j["ptr"]   = isPtr;
@@ -35,13 +35,13 @@ namespace occa {
     }
 
     kernelMetadata::kernelMetadata() :
-      initialized(false) {}
+        initialized(false) {}
 
     bool kernelMetadata::isInitialized() const {
       return initialized;
     }
 
-    kernelMetadata& kernelMetadata::operator += (const argumentInfo &argInfo) {
+    kernelMetadata& kernelMetadata::operator += (const argMetadata_t &argInfo) {
       initialized = true;
       arguments.push_back(argInfo);
       return *this;
@@ -56,7 +56,7 @@ namespace occa {
       const jsonArray &argInfos = j["arguments"].array();
       const int argumentCount = (int) argInfos.size();
       for (int i = 0; i < argumentCount; ++i) {
-        meta.arguments.push_back(argumentInfo::fromJson(argInfos[i]));
+        meta.arguments.push_back(argMetadata_t::fromJson(argInfos[i]));
       }
 
       return meta;

--- a/src/lang/kernelMetadata.cpp
+++ b/src/lang/kernelMetadata.cpp
@@ -34,21 +34,21 @@ namespace occa {
       return j;
     }
 
-    kernelMetadata::kernelMetadata() :
+    kernelMetadata_t::kernelMetadata_t() :
         initialized(false) {}
 
-    bool kernelMetadata::isInitialized() const {
+    bool kernelMetadata_t::isInitialized() const {
       return initialized;
     }
 
-    kernelMetadata& kernelMetadata::operator += (const argMetadata_t &argInfo) {
+    kernelMetadata_t& kernelMetadata_t::operator += (const argMetadata_t &argInfo) {
       initialized = true;
       arguments.push_back(argInfo);
       return *this;
     }
 
-    kernelMetadata kernelMetadata::fromJson(const json &j) {
-      kernelMetadata meta;
+    kernelMetadata_t kernelMetadata_t::fromJson(const json &j) {
+      kernelMetadata_t meta;
       meta.initialized = true;
 
       meta.name = (std::string) j["name"];
@@ -62,7 +62,7 @@ namespace occa {
       return meta;
     }
 
-    json kernelMetadata::toJson() const {
+    json kernelMetadata_t::toJson() const {
       json j;
       j["name"] = name;
 
@@ -86,7 +86,7 @@ namespace occa {
 
       const int kernelCount = (int) metadata.size();
       for (int i = 0; i < kernelCount; ++i) {
-        kernelMetadata kernel = kernelMetadata::fromJson(metadata[i]);
+        kernelMetadata_t kernel = kernelMetadata_t::fromJson(metadata[i]);
         metadataMap[kernel.name] = kernel;
       }
 

--- a/src/lang/kernelMetadata.cpp
+++ b/src/lang/kernelMetadata.cpp
@@ -80,10 +80,10 @@ namespace occa {
     json sourceMetadata_t::getKernelMetadataJson() const {
       json metadataJson(json::array_);
 
-      lang::kernelMetadataMap::const_iterator kIt = kernelsMetadata.begin();
-      while (kIt != kernelsMetadata.end()) {
-        metadataJson += (kIt->second).toJson();
-        ++kIt;
+      lang::kernelMetadataMap::const_iterator it = kernelsMetadata.begin();
+      while (it != kernelsMetadata.end()) {
+        metadataJson += (it->second).toJson();
+        ++it;
       }
 
       return metadataJson;
@@ -91,6 +91,12 @@ namespace occa {
 
     json sourceMetadata_t::getDependencyJson() const {
       json metadataJson;
+
+      strHashMap::const_iterator it = dependencyHashes.begin();
+      while (it != dependencyHashes.end()) {
+        metadataJson[it->first] = it->second.getFullString();
+        ++it;
+      }
 
       return metadataJson;
     }
@@ -104,12 +110,19 @@ namespace occa {
 
       properties props = properties::read(filename);
       jsonArray &kernelMetadata = props["kernel/metadata"].array();
+      jsonObject &dependencyHashes = props["kernel/dependencies"].object();
 
       kernelMetadataMap &metadataMap = metadata.kernelsMetadata;
       const int kernelCount = (int) kernelMetadata.size();
       for (int i = 0; i < kernelCount; ++i) {
         kernelMetadata_t kernel = kernelMetadata_t::fromJson(kernelMetadata[i]);
         metadataMap[kernel.name] = kernel;
+      }
+
+      jsonObject::iterator it = dependencyHashes.begin();
+      while (it != dependencyHashes.end()) {
+        metadata.dependencyHashes[it->first] = hash_t::fromString(it->second);
+        ++it;
       }
 
       return metadata;

--- a/src/lang/kernelMetadata.cpp
+++ b/src/lang/kernelMetadata.cpp
@@ -77,6 +77,24 @@ namespace occa {
 
     sourceMetadata_t::sourceMetadata_t() {}
 
+    json sourceMetadata_t::getKernelMetadataJson() const {
+      json metadataJson(json::array_);
+
+      lang::kernelMetadataMap::const_iterator kIt = kernelsMetadata.begin();
+      while (kIt != kernelsMetadata.end()) {
+        metadataJson += (kIt->second).toJson();
+        ++kIt;
+      }
+
+      return metadataJson;
+    }
+
+    json sourceMetadata_t::getDependencyJson() const {
+      json metadataJson;
+
+      return metadataJson;
+    }
+
     sourceMetadata_t sourceMetadata_t::fromBuildFile(const std::string &filename) {
       sourceMetadata_t metadata;
 

--- a/src/lang/parser.cpp
+++ b/src/lang/parser.cpp
@@ -102,7 +102,9 @@ namespace occa {
                 root.toString());
     }
 
-    void parser_t::setMetadata(kernelMetadataMap &metadataMap) const {
+    void parser_t::setSourceMetadata(sourceMetadata_t &sourceMetadata) const {
+      kernelMetadataMap &metadataMap = sourceMetadata.kernelsMetadata;
+
       statementPtrVector kernelSmnts;
       findStatementsByAttr(statementType::functionDecl,
                            "kernel",

--- a/src/lang/parser.cpp
+++ b/src/lang/parser.cpp
@@ -6,6 +6,7 @@
 #include <occa/lang/builtins/attributes.hpp>
 #include <occa/lang/transforms/builtins.hpp>
 #include <occa/lang/builtins/types.hpp>
+#include <occa/tools/hash.hpp>
 
 namespace occa {
   namespace lang {
@@ -104,7 +105,9 @@ namespace occa {
 
     void parser_t::setSourceMetadata(sourceMetadata_t &sourceMetadata) const {
       kernelMetadataMap &metadataMap = sourceMetadata.kernelsMetadata;
+      strHashMap &dependencyHashes = sourceMetadata.dependencyHashes;
 
+      // Set metadata for all @kernels
       statementPtrVector kernelSmnts;
       findStatementsByAttr(statementType::functionDecl,
                            "kernel",
@@ -133,6 +136,14 @@ namespace occa {
             arg.name()
           );
         }
+      }
+
+      // Set dependencies and their hashes
+      strVector dependencies = preprocessor.getDependencyFilenames();
+      const int dependencyCount = (int) dependencies.size();
+      for (int i = 0; i < dependencyCount; ++i) {
+        const std::string &dependency = dependencies[i];
+        dependencyHashes[dependency] = hashFile(dependency);
       }
     }
     //==================================

--- a/src/lang/parser.cpp
+++ b/src/lang/parser.cpp
@@ -114,7 +114,7 @@ namespace occa {
         functionDeclStatement &declSmnt = *((functionDeclStatement*) kernelSmnts[i]);
         function_t &func = declSmnt.function;
 
-        kernelMetadata &metadata = metadataMap[func.name()];
+        kernelMetadata_t &metadata = metadataMap[func.name()];
         metadata.name = func.name();
 
         int args = (int) func.args.size();

--- a/src/lang/parser.cpp
+++ b/src/lang/parser.cpp
@@ -124,7 +124,7 @@ namespace occa {
           if (arg.hasAttribute("implicitArg")) {
             continue;
           }
-          metadata += argumentInfo(
+          metadata += argMetadata_t(
             arg.has(const_),
             arg.vartype.isPointerType(),
             arg.dtype(),

--- a/src/lang/preprocessor.cpp
+++ b/src/lang/preprocessor.cpp
@@ -313,6 +313,20 @@ namespace occa {
         sourceMacros.erase(mIt);
       }
     }
+
+    strVector preprocessor_t::getDependencyFilenames() const {
+      const int dependencyCount = dependencies.size();
+      strVector deps;
+      deps.reserve(dependencyCount);
+
+      strToBoolMap::const_iterator it = dependencies.begin();
+      while (it != dependencies.end()) {
+        deps.push_back(it->first);
+        ++it;
+      }
+
+      return deps;
+    }
     //==================================
 
     void preprocessor_t::expandMacro(identifierToken &source,

--- a/src/modes/cuda/device.cpp
+++ b/src/modes/cuda/device.cpp
@@ -169,8 +169,8 @@ namespace occa {
       const std::string &sourceFilename,
       const std::string &binaryFilename,
       const bool usingOkl,
-      lang::kernelMetadataMap &launcherMetadata,
-      lang::kernelMetadataMap &deviceMetadata,
+      lang::sourceMetadata_t &launcherMetadata,
+      lang::sourceMetadata_t &deviceMetadata,
       const occa::properties &kernelProps,
       io::lock_t lock
     ) {
@@ -307,8 +307,8 @@ namespace occa {
     modeKernel_t* device::buildOKLKernelFromBinary(const hash_t kernelHash,
                                                    const std::string &hashDir,
                                                    const std::string &kernelName,
-                                                   lang::kernelMetadataMap &launcherMetadata,
-                                                   lang::kernelMetadataMap &deviceMetadata,
+                                                   lang::sourceMetadata_t &launcherMetadata,
+                                                   lang::sourceMetadata_t &deviceMetadata,
                                                    const occa::properties &kernelProps,
                                                    io::lock_t lock) {
 
@@ -334,7 +334,7 @@ namespace occa {
       k.launcherKernel = buildLauncherKernel(kernelHash,
                                              hashDir,
                                              kernelName,
-                                             launcherMetadata[kernelName]);
+                                             launcherMetadata);
 
       // Find device kernels
       orderedKernelMetadata launchedKernelsMetadata = getLaunchedKernelsMetadata(

--- a/src/modes/cuda/device.cpp
+++ b/src/modes/cuda/device.cpp
@@ -344,7 +344,7 @@ namespace occa {
 
       const int launchedKernelsCount = (int) launchedKernelsMetadata.size();
       for (int i = 0; i < launchedKernelsCount; ++i) {
-        lang::kernelMetadata &metadata = launchedKernelsMetadata[i];
+        lang::kernelMetadata_t &metadata = launchedKernelsMetadata[i];
 
         CUfunction cuFunction;
         error = cuModuleGetFunction(&cuFunction,

--- a/src/modes/hip/device.cpp
+++ b/src/modes/hip/device.cpp
@@ -170,8 +170,8 @@ namespace occa {
       const std::string &sourceFilename,
       const std::string &binaryFilename,
       const bool usingOkl,
-      lang::kernelMetadataMap &launcherMetadata,
-      lang::kernelMetadataMap &deviceMetadata,
+      lang::sourceMetadata_t &launcherMetadata,
+      lang::sourceMetadata_t &deviceMetadata,
       const occa::properties &kernelProps,
       io::lock_t lock
     ) {
@@ -280,8 +280,8 @@ namespace occa {
     modeKernel_t* device::buildOKLKernelFromBinary(const hash_t kernelHash,
                                                    const std::string &hashDir,
                                                    const std::string &kernelName,
-                                                   lang::kernelMetadataMap &launcherMetadata,
-                                                   lang::kernelMetadataMap &deviceMetadata,
+                                                   lang::sourceMetadata_t &launcherMetadata,
+                                                   lang::sourceMetadata_t &deviceMetadata,
                                                    const occa::properties &kernelProps,
                                                    io::lock_t lock) {
 
@@ -307,7 +307,7 @@ namespace occa {
       k.launcherKernel = buildLauncherKernel(kernelHash,
                                              hashDir,
                                              kernelName,
-                                             launcherMetadata[kernelName]);
+                                             launcherMetadata);
 
       // Find device kernels
       orderedKernelMetadata launchedKernelsMetadata = getLaunchedKernelsMetadata(

--- a/src/modes/hip/device.cpp
+++ b/src/modes/hip/device.cpp
@@ -317,7 +317,7 @@ namespace occa {
 
       const int launchedKernelsCount = (int) launchedKernelsMetadata.size();
       for (int i = 0; i < launchedKernelsCount; ++i) {
-        lang::kernelMetadata &metadata = launchedKernelsMetadata[i];
+        lang::kernelMetadata_t &metadata = launchedKernelsMetadata[i];
 
         hipFunction_t hipFunction;
         error = hipModuleGetFunction(&hipFunction,

--- a/src/modes/metal/device.cpp
+++ b/src/modes/metal/device.cpp
@@ -221,7 +221,7 @@ namespace occa {
 
       const int launchedKernelsCount = (int) launchedKernelsMetadata.size();
       for (int i = 0; i < launchedKernelsCount; ++i) {
-        lang::kernelMetadata &metadata = launchedKernelsMetadata[i];
+        lang::kernelMetadata_t &metadata = launchedKernelsMetadata[i];
 
         api::metal::function_t metalFunction = (
           metalDevice.buildKernel(binaryFilename,

--- a/src/modes/metal/device.cpp
+++ b/src/modes/metal/device.cpp
@@ -109,8 +109,8 @@ namespace occa {
       const std::string &sourceFilename,
       const std::string &binaryFilename,
       const bool usingOkl,
-      lang::kernelMetadataMap &launcherMetadata,
-      lang::kernelMetadataMap &deviceMetadata,
+      lang::sourceMetadata_t &launcherMetadata,
+      lang::sourceMetadata_t &deviceMetadata,
       const occa::properties &kernelProps,
       io::lock_t lock
     ) {
@@ -194,8 +194,8 @@ namespace occa {
     modeKernel_t* device::buildOKLKernelFromBinary(const hash_t kernelHash,
                                                    const std::string &hashDir,
                                                    const std::string &kernelName,
-                                                   lang::kernelMetadataMap &launcherMetadata,
-                                                   lang::kernelMetadataMap &deviceMetadata,
+                                                   lang::sourceMetadata_t &launcherMetadata,
+                                                   lang::sourceMetadata_t &deviceMetadata,
                                                    const occa::properties &kernelProps,
                                                    io::lock_t lock) {
 
@@ -211,7 +211,7 @@ namespace occa {
       k.launcherKernel = buildLauncherKernel(kernelHash,
                                              hashDir,
                                              kernelName,
-                                             launcherMetadata[kernelName]);
+                                             launcherMetadata);
 
       // Find device kernels
       orderedKernelMetadata launchedKernelsMetadata = getLaunchedKernelsMetadata(

--- a/src/modes/opencl/device.cpp
+++ b/src/modes/opencl/device.cpp
@@ -268,7 +268,7 @@ namespace occa {
 
       const int launchedKernelsCount = (int) launchedKernelsMetadata.size();
       for (int i = 0; i < launchedKernelsCount; ++i) {
-        lang::kernelMetadata &metadata = launchedKernelsMetadata[i];
+        lang::kernelMetadata_t &metadata = launchedKernelsMetadata[i];
         opencl::buildKernelFromProgram(clInfo,
                                        metadata.name,
                                        lock);

--- a/src/modes/opencl/device.cpp
+++ b/src/modes/opencl/device.cpp
@@ -157,8 +157,8 @@ namespace occa {
       const std::string &sourceFilename,
       const std::string &binaryFilename,
       const bool usingOkl,
-      lang::kernelMetadataMap &launcherMetadata,
-      lang::kernelMetadataMap &deviceMetadata,
+      lang::sourceMetadata_t &launcherMetadata,
+      lang::sourceMetadata_t &deviceMetadata,
       const occa::properties &kernelProps,
       io::lock_t lock
     ) {
@@ -207,8 +207,8 @@ namespace occa {
     modeKernel_t* device::buildOKLKernelFromBinary(const hash_t kernelHash,
                                                    const std::string &hashDir,
                                                    const std::string &kernelName,
-                                                   lang::kernelMetadataMap &launcherMetadata,
-                                                   lang::kernelMetadataMap &deviceMetadata,
+                                                   lang::sourceMetadata_t &launcherMetadata,
+                                                   lang::sourceMetadata_t &deviceMetadata,
                                                    const occa::properties &kernelProps,
                                                    io::lock_t lock) {
       info_t clInfo;
@@ -229,8 +229,8 @@ namespace occa {
                                                    const hash_t kernelHash,
                                                    const std::string &hashDir,
                                                    const std::string &kernelName,
-                                                   lang::kernelMetadataMap &launcherMetadata,
-                                                   lang::kernelMetadataMap &deviceMetadata,
+                                                   lang::sourceMetadata_t &launcherMetadata,
+                                                   lang::sourceMetadata_t &deviceMetadata,
                                                    const occa::properties &kernelProps,
                                                    io::lock_t lock) {
 
@@ -254,7 +254,7 @@ namespace occa {
       k.launcherKernel = buildLauncherKernel(kernelHash,
                                              hashDir,
                                              kernelName,
-                                             launcherMetadata[kernelName]);
+                                             launcherMetadata);
       if (!k.launcherKernel) {
         delete &k;
         return NULL;

--- a/src/modes/openmp/device.cpp
+++ b/src/modes/openmp/device.cpp
@@ -21,7 +21,7 @@ namespace occa {
     bool device::parseFile(const std::string &filename,
                            const std::string &outputFile,
                            const occa::properties &kernelProps,
-                           lang::kernelMetadataMap &metadata) {
+                           lang::sourceMetadata_t &metadata) {
       lang::okl::openmpParser parser(kernelProps);
       parser.parseFile(filename);
 
@@ -41,7 +41,7 @@ namespace occa {
         }
       }
 
-      parser.setMetadata(metadata);
+      parser.setSourceMetadata(metadata);
 
       return true;
     }

--- a/src/modes/serial/device.cpp
+++ b/src/modes/serial/device.cpp
@@ -139,7 +139,7 @@ namespace occa {
     bool device::parseFile(const std::string &filename,
                            const std::string &outputFile,
                            const occa::properties &kernelProps,
-                           lang::kernelMetadataMap &metadata) {
+                           lang::sourceMetadata_t &metadata) {
       lang::okl::serialParser parser(kernelProps);
       parser.parseFile(filename);
 
@@ -158,7 +158,7 @@ namespace occa {
         }
       }
 
-      parser.setMetadata(metadata);
+      parser.setSourceMetadata(metadata);
 
       return true;
     }
@@ -230,7 +230,7 @@ namespace occa {
                       assembleKernelHeader(kernelProps))
       );
 
-      lang::kernelMetadataMap metadata;
+      lang::sourceMetadata_t metadata;
       if (kernelProps.get("okl", true)) {
         const std::string outputFile = hashDir + kc::sourceFile;
         bool valid = parseFile(sourceFilename,
@@ -297,7 +297,7 @@ namespace occa {
       modeKernel_t *k = buildKernelFromBinary(binaryFilename,
                                               kernelName,
                                               kernelProps,
-                                              metadata[kernelName]);
+                                              metadata.kernelsMetadata[kernelName]);
       if (k) {
         io::markCachedFileComplete(hashDir, kcBinaryFile);
         k->sourceFilename = filename;
@@ -313,8 +313,8 @@ namespace occa {
 
       lang::kernelMetadata_t metadata;
       if (io::isFile(buildFile)) {
-        lang::kernelMetadataMap metadataMap = lang::getBuildFileMetadata(buildFile);
-        metadata = metadataMap[kernelName];
+        lang::sourceMetadata_t sourceMetadata = lang::sourceMetadata_t::fromBuildFile(buildFile);
+        metadata = sourceMetadata.kernelsMetadata[kernelName];
       }
 
       return buildKernelFromBinary(filename,

--- a/src/modes/serial/device.cpp
+++ b/src/modes/serial/device.cpp
@@ -311,7 +311,7 @@ namespace occa {
       std::string buildFile = io::dirname(filename);
       buildFile += kc::buildFile;
 
-      lang::kernelMetadata metadata;
+      lang::kernelMetadata_t metadata;
       if (io::isFile(buildFile)) {
         lang::kernelMetadataMap metadataMap = lang::getBuildFileMetadata(buildFile);
         metadata = metadataMap[kernelName];
@@ -326,7 +326,7 @@ namespace occa {
     modeKernel_t* device::buildKernelFromBinary(const std::string &filename,
                                                 const std::string &kernelName,
                                                 const occa::properties &kernelProps,
-                                                lang::kernelMetadata &metadata) {
+                                                lang::kernelMetadata_t &metadata) {
       kernel &k = *(new kernel(this,
                                kernelName,
                                filename,

--- a/src/modes/serial/kernel.cpp
+++ b/src/modes/serial/kernel.cpp
@@ -34,7 +34,7 @@ namespace occa {
       return dim(-1,-1,-1);
     }
 
-    const lang::kernelMetadata& kernel::getMetadata() const {
+    const lang::kernelMetadata_t& kernel::getMetadata() const {
       return metadata;
     }
 


### PR DESCRIPTION
The `build.json` file now stores a map from a kernel's dependency which comes from a `#include` and its file content hash. 

The first time a kernel is build, the hash comes from the file source. Consecutive builds will check if the dependencies changed. If they did, the new hash comes from a combination of the kernel source and dependency hashes.

This change is still missing tests