### PR TITLE
[OKL] Adds @directive preprocessor attribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ bin-tests: unit-tests
 
 $(testPath)/bin/%:$(testPath)/src/%.cpp $(outputs)
 	@mkdir -p $(abspath $(dir $@))
-	$(compiler) $(testFlags) $(pthreadFlag) -o $@ $(flags) $< $(paths) $(linkerFlags) -L$(OCCA_DIR)/lib -locca
+	$(compiler) $(testFlags) $(pthreadFlag) -o $@ -Wl,-rpath,$(libPath) $(flags) $< $(paths) $(linkerFlags) -L$(OCCA_DIR)/lib -locca
 #=================================================
 
 

--- a/include/occa/lang/preprocessor.hpp
+++ b/include/occa/lang/preprocessor.hpp
@@ -130,7 +130,13 @@ namespace occa {
 
       void processToken(token_t *token);
       void processIdentifier(identifierToken &token);
-      void processOperator(operatorToken &token);
+
+      void processOperator(operatorToken &opToken);
+      void processHashOperator(operatorToken &opToken);
+      void processAttributeOperator(operatorToken &opToken);
+      void freeAttributeOperatorTokens(token_t &opToken,
+                                       token_t &directiveToken,
+                                       std::list<token_t*> &prevOutputCache);
 
       bool lineIsTrue(identifierToken &directive,
                       bool &isTrue);

--- a/include/occa/lang/tokenizer.hpp
+++ b/include/occa/lang/tokenizer.hpp
@@ -96,7 +96,7 @@ namespace occa {
       int peekForOperator();
 
       void getIdentifier(std::string &value);
-      void getString(std::string &value,
+      bool getString(std::string &value,
                      const int encoding = 0);
       void getRawString(std::string &value);
 

--- a/src/lang/macro.cpp
+++ b/src/lang/macro.cpp
@@ -624,7 +624,7 @@ namespace occa {
 
         if (!token) {
           errorOn(&source,
-                  "Not able to find closing )");
+                  "Not able to find a closing )");
           break;
         }
 

--- a/src/lang/preprocessor.cpp
+++ b/src/lang/preprocessor.cpp
@@ -629,8 +629,16 @@ namespace occa {
       }
 
       // Try and get the 3 @directive[(]["..."][)] tokens
+      const int currentTokenizerErrors = tokenizer->errors;
+      const int currentErrors = errors;
       while (!inputIsEmpty() && outputCache.size() < 3) {
         fetchNext();
+        if ((errors > currentErrors) ||
+            (tokenizer->errors > currentTokenizerErrors)) {
+          return freeAttributeOperatorTokens(opToken,
+                                             *directiveToken,
+                                             prevOutputCache);
+        }
       }
       if (outputCache.size() < 3) {
         errorOn(directiveToken,
@@ -671,15 +679,10 @@ namespace occa {
       // Make sure @directive content starts with a #
       bool missingStartHash = (!sourceLength || source[0] != '#');
       // Make sure there are no newlines inserted
-      bool hasNewlines = false;
-      if (!missingStartHash) {
-        for (int i = 1; i < sourceLength; ++i) {
-          hasNewlines = (source[i] == '\n');
-          if (hasNewlines) {
-            break;
-          }
-        }
-      }
+      bool hasNewlines = (
+        !missingStartHash
+        && source.find("\\n") != std::string::npos
+      );
 
       // Print error message if needed
       if (missingStartHash || hasNewlines) {

--- a/tests/src/lang/preprocessor.cpp
+++ b/tests/src/lang/preprocessor.cpp
@@ -17,6 +17,7 @@ void testSpecialMacros();
 void testInclude();
 void testPragma();
 void testOccaPragma();
+void testOccaDirective();
 
 using namespace occa::lang;
 
@@ -40,10 +41,11 @@ void setStream(const std::string &s) {
   preprocessor.clear();
 }
 
-void getToken() {
+token_t* getToken() {
   delete token;
   token = NULL;
   tokenStream >> token;
+  return token;
 }
 
 void setToken(const std::string &s) {
@@ -82,6 +84,7 @@ int main(const int argc, const char **argv) {
   testInclude();
   testPragma();
   testOccaPragma();
+  testOccaDirective();
 
   delete token;
 
@@ -667,6 +670,64 @@ void testOccaPragma() {
 
 #undef checkOp
 #undef checkIdentifier
+#undef checkPrimitive
+}
+
+void testOccaDirective() {
+  preprocessor_t *pp;
+  occa::lang::tokenVector tokens;
+
+#define loadDirectiveTokens(directive, content)                 \
+  setStream("@directive(\"" directive "\")\n"                   \
+            content);                                           \
+  tokens.clear();                                               \
+  while (!tokenStream.isEmpty()) {                              \
+    tokens.push_back(getToken());                               \
+  }                                                             \
+  pp = (preprocessor_t*) tokenStream.getInput("preprocessor_t")
+
+#define checkTokenType(index, token_type)             \
+  ASSERT_EQ_BINARY(token_type, tokens[index]->type())
+
+
+#define checkPrimitive(index, ptype, primitive_)              \
+  checkTokenType(index, tokenType::primitive);                \
+  ASSERT_EQ(primitive_,                                       \
+            (ptype) ((primitiveToken*) tokens[index])->value)
+
+#define checkPragma(index, expectedValue)           \
+  checkTokenType(0, tokenType::pragma);             \
+  ASSERT_EQ(expectedValue,                          \
+            tokens[index]->to<pragmaToken>().value)
+
+
+  // Define
+  loadDirectiveTokens("#define A 1",
+                      "A");
+  ASSERT_EQ(1, (int) tokens.size());
+  checkPrimitive(0, int, 1);
+
+  // Pragma
+  loadDirectiveTokens("#pragma",
+                      "");
+  ASSERT_EQ(1, (int) tokens.size());
+  checkPragma(0, "");
+
+  loadDirectiveTokens("#pragma foo",
+                      "");
+  ASSERT_EQ(1, (int) tokens.size());
+  checkPragma(0, "foo");
+
+  loadDirectiveTokens("#pragma foo a b c",
+                      "");
+  ASSERT_EQ(1, (int) tokens.size());
+  checkPragma(0, "foo a b c");
+
+  // OCCA Pragma
+  loadDirectiveTokens("#pragma occa attributes @tile(16, @outer, @inner)",
+                      "");
+
+#undef loadDirectiveTokens
 #undef checkPrimitive
 }
 //======================================


### PR DESCRIPTION
### Description

When using stringification macros such as `OCCA_JIT`, there is no way to add preprocessor directives such as

```
OCCA_JIT(
  props,
  (entries, a, b, ab),
  (
    for (int block = 0; block < entries; block += 16; @outer) {
      #pragma ivdep
      for (int i = block; i < (block + 16); ++i; @inner) {
        ...
      }
    }
  )
)
```

Introducing `@directive` which replaces

```
#pragma ivdep
```

with

```
@directive("#pragma ivdep")
```

resulting in the code looking like:

```
OCCA_JIT(
  props,
  (entries, a, b, ab),
  (
    for (int block = 0; block < entries; block += 16; @outer) {
      @directive("#pragma ivdep")
      for (int i = block; i < (block + 16); ++i; @inner) {
        ...
      }
    }
  )
)
```
