### PR TITLE
[Core] Fixes object-mode specific properties, adds config.default.json to help explain default props

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,0 +1,176 @@
+// By default, should be placed in ~/.occa/config.json
+// Note it uses most of JSON5 format
+{
+  env: {
+    OCCA_COLOR_ENABLED: true,
+    OCCA_DIR: "~/occa",
+    OCCA_CACHE_DIR: "~/.occa",
+    OCCA_MEM_BYTE_ALIGN: 64,
+    OCCA_PATH: [
+      "/path/to/places/with/kernels",
+    ],
+    OCCA_CONFIG: "<path to this file>", // (defaults to "${OCCA_CACHE_DIR}/config.json")
+  },
+  settings: {
+    // Automaticly added settings, don't override!
+    // version: "<Major>.<Minor>.<Patch>", (e.g. "1.0.0")
+    // okl_version: "<Major>.<Minor>.<Patch>", (e.g. "1.0.0")
+
+    // General core object settings
+    device: {
+      mode: "<mode-of-the-device>",
+      verbose: false,
+    },
+    kernel: {
+      mode: "<mode-of-the-kernel>",
+      verbose: false,
+
+      // Silently run even with failed compilations
+      // kernel::isInitialized() will return false on failed compilations
+      allow_failed_kernels: false,
+
+      // Map of key -> value pairs to `#define key value`
+      defines: {},
+
+      // List of files to `#include "file"`
+      include: [],
+
+      // List of source-code snippets to include at the top of the source code
+      header: [],
+
+      // OKL Options
+      okl: {
+        // Validate for proper OKL kernels
+        // This checks if OKL attributes are used properly. For example:
+        //   @outer, @inner, @shared, @exclusive
+        validate: true,
+
+        // Additional places to search for headers
+        include_paths: [],
+
+        // Macro to expand @restrict variables since it is compiler-dependent in C++
+        restrict: "__restrict__",
+      },
+    },
+    memory: {
+      mode: "<mode-of-the-memory>"
+      verbose: false,
+    },
+    stream: {},
+    // Mode-specific settings
+    mode: {
+      Serial: {
+        kernel: {
+          compiler: "g++",
+          compiler_flags: "-O3",
+          compiler_env_script: "",
+
+          // Include certain standard headers such as:
+          //   #include <stdint.h>
+          //   #include <cstdlib>
+          //   #include <cstdio>
+          //   #include <cmath>
+          include_std: true,
+        },
+      },
+      OpenMP: {
+        kernel: {
+          compiler: "g++",
+          compiler_flags: "-O3",
+          compiler_env_script: "",
+        },
+      },
+      CUDA: {
+        device: {
+          // Required props when creating a CUDA device:
+          device_id: 0,
+        }
+        kernel: {
+          compiler: "nvcc",
+          compiler_flags: "-O3",
+          compiler_env_script: "",
+        },
+        memory: {
+          // Uses unified memory
+          unified: false,
+
+          // Uses host-mapped memory
+          mapped: false,
+
+          // If true, use CU_MEM_ATTACH_HOST instead of CU_MEM_ATTACH_GLOBAL
+          // with unified memory allocations
+          attached_host: false,
+        },
+      },
+      HIP: {
+        device: {
+          // Required props when creating a HIP device:
+          device_id: 0,
+        }
+        kernel: {
+          compiler: "hipcc",
+          compiler_flags: "-O3",
+          compiler_env_script: "",
+
+          // Auto-detected
+          arch: {
+            major: "<HIP-major-version>",
+            minor: "<HIP-minor-version>",
+          },
+
+          // Used with flags "-t gfx <target>"
+          target: "<HIP-target>",
+        },
+        memory: {
+          // Uses host-mapped memory
+          mapped: false,
+        },
+      },
+      OpenCL: {
+        device: {
+          // Required props when creating a OpenCL device:
+          platform_id: 0,
+          device_id: 0,
+        },
+        kernel: {
+          compiler_flags: "",
+
+          // Additional extensions to use when compiling kernels
+          extensions: {
+            "cl_khr_fp64": true,
+          },
+        },
+        memory: {
+          // Uses host-mapped memory
+          mapped: false,
+        },
+      },
+      Metal: {
+        device: {
+          // Required props when creating a Metal device:
+          device_id: 0,
+        },
+        kernel: {
+          compiler_flags: "",
+        },
+      },
+    },
+    // System settings
+    sys: {
+      // Cannot delete any directory less than 2 directories from /
+      // For example:
+      //   Safe:   /home/occa/foo
+      //   Unsafe: /home/foo
+      safe_rmrf: true,
+    },
+    // Caching lock settings
+    locks: {
+      stale_warning: 10.0,
+      stale_age: 20.0,
+    },
+    // OKL settings
+    okl: {
+      validate: true,
+    },
+  },
+}

--- a/config.default.json
+++ b/config.default.json
@@ -58,7 +58,7 @@
     },
     stream: {},
     // Mode-specific settings
-    mode: {
+    modes: {
       Serial: {
         kernel: {
           compiler: "g++",

--- a/examples/cpp/03_inline_okl/main.cpp
+++ b/examples/cpp/03_inline_okl/main.cpp
@@ -21,15 +21,28 @@ int main(int argc, const char **argv) {
     ab[i] = 0;
   }
 
-  occa::properties props;
-  props["defines/TILE_SIZE"] = 16;
-
   // Const-ness of variables is passed through which can be useful for the compiler
   const float *c_a = a;
   const float *c_b = b;
 
   // Arguments:
-  // 1. Runtime occa::properties (pass occa::properties() to ignore this argument)
+  // 1. Captured variables
+  // 2. Inlined OKL source
+  OCCA_JIT(
+    (entries, c_a, c_b, ab),
+    (
+      for (int i = 0; i < entries; ++i; @tile(16, @outer, @inner)) {
+        ab[i] = 100 * (c_a[i] + c_b[i]);
+      }
+    )
+  );
+
+  // Runtime occa::properties can also be passed in the first argument
+  occa::properties props;
+  props["defines/TILE_SIZE"] = 16;
+
+  // Arguments:
+  // 1. Properties (optional)
   // 2. Captured variables
   // 3. Inlined OKL source
   OCCA_JIT(
@@ -39,7 +52,7 @@ int main(int argc, const char **argv) {
       // TILE_SIZE is passed as a compile-time define as opposed to a runtime variable
       // through props
       for (int i = 0; i < entries; ++i; @tile(TILE_SIZE, @outer, @inner)) {
-        ab[i] = 100 * (c_a[i] + c_b[i]);
+        ab[i] = 200 * (c_a[i] + c_b[i]);
       }
     )
   );

--- a/include/occa.h
+++ b/include/occa.h
@@ -17,22 +17,6 @@
 // Just in case someone wants to run with an older format than C99
 #ifndef OCCA_DISABLE_VARIADIC_MACROS
 
-#define OCCA_ARG_COUNT(...) OCCA_ARG_COUNT2(__VA_ARGS__,                \
-                                            50,49,48,47,46,45,44,43,42,41, \
-                                            40,39,38,37,36,35,34,33,32,31, \
-                                            30,29,28,27,26,25,24,23,22,21, \
-                                            20,19,18,17,16,15,14,13,12,11, \
-                                            10,9,8,7,6,5,4,3,2,1,       \
-                                            0)
-
-#define OCCA_ARG_COUNT2(KERNEL,                                   \
-                        _1,_2,_3,_4,_5,_6,_7,_8,_9,_10,           \
-                        _11,_12,_13,_14,_15,_16,_17,_18,_19,_20,  \
-                        _21,_22,_23,_24,_25,_26,_27,_28,_29,_30,  \
-                        _31,_32,_33,_34,_35,_36,_37,_38,_39,_40,  \
-                        _41,_42,_43,_44,_45,_46,_47,_48,_49,_50,  \
-                        N, ...) N
-
 #define OCCA_C_RUN_KERNEL3(N, kernel, ...) occaKernelRunN(kernel, N, __VA_ARGS__)
 #define OCCA_C_RUN_KERNEL2(...) OCCA_C_RUN_KERNEL3(__VA_ARGS__)
 #define OCCA_C_RUN_KERNEL1(...) OCCA_C_RUN_KERNEL2(__VA_ARGS__)

--- a/include/occa/c/device.h
+++ b/include/occa/c/device.h
@@ -19,6 +19,8 @@ OCCA_LFUNC occaProperties OCCA_RFUNC occaDeviceGetKernelProperties(occaDevice de
 
 OCCA_LFUNC occaProperties OCCA_RFUNC occaDeviceGetMemoryProperties(occaDevice device);
 
+OCCA_LFUNC occaProperties OCCA_RFUNC occaDeviceGetStreamProperties(occaDevice device);
+
 OCCA_LFUNC occaUDim_t OCCA_RFUNC occaDeviceMemorySize(occaDevice device);
 
 OCCA_LFUNC occaUDim_t OCCA_RFUNC occaDeviceMemoryAllocated(occaDevice device);

--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -176,17 +176,16 @@ namespace occa {
 
     const std::string& mode() const;
 
-    occa::properties& properties();
     const occa::properties& properties() const;
 
-    occa::properties& kernelProperties();
     const occa::properties& kernelProperties() const;
+    occa::properties kernelProperties(const occa::properties &additionalProps) const;
 
-    occa::properties& memoryProperties();
     const occa::properties& memoryProperties() const;
+    occa::properties memoryProperties(const occa::properties &additionalProps) const;
 
-    occa::properties& streamProperties();
     const occa::properties& streamProperties() const;
+    occa::properties streamProperties(const occa::properties &additionalProps) const;
 
     hash_t hash() const;
 
@@ -310,6 +309,19 @@ namespace occa {
   template <>
   occa::memory device::malloc<void>(const dim_t entries,
                                     const occa::properties &props);
+  //====================================
+
+  //---[ Utils ]------------------------
+  occa::properties getModeSpecificProps(const std::string &mode,
+                                        const occa::properties &props);
+
+  occa::properties getObjectSpecificProps(const std::string &mode,
+                                          const std::string &object,
+                                          const occa::properties &props);
+
+  occa::properties initialObjectProps(const std::string &mode,
+                                      const std::string &object,
+                                      const occa::properties &props);
   //====================================
 }
 

--- a/include/occa/defines/macros.hpp
+++ b/include/occa/defines/macros.hpp
@@ -24,4 +24,27 @@
 #  define OCCA_INLINE __forceinline
 #endif
 
+// Just in case someone wants to run with an older format than C99
+#ifndef OCCA_DISABLE_VARIADIC_MACROS
+
+#  define OCCA_ARG_COUNT(...) OCCA_ARG_COUNT2(\
+    __VA_ARGS__,                              \
+    50, 49, 48, 47, 46, 45, 44, 43, 42, 41,   \
+    40, 39, 38, 37, 36, 35, 34, 33, 32, 31,   \
+    30, 29, 28, 27, 26, 25, 24, 23, 22, 21,   \
+    20, 19, 18, 17, 16, 15, 14, 13, 12, 11,   \
+    10, 9, 8, 7, 6, 5, 4, 3, 2, 1,            \
+    0)
+
+#  define OCCA_ARG_COUNT2(                          \
+  KERNEL,                                           \
+  _1, _2, _3, _4, _5, _6, _7, _8, _9, _10,          \
+  _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
+  _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \
+  _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
+  _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, \
+  N,  ...) N
+
+#endif // OCCA_DISABLE_VARIADIC_MACROS
+
 #endif

--- a/include/occa/defines/macros.hpp
+++ b/include/occa/defines/macros.hpp
@@ -7,9 +7,6 @@
 #  define __PRETTY_FUNCTION__ __FUNCTION__
 #endif
 
-#define OCCA_STRINGIFY2(macro) #macro
-#define OCCA_STRINGIFY(macro) OCCA_STRINGIFY2(macro)
-
 #ifdef __cplusplus
 #  define OCCA_START_EXTERN_C extern "C" {
 #  define OCCA_END_EXTERN_C   }
@@ -37,7 +34,6 @@
     0)
 
 #  define OCCA_ARG_COUNT2(                          \
-  KERNEL,                                           \
   _1, _2, _3, _4, _5, _6, _7, _8, _9, _10,          \
   _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
   _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \

--- a/include/occa/defines/okl.hpp
+++ b/include/occa/defines/okl.hpp
@@ -5,7 +5,13 @@
 
 #define OCCA_INLINED_KERNEL_NAME "_occa_inlinedKernel"
 
-#define OCCA_JIT(OCCA_PROPS, OKL_ARGS, OKL_SOURCE)        \
+#define OCCA_JIT(...) \
+  OCCA_JIT_ ## OCCA_ARG_COUNT(__VA_ARGS__) (__VA_ARGS__)
+
+#define OCCA_JIT_2(OKL_ARGS, OKL_SOURCE)        \
+  OCCA_JIT_3(occa::properties(), OKL_ARGS, OKL_SOURCE)
+
+#define OCCA_JIT_3(OCCA_PROPS, OKL_ARGS, OKL_SOURCE)      \
   do {                                                    \
     static occa::kernelBuilder _inlinedKernelBuilder = (  \
       occa::kernelBuilder::fromString(                    \

--- a/include/occa/defines/okl.hpp
+++ b/include/occa/defines/okl.hpp
@@ -1,12 +1,10 @@
+// Just in case someone wants to run with an older format than C99
 #ifndef OCCA_DISABLE_VARIADIC_MACROS
 #  ifndef OCCA_DEFINES_OKL_HEADER
 #  define OCCA_DEFINES_OKL_HEADER
 
 
 #define OCCA_INLINED_KERNEL_NAME "_occa_inlinedKernel"
-
-#define OCCA_JIT(...) \
-  OCCA_JIT_ ## OCCA_ARG_COUNT(__VA_ARGS__) (__VA_ARGS__)
 
 #define OCCA_JIT_2(OKL_ARGS, OKL_SOURCE)        \
   OCCA_JIT_3(occa::properties(), OKL_ARGS, OKL_SOURCE)
@@ -30,6 +28,18 @@
     );                                                    \
     _inlinedKernel OKL_ARGS;                              \
   } while (false)
+
+#define OCCA_JIT(...)                                 \
+  EXPAND_OCCA_JIT(OCCA_ARG_COUNT(__VA_ARGS__), __VA_ARGS__)
+
+#define EXPAND_OCCA_JIT(ARG_COUNT_FUNC, ...)      \
+  EXPAND_OCCA_JIT_2(ARG_COUNT_FUNC, __VA_ARGS__)
+
+#define EXPAND_OCCA_JIT_2(ARG_COUNT, ...)                 \
+  EXPAND_OCCA_JIT_3(OCCA_JIT_ ## ARG_COUNT, __VA_ARGS__)
+
+#define EXPAND_OCCA_JIT_3(OCCA_JIT_MACRO, ...)  \
+  OCCA_JIT_MACRO (__VA_ARGS__)
 
 
 #define OCCA_JIT_WITH_SCOPE(OKL_SCOPE, OKL_SOURCE)                    \

--- a/include/occa/lang/stream.tpp
+++ b/include/occa/lang/stream.tpp
@@ -12,7 +12,7 @@ namespace occa {
     template <class output_t>
     void* baseStream<output_t>::getInput(const std::string &name) {
       occa::properties props;
-      props["inputName"] = name;
+      props["input_name"] = name;
       return passMessageToInput(props);
     }
 

--- a/include/occa/tools/env.hpp
+++ b/include/occa/tools/env.hpp
@@ -41,8 +41,10 @@ namespace occa {
 
       void initSettings();
       void initEnvironment();
-      void initCachePath();
-      void initIncludePath();
+      void loadConfig();
+
+      void setupCachePath();
+      void setupIncludePath();
       void registerFileOpeners();
 
       void cleanFileOpeners();

--- a/include/occa/tools/json.hpp
+++ b/include/occa/tools/json.hpp
@@ -256,6 +256,7 @@ namespace occa {
     void loadTrue(const char *&c);
     void loadFalse(const char *&c);
     void loadNull(const char *&c);
+    void loadComment(const char *&c);
 
     json operator + (const json &j) const;
     json& operator += (const json &j);

--- a/include/occa/tools/properties.hpp
+++ b/include/occa/tools/properties.hpp
@@ -31,6 +31,22 @@ namespace occa {
     return sum;
   }
 
+  inline properties operator + (const properties &left, const json &right) {
+    properties sum = left;
+    sum.mergeWithObject(right.value_.object);
+    return sum;
+  }
+
+  inline properties& operator += (properties &left, const properties &right) {
+    left.mergeWithObject(right.value_.object);
+    return left;
+  }
+
+  inline properties& operator += (properties &left, const json &right) {
+    left.mergeWithObject(right.value_.object);
+    return left;
+  }
+
   template <>
   hash_t hash(const properties &props);
 }

--- a/src/c/device.cpp
+++ b/src/c/device.cpp
@@ -37,17 +37,22 @@ const char* OCCA_RFUNC occaDeviceMode(occaDevice device) {
 }
 
 occaProperties OCCA_RFUNC occaDeviceGetProperties(occaDevice device) {
-  occa::properties &props = occa::c::device(device).properties();
+  const occa::properties &props = occa::c::device(device).properties();
   return occa::c::newOccaType(props, false);
 }
 
 occaProperties OCCA_RFUNC occaDeviceGetKernelProperties(occaDevice device) {
-  occa::properties &props = occa::c::device(device).kernelProperties();
+  const occa::properties &props = occa::c::device(device).kernelProperties();
   return occa::c::newOccaType(props, false);
 }
 
 occaProperties OCCA_RFUNC occaDeviceGetMemoryProperties(occaDevice device) {
-  occa::properties &props = occa::c::device(device).memoryProperties();
+  const occa::properties &props = occa::c::device(device).memoryProperties();
+  return occa::c::newOccaType(props, false);
+}
+
+occaProperties OCCA_RFUNC occaDeviceGetStreamProperties(occaDevice device) {
+  const occa::properties &props = occa::c::device(device).streamProperties();
   return occa::c::newOccaType(props, false);
 }
 

--- a/src/io/lock.cpp
+++ b/src/io/lock.cpp
@@ -35,10 +35,10 @@ namespace occa {
       lockDir += tag;
 
       occa::json &lockSettings = settings()["locks"];
-      staleWarning = lockSettings.get("stale-warning",
+      staleWarning = lockSettings.get("stale_warning",
                                       (float) 10.0);
       if (staleAge <= 0) {
-        staleAge = lockSettings.get("stale-age",
+        staleAge = lockSettings.get("stale_age",
                                     (float) 20.0);
       }
     }

--- a/src/lang/modes/opencl.cpp
+++ b/src/lang/modes/opencl.cpp
@@ -18,10 +18,10 @@ namespace occa {
 
         okl::addAttributes(*this);
 
-        if (!settings.has("options/restrict")) {
-          settings["options/restrict"] = "restrict";
+        if (!settings.has("okl/restrict")) {
+          settings["okl/restrict"] = "restrict";
         }
-        settings["opencl/extensions/cl_khr_fp64"] = true;
+        settings["extensions/cl_khr_fp64"] = true;
       }
 
       void openclParser::onClear() {
@@ -74,11 +74,11 @@ namespace occa {
       }
 
       void openclParser::addExtensions() {
-        if (!settings.has("opencl/extensions")) {
+        if (!settings.has("extensions")) {
           return;
         }
 
-        occa::json &extensions = settings["opencl/extensions"];
+        occa::json &extensions = settings["extensions"];
         if (!extensions.isObject()) {
           return;
         }

--- a/src/lang/modes/serial.cpp
+++ b/src/lang/modes/serial.cpp
@@ -30,7 +30,7 @@ namespace occa {
 
       void serialParser::setupHeaders() {
         strVector headers;
-        const bool includingStd = settings.get("serial/include-std", true);
+        const bool includingStd = settings.get("serial/include_std", true);
         headers.push_back("include <occa.hpp>\n");
         if (includingStd) {
           headers.push_back("include <stdint.h>");

--- a/src/lang/parser.cpp
+++ b/src/lang/parser.cpp
@@ -244,7 +244,7 @@ namespace occa {
 
       // Setup @restrict
       const std::string restrictStr = (
-        settings.get<std::string>("options/restrict",
+        settings.get<std::string>("okl/restrict",
                                   "__restrict__")
       );
 

--- a/src/lang/preprocessor.cpp
+++ b/src/lang/preprocessor.cpp
@@ -27,10 +27,10 @@ namespace occa {
     preprocessor_t::preprocessor_t(const occa::properties &settings_) {
       init();
       initDirectives();
-      if (!settings_.has("include_paths")) {
+      if (!settings_.has("okl/include_paths")) {
         return;
       }
-      json paths = settings_["include_paths"];
+      json paths = settings_["okl/include_paths"];
       if (!paths.isArray()) {
         return;
       }
@@ -214,7 +214,7 @@ namespace occa {
     }
 
     void* preprocessor_t::passMessageToInput(const occa::properties &props) {
-      const std::string inputName = props.get<std::string>("inputName");
+      const std::string inputName = props.get<std::string>("input_name");
       if (inputName == "preprocessor_t") {
         return (void*) this;
       }

--- a/src/lang/tokenizer.cpp
+++ b/src/lang/tokenizer.cpp
@@ -133,7 +133,7 @@ namespace occa {
     }
 
     void* tokenizer_t::passMessageToInput(const occa::properties &props) {
-      const std::string inputName = props.get<std::string>("inputName");
+      const std::string inputName = props.get<std::string>("input_name");
       if (inputName == "tokenizer_t") {
         return (void*) this;
       }

--- a/src/modes/cuda/device.cpp
+++ b/src/modes/cuda/device.cpp
@@ -34,32 +34,33 @@ namespace occa {
 
       p2pEnabled = false;
 
+      occa::json &kernelProps = properties["kernel"];
       std::string compiler, compilerFlags;
 
-      if (properties.get<std::string>("kernel/compiler").size()) {
-        compiler = (std::string) properties["kernel/compiler"];
+      if (kernelProps.get<std::string>("compiler").size()) {
+        compiler = (std::string) kernelProps["compiler"];
       } else if (env::var("OCCA_CUDA_COMPILER").size()) {
         compiler = env::var("OCCA_CUDA_COMPILER");
       } else {
         compiler = "nvcc";
       }
 
-      if (properties.get<std::string>("kernel/compiler_flags").size()) {
-        compilerFlags = (std::string) properties["kernel/compiler_flags"];
+      if (kernelProps.get<std::string>("compiler_flags").size()) {
+        compilerFlags = (std::string) kernelProps["compiler_flags"];
       } else {
         compilerFlags = "-O3";
       }
 
-      properties["kernel/compiler"] = compiler;
-      properties["kernel/compiler_flags"] = compilerFlags;
+      kernelProps["compiler"] = compiler;
+      kernelProps["compiler_flags"] = compilerFlags;
 
       OCCA_CUDA_ERROR("Device: Getting CUDA Device Arch",
                       cuDeviceComputeCapability(&archMajorVersion,
                                                 &archMinorVersion,
                                                 cuDevice) );
 
-      archMajorVersion = properties.get("cuda/arch/major", archMajorVersion);
-      archMinorVersion = properties.get("cuda/arch/minor", archMinorVersion);
+      archMajorVersion = kernelProps.get("arch/major", archMajorVersion);
+      archMinorVersion = kernelProps.get("arch/minor", archMinorVersion);
     }
 
     device::~device() {
@@ -445,7 +446,7 @@ namespace occa {
 #if CUDA_VERSION >= 8000
       mem.isUnified = true;
 
-      const unsigned int flags = (props.get("cuda/attachedHost", false) ?
+      const unsigned int flags = (props.get("attached_host", false) ?
                                   CU_MEM_ATTACH_HOST : CU_MEM_ATTACH_GLOBAL);
 
       OCCA_CUDA_ERROR("Device: Setting Context",

--- a/src/modes/cuda/utils.cpp
+++ b/src/modes/cuda/utils.cpp
@@ -205,7 +205,7 @@ namespace occa {
 
       occa::properties allProps;
       allProps["mode"]     = "CUDA";
-      allProps["deviceID"] = -1;
+      allProps["device_id"] = -1;
       allProps["wrapped"]  = true;
       allProps += props;
 

--- a/src/modes/hip/device.cpp
+++ b/src/modes/hip/device.cpp
@@ -40,34 +40,35 @@ namespace occa {
 
       p2pEnabled = false;
 
+      occa::json &kernelProps = properties["kernel"];
       std::string compiler, compilerFlags;
 
-      if (properties.get<std::string>("kernel/compiler").size()) {
-        compiler = (std::string) properties["kernel/compiler"];
+      if (kernelProps.get<std::string>("compiler").size()) {
+        compiler = (std::string) kernelProps["compiler"];
       } else if (env::var("OCCA_HIP_COMPILER").size()) {
         compiler = env::var("OCCA_HIP_COMPILER");
       } else {
         compiler = "hipcc";
       }
 
-      if (properties.get<std::string>("kernel/compiler_flags").size()) {
-        compilerFlags = (std::string) properties["kernel/compiler_flags"];
+      if (kernelProps.get<std::string>("compiler_flags").size()) {
+        compilerFlags = (std::string) kernelProps["compiler_flags"];
       } else {
         compilerFlags = "-O3";
       }
 
-      properties["kernel/compiler"]      = compiler;
-      properties["kernel/compilerFlags"] = compilerFlags;
+      kernelProps["compiler"]      = compiler;
+      kernelProps["compilerFlags"] = compilerFlags;
 
       OCCA_HIP_ERROR("Device: Getting HIP Device Arch",
                      hipDeviceComputeCapability(&archMajorVersion,
                                                 &archMinorVersion,
                                                 hipDevice) );
 
-      archMajorVersion = properties.get("hip/arch/major", archMajorVersion);
-      archMinorVersion = properties.get("hip/arch/minor", archMinorVersion);
+      archMajorVersion = kernelProps.get("arch/major", archMajorVersion);
+      archMinorVersion = kernelProps.get("arch/minor", archMinorVersion);
 
-      properties["kernel/target"] = toString(props.gcnArch);
+      kernelProps["target"] = toString(props.gcnArch);
     }
 
     device::~device() { }

--- a/src/modes/metal/device.cpp
+++ b/src/modes/metal/device.cpp
@@ -19,15 +19,16 @@ namespace occa {
                  properties.has("device_id") &&
                  properties["device_id"].isNumber());
 
+      occa::json &kernelProps = properties["kernel"];
       std::string compilerFlags;
 
-      if (properties.get<std::string>("kernel/compiler_flags").size()) {
-        compilerFlags = (std::string) properties["kernel/compiler_flags"];
+      if (kernelProps.get<std::string>("compiler_flags").size()) {
+        compilerFlags = (std::string) kernelProps["compiler_flags"];
       } else {
         compilerFlags = "-O3";
       }
 
-      properties["kernel/compiler_flags"] = compilerFlags;
+      kernelProps["compiler_flags"] = compilerFlags;
 
       deviceID = properties.get<int>("device_id");
 

--- a/src/modes/opencl/device.cpp
+++ b/src/modes/opencl/device.cpp
@@ -37,16 +37,17 @@ namespace occa {
         OCCA_OPENCL_ERROR("Device: Creating Context", error);
       }
 
+      occa::json &kernelProps = properties["kernel"];
       std::string compilerFlags;
 
       // Use "-cl-opt-disable" for debug-mode
-      if (properties.has("kernel/compiler_flags")) {
-        compilerFlags = (std::string) properties["kernel/compiler_flags"];
+      if (kernelProps.has("compiler_flags")) {
+        compilerFlags = (std::string) kernelProps["compiler_flags"];
       } else if (env::var("OCCA_OPENCL_COMPILER_FLAGS").size()) {
         compilerFlags = env::var("OCCA_OPENCL_COMPILER_FLAGS");
       }
 
-      properties["kernel/compiler_flags"] = compilerFlags;
+      kernelProps["compiler_flags"] = compilerFlags;
     }
 
     device::~device() {

--- a/src/modes/serial/device.cpp
+++ b/src/modes/serial/device.cpp
@@ -14,11 +14,12 @@ namespace occa {
     device::device(const occa::properties &properties_) :
       occa::modeDevice_t(properties_) {
 
-      int vendor;
+      occa::json &kernelProps = properties["kernel"];
       std::string compiler, compilerFlags, compilerEnvScript;
+      int vendor;
 
-      if (properties.get<std::string>("kernel/compiler").size()) {
-        compiler = (std::string) properties["kernel/compiler"];
+      if (kernelProps.get<std::string>("compiler").size()) {
+        compiler = (std::string) kernelProps["compiler"];
       } else if (env::var("OCCA_CXX").size()) {
         compiler = env::var("OCCA_CXX");
       } else if (env::var("CXX").size()) {
@@ -33,8 +34,8 @@ namespace occa {
 
       vendor = sys::compilerVendor(compiler);
 
-      if (properties.get<std::string>("kernel/compiler_flags").size()) {
-        compilerFlags = (std::string) properties["kernel/compiler_flags"];
+      if (kernelProps.get<std::string>("compiler_flags").size()) {
+        compilerFlags = (std::string) kernelProps["compiler_flags"];
       } else if (env::var("OCCA_CXXFLAGS").size()) {
         compilerFlags = env::var("OCCA_CXXFLAGS");
       } else if (env::var("CXXFLAGS").size()) {
@@ -47,8 +48,8 @@ namespace occa {
 #endif
       }
 
-      if (properties.get<std::string>("kernel/compiler_env_script").size()) {
-        compilerEnvScript = (std::string) properties["kernel/compiler_env_script"];
+      if (kernelProps.get<std::string>("compiler_env_script").size()) {
+        compilerEnvScript = (std::string) kernelProps["compiler_env_script"];
       } else {
 #if (OCCA_OS == OCCA_WINDOWS_OS)
         std::string byteness;
@@ -79,10 +80,10 @@ namespace occa {
 #endif
       }
 
-      properties["kernel/vendor"] = vendor;
-      properties["kernel/compiler"] = compiler;
-      properties["kernel/compiler_flags"] = compilerFlags;
-      properties["kernel/compiler_env_script"] = compilerEnvScript;
+      kernelProps["vendor"] = vendor;
+      kernelProps["compiler"] = compiler;
+      kernelProps["compiler_flags"] = compilerFlags;
+      kernelProps["compiler_env_script"] = compilerEnvScript;
     }
 
     device::~device() {}

--- a/src/tools/json.cpp
+++ b/src/tools/json.cpp
@@ -33,19 +33,20 @@ namespace occa {
     clear();
     lex::skipWhitespace(c);
     switch (*c) {
-    case '0': case '1': case '2': case '3': case '4':
-    case '5': case '6': case '7': case '8': case '9':
-    case '-': loadNumber(c); break;
-    case '{': loadObject(c); break;
-    case '[': loadArray(c);  break;
-    case '\'':
-    case '"': loadString(c); break;
-    case 't': loadTrue(c);   break;
-    case 'f': loadFalse(c);  break;
-    case 'n': loadNull(c);   break;
-    default: {
-      OCCA_FORCE_ERROR("Cannot load JSON: " << c);
-    }}
+      case '0': case '1': case '2': case '3': case '4':
+      case '5': case '6': case '7': case '8': case '9':
+      case '-': loadNumber(c);  break;
+      case '{': loadObject(c);  break;
+      case '[': loadArray(c);   break;
+      case '\'':
+      case '"': loadString(c);  break;
+      case 't': loadTrue(c);    break;
+      case 'f': loadFalse(c);   break;
+      case 'n': loadNull(c);    break;
+      case '/': loadComment(c); break;
+      default: {
+        OCCA_FORCE_ERROR("Cannot load JSON: " << c);
+      }}
     return *this;
   }
 
@@ -369,6 +370,12 @@ namespace occa {
     type = null_;
   }
 
+  void json::loadComment(const char *&c) {
+    OCCA_ERROR("Cannot read value: " << c,
+               !strncmp(c, "//", 2));
+    lex::skipTo(c, '\n', '\\');
+  }
+
   json json::operator + (const json &j) const {
     json sum = *this;
     sum += j;
@@ -376,6 +383,11 @@ namespace occa {
   }
 
   json& json::operator += (const json &j) {
+    // Nothing to add
+    if (j.type == none_) {
+      return *this;
+    }
+
     // We're not defined, treat this as an = operator
     if (type == none_) {
       type = j.type;

--- a/src/tools/sys.cpp
+++ b/src/tools/sys.cpp
@@ -261,9 +261,9 @@ namespace occa {
       }
 
       // Make sure we're not deleting /
-      if (settings().get("options/safe-rmrf", true)) {
+      if (settings().get("sys/safe_rmrf", true)) {
         OCCA_ERROR("For safety, not deleting [" << filename << "]."
-                   " To disable this error, set 'options/safe-rmrf' settings to false",
+                   " To disable this error, set 'sys/safe_rmrf' settings to false",
                    isSafeToRmrf(filename));
       }
       rmdir(filename, true);

--- a/tests/src/core/device.cpp
+++ b/tests/src/core/device.cpp
@@ -1,0 +1,99 @@
+#include <occa.hpp>
+#include <occa/tools/testing.hpp>
+
+void testProperties();
+
+int main(const int argc, const char **argv) {
+  testProperties();
+
+  return 0;
+}
+
+void testProperties() {
+  occa::device device;
+
+  device.setup(
+    "mode: 'Serial'"
+  );
+  ASSERT_EQ(
+    "Serial",
+    (std::string) device.properties()["mode"]
+  );
+
+  device.setup(
+    "mode: 'Serial',"
+    "one: 1"
+  );
+  ASSERT_EQ(
+    1,
+    (int) device.properties()["one"]
+  );
+
+  // Object and mode overrides
+  device.setup(
+    "mode: 'Serial'"
+  );
+  ASSERT_EQ(
+    "Serial",
+    (std::string) device.kernelProperties()["mode"]
+  );
+
+  device.setup(
+    "mode: 'Serial',"
+    "kernel: {"
+    "  one: 1,"
+    "}"
+  );
+  ASSERT_EQ(
+    1,
+    (int) device.kernelProperties()["one"]
+  );
+
+  device.setup(
+    "mode: 'Serial',"
+    "one: 2,"
+    "kernel: {"
+    "  one: 1,"
+    "}"
+  );
+  ASSERT_EQ(
+    1,
+    (int) device.kernelProperties()["one"]
+  );
+
+  device.setup(
+    "mode: 'Serial',"
+    "one: 3,"
+    "kernel: {"
+    "  one: 2,"
+    "  modes: {"
+    "    Serial: {"
+    "      one: 1,"
+    "    },"
+    "  },"
+    "}"
+  );
+  ASSERT_EQ(
+    1,
+    (int) device.kernelProperties()["one"]
+  );
+
+  device.setup(
+    "mode: 'Serial',"
+    "one: 3,"
+    "kernel: {"
+    "  one: 2,"
+    "},"
+    "modes: {"
+    "  Serial: {"
+    "    kernel: {"
+    "      one: 1,"
+    "    },"
+    "  },"
+    "}"
+  );
+  ASSERT_EQ(
+    1,
+    (int) device.kernelProperties()["one"]
+  );
+}

--- a/tests/src/lang/mode/opencl.cpp
+++ b/tests/src/lang/mode/opencl.cpp
@@ -56,13 +56,13 @@ void testPragma() {
             ->to<pragmaStatement>()
             .value());
 
-  parser.settings["opencl/extensions/cl_khr_fp64"] = false;
+  parser.settings["extensions/cl_khr_fp64"] = false;
   parseSource("");
   ASSERT_EQ(0,
             parser.root.size());
 
 
-  parser.settings["opencl/extensions/foobar"] = true;
+  parser.settings["extensions/foobar"] = true;
   parseSource("");
   ASSERT_EQ(1,
             parser.root.size());
@@ -72,8 +72,8 @@ void testPragma() {
             ->to<pragmaStatement>()
             .value());
 
-  parser.settings["opencl/extensions/foobar"] = false;
-  parser.settings["opencl/extensions/cl_khr_fp64"] = true;
+  parser.settings["extensions/foobar"] = false;
+  parser.settings["extensions/cl_khr_fp64"] = true;
 }
 //======================================
 

--- a/tests/src/lang/mode/openmp.cpp
+++ b/tests/src/lang/mode/openmp.cpp
@@ -7,7 +7,7 @@ void testPragma();
 
 int main(const int argc, const char **argv) {
   parser.settings["okl/validate"] = false;
-  parser.settings["serial/include-std"] = false;
+  parser.settings["serial/include_std"] = false;
 
   // testPragma();
 

--- a/tests/src/lang/mode/serial.cpp
+++ b/tests/src/lang/mode/serial.cpp
@@ -8,7 +8,7 @@ void testKernel();
 void testExclusives();
 
 int main(const int argc, const char **argv) {
-  parser.settings["serial/include-std"] = false;
+  parser.settings["serial/include_std"] = false;
 
   // parser.settings["okl/validate"] = false;
   // testPreprocessor();

--- a/tests/src/lang/stream.cpp
+++ b/tests/src/lang/stream.cpp
@@ -27,7 +27,7 @@ public:
   }
 
   virtual void* passMessageToInput(const occa::properties &props) {
-    const std::string inputName = props.get<std::string>("inputName");
+    const std::string inputName = props.get<std::string>("input_name");
     if (inputName == "vectorStream") {
       return (void*) this;
     }
@@ -132,11 +132,11 @@ int main(const int argc, const char **argv) {
 
   // Test passMessage
   ASSERT_EQ((void*) NULL,
-            sDouble.passMessageToInput("inputName: 'test'"));
+            sDouble.passMessageToInput("input_name: 'test'"));
   ASSERT_EQ((void*) NULL,
             sDouble.getInput("test"));
 
-  vectorStream<int> *vs = (vectorStream<int>*) sDouble.passMessageToInput("inputName: 'vectorStream'");
+  vectorStream<int> *vs = (vectorStream<int>*) sDouble.passMessageToInput("input_name: 'vectorStream'");
   ASSERT_NEQ((void*) NULL,
              (void*) vs);
   ASSERT_EQ(4, (int) vs->values.size());

--- a/tests/src/tools/sys.cpp
+++ b/tests/src/tools/sys.cpp
@@ -53,6 +53,6 @@ void testRmrf() {
     occa::sys::rmrf(filename);
   );
 
-  occa::settings()["options/safe-rmrf"] = false;
+  occa::settings()["sys/safe_rmrf"] = false;
   occa::sys::rmrf(filename);
 }


### PR DESCRIPTION
### Description

- Adds the ability to store a `config.json` for defaults. Nice for development to avoid having to set environment variables
- Properly solves #131 
- Adds a `config.default.json` to explain what defaults we use
- Fixes some non-standard properties, such as `options/safe-rmrf` -> `sys/safe_rmrf`