### PR TITLE
[Preprocessor] Fixes loading @ directive inside #if/#else statements

### DIFF
--- a/include/occa/lang/preprocessor.hpp
+++ b/include/occa/lang/preprocessor.hpp
@@ -129,6 +129,11 @@ namespace occa {
       void removeNewline(tokenVector &lineTokens);
 
       void processToken(token_t *token);
+
+      bool canProcessWhileIgnoring(token_t *token);
+      bool processingDirectiveAttribute(operatorToken &opToken,
+                                        token_t *&directiveToken);
+
       void processIdentifier(identifierToken &token);
 
       void processOperator(operatorToken &opToken);


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description

The following was failing since the first `@directive` set the reading status to `ignore`, avoiding reading following `@directive` to stop the `#if`

```cpp
@directive("#if true")
// ...
@directive("#else")
// ...
@directive("#endif")
```