### PR TITLE
[Valgrind] Removed bad access to json.initialized

### DIFF
--- a/include/occa/tools/json.hpp
+++ b/include/occa/tools/json.hpp
@@ -231,7 +231,7 @@ namespace occa {
       return *this;
     }
 
-    virtual bool isInitialized();
+    virtual bool isInitialized() const;
 
     json& load(const char *&c);
     json& load(const std::string &s);

--- a/include/occa/tools/properties.hpp
+++ b/include/occa/tools/properties.hpp
@@ -6,7 +6,9 @@
 namespace occa {
   class properties: public json {
   public:
-    bool initialized;
+    // Note: Do not use directly since we're casting between
+    //       occa::json& <--> occa::properties&
+    mutable bool initialized;
 
     properties();
     properties(const properties &other);
@@ -15,19 +17,19 @@ namespace occa {
     properties(const std::string &s);
     ~properties();
 
-    bool isInitialized();
+    bool isInitialized() const;
 
     void load(const char *&c);
     void load(const std::string &s);
 
     static properties read(const std::string &filename);
-
-    inline properties operator + (const properties &p) const {
-      properties ret = *this;
-      ret.mergeWithObject(p.value_.object);
-      return ret;
-    }
   };
+
+  inline properties operator + (const properties &left, const properties &right) {
+    properties sum = left;
+    sum.mergeWithObject(right.value_.object);
+    return sum;
+  }
 
   template <>
   hash_t hash(const properties &props);

--- a/src/tools/json.cpp
+++ b/src/tools/json.cpp
@@ -25,7 +25,7 @@ namespace occa {
     return *this;
   }
 
-  bool json::isInitialized() {
+  bool json::isInitialized() const {
     return (type != none_);
   }
 

--- a/src/tools/properties.cpp
+++ b/src/tools/properties.cpp
@@ -11,7 +11,9 @@ namespace occa {
   properties::properties(const properties &other) {
     type = object_;
     value_ = other.value_;
-    initialized = other.initialized;
+
+    // Note: "other" might be a json object
+    initialized = other.isInitialized();
   }
 
   properties::properties(const json &j) {
@@ -20,17 +22,19 @@ namespace occa {
     initialized = true;
   }
 
-  properties::properties(const char *c) {
+  properties::properties(const char *c) :
+      initialized(false) {
     properties::load(c);
   }
 
-  properties::properties(const std::string &s) {
+  properties::properties(const std::string &s) :
+      initialized(false) {
     properties::load(s);
   }
 
   properties::~properties() {}
 
-  bool properties::isInitialized() {
+  bool properties::isInitialized() const {
     if (!initialized) {
       initialized = value_.object.size();
     }


### PR DESCRIPTION
## Using Valgrind Suppressions

```bash
valgrind -v --leak-check=full --show-leak-kinds=all --suppressions=<path/to/conf>
```

## Finding Suppressions to Use

Add the ` --gen-suppressions=all` flag to your `valgrind` command

## Useful Suppressions

### libdl

`dlopen` ends up allocating some thread-local storage memory

Link:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=700899

Suppression:
```conf
{
  dlopen_leaks
  Memcheck:Leak
  fun:calloc
  fun:_dlerror_run
  fun:*dlopen*
  ...
}
```

### OpenMP

Some allocations are not cleaned up by OpenMP even when not using them

```conf
{
   openmp_leaks
   Memcheck:Param
   sched_setaffinity(mask)
   fun:syscall
   ...
   obj:*lib*omp*
   ...
}
 
{
   openmp_leaks
   Memcheck:Leak
   fun:*alloc
   ...
   obj:*lib*omp*
   ...
}
```

### CUDA

Useful suppressions that Valgrind doesn't detect

```conf
{
   alloc_libcuda
   Memcheck:Leak
   match-leak-kinds: definite,indirect,possible,reachable
   fun:*alloc
   ...
   obj:*libcuda.so*
   ...
}
 
{
   alloc_libcufft
   Memcheck:Leak
   match-leak-kinds: definite,indirect,possible,reachable
   fun:*alloc
   ...
   obj:*libcufft.so*
   ...
}
 
{
   alloc_libcudaart
   Memcheck:Leak
   match-leak-kinds: definite,indirect,possible,reachable
   fun:*alloc
   ...
   obj:*libcudart.so*
   ...
}
 ```

### OpenCL

Useful suppressions that Valgrind doesn't detect

```conf
{
   opencl_leaks
   Memcheck:Leak
   match-leak-kinds: definite,indirect,possible,reachable
   fun:*alloc
   ...
   obj:*opencl.so*
   ...
}
 
{
   opencl_leaks
   Memcheck:Leak
   match-leak-kinds: definite,indirect,possible,reachable
   fun:*alloc
   ...
   obj:*libOpenCL*
}
...