### PR TITLE
[BG] Fixes <void> templated malloc

### DIFF
--- a/include/occa/core/base.hpp
+++ b/include/occa/core/base.hpp
@@ -68,21 +68,27 @@ namespace occa {
   template <class TM = void>
   occa::memory malloc(const dim_t entries,
                       const void *src = NULL,
-                      const occa::properties &props = occa::properties()) {
-    return malloc(entries, dtype::get<TM>(), src, props);
-  }
+                      const occa::properties &props = occa::properties());
+
+  template <>
+  occa::memory malloc<void>(const dim_t entries,
+                            const void *src,
+                            const occa::properties &props);
 
   void* umalloc(const dim_t entries,
                 const dtype_t &dtype,
                 const void *src = NULL,
                 const occa::properties &props = occa::properties());
 
-  template <class TM>
-  TM* umalloc(const dim_t bytes,
+  template <class TM = void>
+  TM* umalloc(const dim_t entries,
               const void *src = NULL,
-              const occa::properties &props = occa::properties()) {
-    return (TM*) umalloc(bytes, dtype::get<TM>(), src, props);
-  }
+              const occa::properties &props = occa::properties());
+
+  template <>
+  void* umalloc<void>(const dim_t entries,
+                      const void *src,
+                      const occa::properties &props);
 
   void memcpy(void *dest, const void *src,
               const dim_t bytes,
@@ -132,5 +138,7 @@ namespace occa {
 
   void printModeInfo();
 }
+
+#include "base.tpp"
 
 #endif

--- a/include/occa/core/base.tpp
+++ b/include/occa/core/base.tpp
@@ -1,0 +1,15 @@
+namespace occa {
+  template <class TM>
+  occa::memory malloc(const dim_t entries,
+                      const void *src,
+                      const occa::properties &props) {
+    return malloc(entries, dtype::get<TM>(), src, props);
+  }
+
+  template <class TM>
+  TM* umalloc(const dim_t entries,
+              const void *src,
+              const occa::properties &props) {
+    return (TM*) umalloc(entries, dtype::get<TM>(), src, props);
+  }
+}

--- a/src/core/base.cpp
+++ b/src/core/base.cpp
@@ -102,11 +102,25 @@ namespace occa {
     return getDevice().malloc(entries, dtype, src, props);
   }
 
+  template <>
+  occa::memory malloc<void>(const dim_t entries,
+                            const void *src,
+                            const occa::properties &props) {
+    return getDevice().malloc(entries, dtype::byte, src, props);
+  }
+
   void* umalloc(const dim_t entries,
                 const dtype_t &dtype,
                 const void *src,
                 const occa::properties &props) {
     return getDevice().umalloc(entries, dtype, src, props);
+  }
+
+  template <>
+  void* umalloc<void>(const dim_t entries,
+                      const void *src,
+                      const occa::properties &props) {
+    return getDevice().umalloc(entries, dtype::byte, src, props);
   }
 
   void memcpy(void *dest, const void *src,

--- a/tests/src/core/memory.cpp
+++ b/tests/src/core/memory.cpp
@@ -25,6 +25,21 @@ void testMalloc() {
   mem = occa::malloc(bytes, hostPtr, "use_host_pointer: true");
   ASSERT_EQ(mem.ptr<int>()[0], value);
   ASSERT_EQ(mem.ptr<int>(), hostPtr);
+
+  occa::setDevice(
+    "mode: 'Serial',"
+    "memory: {"
+    "  use_host_pointer: true,"
+    "}"
+  );
+
+  mem = occa::malloc(bytes, hostPtr);
+  ASSERT_EQ(((int*) mem.ptr())[0], value);
+  ASSERT_EQ(mem.ptr<int>(), hostPtr);
+
+  mem = occa::malloc(bytes, hostPtr, "use_host_pointer: false");
+  ASSERT_EQ(mem.ptr<int>()[0], value);
+  ASSERT_NEQ(mem.ptr<int>(), hostPtr);
 }
 
 void testCpuWrapMemory() {
@@ -38,5 +53,5 @@ void testCpuWrapMemory() {
 
   mem = occa::cpu::wrapMemory(hostPtr, bytes, "use_host_pointer: false");
   ASSERT_EQ(mem.ptr<int>()[0], value);
-  ASSERT_EQ(mem.ptr<int>(), hostPtr);
+  ASSERT_NEQ(mem.ptr<int>(), hostPtr);
 }


### PR DESCRIPTION
The new default `void` mallloc ended up trying to allocate 0 bytes since 

```cpp
dtype::get<void>() == 0
```