### PR TITLE
[Serial] Fixes lack of C++11 flags when compiling kernels

### DIFF
--- a/include/occa/tools.hpp
+++ b/include/occa/tools.hpp
@@ -15,5 +15,6 @@
 #include <occa/tools/sys.hpp>
 #include <occa/tools/tls.hpp>
 #include <occa/tools/uva.hpp>
+#include <occa/tools/vector.hpp>
 
 #endif

--- a/include/occa/tools/string.hpp
+++ b/include/occa/tools/string.hpp
@@ -238,13 +238,9 @@ namespace occa {
   }
 
   std::string stringifyBytes(udim_t bytes);
+
   void stringifyBytesFraction(std::stringstream &ss,
                               uint64_t fraction);
-
-  //---[ Vector Methods ]---------------
-  std::string join(const strVector &vec,
-                   const std::string &seq);
-  //====================================
 
   //---[ Color Strings ]----------------
   namespace color {

--- a/include/occa/tools/sys.hpp
+++ b/include/occa/tools/sys.hpp
@@ -79,11 +79,19 @@ namespace occa {
 
     int compilerVendor(const std::string &compiler);
 
+    std::string compilerCpp11Flags(const std::string &compiler);
+    std::string compilerCpp11Flags(const int vendor_);
+
+    void addCpp11Flags(const std::string &compiler, std::string &compilerFlags);
+    void addCpp11Flags(const int vendor_, std::string &compilerFlags);
+
     std::string compilerSharedBinaryFlags(const std::string &compiler);
     std::string compilerSharedBinaryFlags(const int vendor_);
 
-    void addSharedBinaryFlagsTo(const std::string &compiler, std::string &compilerFlags);
-    void addSharedBinaryFlagsTo(const int vendor_, std::string &compilerFlags);
+    void addSharedBinaryFlags(const std::string &compiler, std::string &compilerFlags);
+    void addSharedBinaryFlags(const int vendor_, std::string &compilerFlags);
+
+    void addCompilerFlags(std::string &compilerFlags, const std::string &flags);
     //==================================
 
     //---[ Dynamic Methods ]------------

--- a/include/occa/tools/vector.hpp
+++ b/include/occa/tools/vector.hpp
@@ -1,0 +1,26 @@
+#ifndef OCCA_TOOLS_VECTOR_HEADER
+#define OCCA_TOOLS_VECTOR_HEADER
+
+#include <string>
+#include <vector>
+
+#include <occa/types/typedefs.hpp>
+
+namespace occa {
+  template <class TM>
+  dim_t indexOf(const std::vector<TM> &vec,
+              const TM &value) {
+    const dim_t size = vec.size();
+    for (dim_t i = 0; i < size; ++i) {
+      if (vec[i] == value) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  std::string join(const std::vector<std::string> &vec,
+                   const std::string &delimiter);
+}
+
+#endif

--- a/src/modes/serial/device.cpp
+++ b/src/modes/serial/device.cpp
@@ -256,8 +256,10 @@ namespace occa {
       }
 
       std::string compilerFlags = kernelProps["compiler_flags"];
-      sys::addSharedBinaryFlagsTo((int) kernelProps["vendor"],
-                                  compilerFlags);
+      const int vendor = (int) kernelProps["vendor"];
+
+      sys::addSharedBinaryFlags(vendor, compilerFlags);
+      sys::addCpp11Flags(vendor, compilerFlags);
 
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
       command << (std::string) kernelProps["compiler"]
@@ -281,7 +283,7 @@ namespace occa {
               << std::endl;
 #endif
 
-      const std::string &sCommand = command.str();
+      const std::string &sCommand = strip(command.str());
 
       if (verbose) {
         io::stdout << "Compiling [" << kernelName << "]\n" << sCommand << "\n";

--- a/src/tools/string.cpp
+++ b/src/tools/string.cpp
@@ -342,22 +342,6 @@ namespace occa {
     }
   }
 
-  //---[ Vector Methods ]---------------
-  std::string join(const strVector &vec,
-                   const std::string &seq) {
-    const int entries = (int) vec.size();
-    if (entries == 0) {
-      return "";
-    }
-    std::string ret = vec[0];
-    for (int i = 1; i < entries; ++i) {
-      ret += seq;
-      ret += vec[i];
-    }
-    return ret;
-  }
-  //====================================
-
   //---[ Color Strings ]----------------
   namespace color {
     const char fgMap[9][7] = {

--- a/src/tools/vector.cpp
+++ b/src/tools/vector.cpp
@@ -1,0 +1,17 @@
+#include <occa/tools/string.hpp>
+#include <occa/tools/vector.hpp>
+
+namespace occa {
+  std::string join(const std::vector<std::string> &vec,
+                   const std::string &delimiter) {
+    const size_t size = vec.size();
+    std::string ret;
+    for (size_t i = 0; i < size; ++i) {
+      if (i) {
+        ret += delimiter;
+      }
+      ret += toString(vec[i]);
+    }
+    return ret;
+  }
+}

--- a/tests/src/tools/vector.cpp
+++ b/tests/src/tools/vector.cpp
@@ -1,0 +1,56 @@
+#include <occa.hpp>
+#include <occa/tools/testing.hpp>
+
+using namespace occa;
+
+template <class TM>
+TM castNum(const int i) {
+  return fromString<TM>(
+    toString(i)
+  );
+}
+
+template <class TM>
+void testIndexOf() {
+  std::vector<TM> vec;
+  for (int i = 0; i < 10; ++i) {
+    vec.push_back(castNum<TM>(i));
+  }
+
+  ASSERT_EQ(
+    (dim_t) 5,
+    indexOf(vec, castNum<TM>(5))
+  );
+
+  ASSERT_EQ(
+    (dim_t) -1,
+    indexOf(vec, castNum<TM>(-1))
+  );
+
+  ASSERT_EQ(
+    (dim_t) -1,
+    indexOf(vec, castNum<TM>(11))
+  );
+}
+
+void testJoin();
+
+int main(const int argc, const char **argv) {
+  testIndexOf<int>();
+  testIndexOf<float>();
+  testIndexOf<std::string>();
+  testJoin();
+
+  return 0;
+}
+
+void testJoin() {
+  strVector vec;
+  vec.push_back("a");
+  vec.push_back("b");
+  vec.push_back("c");
+  ASSERT_EQ(join(vec, ","),
+            "a,b,c");
+  ASSERT_EQ(join(vec, " , "),
+            "a , b , c");
+}


### PR DESCRIPTION
## Description

After updating OCCA to use C++11, I forgot to update Serial kernel compilations to use C++11 headers since they `#include <occa.hpp>`