### PR TITLE
Copy to prefix instead of prefix/subfolder

### DIFF
--- a/include/occa/scripts/shellTools.sh
+++ b/include/occa/scripts/shellTools.sh
@@ -542,8 +542,8 @@ function installOcca {
         return
     fi
     mkdir -p "${PREFIX}"
-    cp -r bin     "${PREFIX}/bin"
-    cp -r include "${PREFIX}/include"
-    cp -r lib     "${PREFIX}/lib"
+    cp -r bin     "${PREFIX}"
+    cp -r include "${PREFIX}"
+    cp -r lib     "${PREFIX}"
 }
 #=======================================

--- a/include/occa/scripts/shellTools.sh
+++ b/include/occa/scripts/shellTools.sh
@@ -541,7 +541,11 @@ function installOcca {
     if [ -z "${PREFIX}" ]; then
         return
     fi
-    mkdir -p "${PREFIX}"
+    if [ -d "${PREFIX}" ]; then
+      echo "Warning: Install PREFIX=${PREFIX} already exists."
+    else
+      mkdir -p "${PREFIX}"
+    fi
     cp -r bin     "${PREFIX}"
     cp -r include "${PREFIX}"
     cp -r lib     "${PREFIX}"


### PR DESCRIPTION
<!-- Thank you for contributing!! :) -->

### Description

Copy bin, include, lib into PREFIX/ when installing.

### Checks
- [x] Nothing got committed into `./lib` and `./obj`
- [x] MIT License copyright in new files
