### PR TITLE
[Kernel] Adds occa::null

### DIFF
--- a/include/occa/core/kernelArg.hpp
+++ b/include/occa/core/kernelArg.hpp
@@ -17,7 +17,15 @@ namespace occa {
   namespace kArgInfo {
     static const char none       = 0;
     static const char usePointer = (1 << 0);
+    static const char isNull     = (1 << 1);
   }
+
+  class null_t {
+   public:
+    inline null_t() {}
+  };
+
+  extern const null_t null;
 
   union kernelArgData_t {
     uint8_t  uint8_;
@@ -54,6 +62,8 @@ namespace occa {
 
     void* ptr() const;
 
+    bool isNull() const;
+
     void setupForKernelCall(const bool isConst) const;
   };
 
@@ -66,6 +76,8 @@ namespace occa {
     kernelArg(const kernelArgData &arg);
     kernelArg(const kernelArg &other);
     kernelArg& operator = (const kernelArg &other);
+
+    kernelArg(const null_t arg);
 
     kernelArg(const uint8_t arg);
     kernelArg(const uint16_t arg);

--- a/src/core/kernel.cpp
+++ b/src/core/kernel.cpp
@@ -107,7 +107,8 @@ namespace occa {
         lang::argMetadata_t &argInfo = metadata.arguments[i];
 
         modeMemory_t *mem = arg.getModeMemory();
-        bool isPtr = (bool) mem;
+        const bool isNull = arg.isNull();
+        const bool isPtr = mem || isNull;
         if (isPtr != argInfo.isPtr) {
           if (argInfo.isPtr) {
             OCCA_FORCE_ERROR("(" << name << ") Kernel expects an occa::memory for argument ["
@@ -118,7 +119,7 @@ namespace occa {
           }
         }
 
-        if (!isPtr) {
+        if (!isPtr || isNull) {
           continue;
         }
 

--- a/src/core/kernelArg.cpp
+++ b/src/core/kernelArg.cpp
@@ -5,6 +5,8 @@
 
 namespace occa {
   //---[ KernelArg ]--------------------
+  const null_t null;
+
   kernelArgData::kernelArgData() :
     modeMemory(NULL),
     size(0),
@@ -43,6 +45,10 @@ namespace occa {
 
   void* kernelArgData::ptr() const {
     return ((info & kArgInfo::usePointer) ? data.void_ : (void*) &data);
+  }
+
+  bool kernelArgData::isNull() const {
+    return (info & kArgInfo::isNull);
   }
 
   void kernelArgData::setupForKernelCall(const bool isConst) const {
@@ -105,6 +111,17 @@ namespace occa {
 
   const kernelArgData& kernelArg::operator [] (const int index) const {
     return args[index];
+  }
+
+  kernelArg::kernelArg(const null_t arg) {
+    kernelArgData kArg;
+    kArg.data.void_ = NULL;
+    kArg.size       = sizeof(void*);
+    kArg.info       = (
+      kArgInfo::usePointer
+      | kArgInfo::isNull
+    );
+    args.push_back(kArg);
   }
 
   kernelArg::kernelArg(const uint8_t arg) {

--- a/tests/files/argKernel.okl
+++ b/tests/files/argKernel.okl
@@ -1,5 +1,6 @@
 @kernel void argKernel(char *mem,
                        char *uvaPtr,
+                       void *null,
                        int i8,
                        int u8,
                        int i16,
@@ -16,6 +17,7 @@
     printf(
       "mem: %d\n"
       "uvaPtr: %d\n"
+      "null: %p\n"
       "i8: %d\n"
       "u8: %d\n"
       "i16: %d\n"
@@ -30,6 +32,7 @@
       "str: %s\n",
       mem[0],
       uvaPtr[0],
+      null,
       (int) i8,
       (int) u8,
       (int) i16,
@@ -43,5 +46,8 @@
       xy[0], xy[1],
       str
     );
+    if (null != NULL) {
+      throw 1;
+    }
   }
 }

--- a/tests/src/core/kernel.cpp
+++ b/tests/src/core/kernel.cpp
@@ -163,6 +163,7 @@ void testRun() {
   argKernel(
     mem,
     uvaPtr,
+    occa::null,
     (int8_t) 2,
     (uint8_t) 3,
     (int16_t) 4,


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description

#235 `occa::null` can be passed to kernels as a way to omit an `occa::memory` argument