### PR TITLE
[Memory] Adds own_host_pointer flag to malloc and wrapMemory

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -598,10 +598,12 @@ namespace occa {
                             void *ptr,
                             const udim_t bytes,
                             const occa::properties &props) {
-      occa::properties memProps = props;
-      memProps["use_host_pointer"] = true;
+      static occa::properties defaultProps(
+        "use_host_pointer: true,"
+        "own_host_pointer: false"
+      );
 
-      return device.malloc(bytes, ptr, memProps);
+      return device.malloc(bytes, ptr, defaultProps + props);
     }
   }
 }

--- a/src/modes/serial/device.cpp
+++ b/src/modes/serial/device.cpp
@@ -355,7 +355,7 @@ namespace occa {
 
       if (props.get("use_host_pointer", false)) {
         mem->ptr = (char*) const_cast<void*>(src);
-        mem->isOrigin = false;
+        mem->isOrigin = props.get("own_host_pointer", false);
       } else {
         mem->ptr = (char*) sys::malloc(bytes);
         if (src) {


### PR DESCRIPTION
```cpp
int *ptr = new int[10];

occa::memory mem_doesnt_deallocates_ptr = occa::malloc<int>(
  10,
  ptr,
  "use_host_pointer: true"
)
occa::memory mem_deallocates_ptr = occa::malloc<int>(
  10,
  ptr,
  "use_host_pointer: true, "
  "own_host_pointer: true"
)
```