### PR TITLE
[OCCA] Uninitialized memory passed as null

### DIFF
--- a/include/occa/core/kernelArg.hpp
+++ b/include/occa/core/kernelArg.hpp
@@ -20,12 +20,12 @@ namespace occa {
     static const char isNull     = (1 << 1);
   }
 
-  class null_t {
+  class nullKernelArg_t {
    public:
-    inline null_t() {}
+    inline nullKernelArg_t() {}
   };
 
-  extern const null_t null;
+  extern const nullKernelArg_t nullKernelArg;
 
   union kernelArgData_t {
     uint8_t  uint8_;
@@ -77,7 +77,7 @@ namespace occa {
     kernelArg(const kernelArg &other);
     kernelArg& operator = (const kernelArg &other);
 
-    kernelArg(const null_t arg);
+    kernelArg(const nullKernelArg_t arg);
 
     kernelArg(const uint8_t arg);
     kernelArg(const uint16_t arg);

--- a/include/occa/core/memory.hpp
+++ b/include/occa/core/memory.hpp
@@ -104,6 +104,7 @@ namespace occa {
   };
   //====================================
 
+
   //---[ memory ]-----------------------
   class memory : public gc::ringEntry_t {
     friend class occa::modeMemory_t;
@@ -238,6 +239,8 @@ namespace occa {
     void detach();
     void deleteRefs(const bool freeMemory = false);
   };
+
+  extern memory null;
   //====================================
 
   std::ostream& operator << (std::ostream &out,

--- a/src/core/kernelArg.cpp
+++ b/src/core/kernelArg.cpp
@@ -5,7 +5,7 @@
 
 namespace occa {
   //---[ KernelArg ]--------------------
-  const null_t null;
+  const nullKernelArg_t nullKernelArg;
 
   kernelArgData::kernelArgData() :
     modeMemory(NULL),
@@ -113,7 +113,7 @@ namespace occa {
     return args[index];
   }
 
-  kernelArg::kernelArg(const null_t arg) {
+  kernelArg::kernelArg(const nullKernelArg_t arg) {
     kernelArgData kArg;
     kArg.data.void_ = NULL;
     kArg.size       = sizeof(void*);
@@ -221,7 +221,7 @@ namespace occa {
 
     if (modeMemory) {
       add(modeMemory->makeKernelArg());
-    } else {
+    } else if (arg != NULL) {
       kernelArgData kArg;
       kArg.data.void_ = arg;
       kArg.size       = bytes;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -67,13 +67,15 @@ namespace occa {
   bool modeMemory_t::isStale() const {
     return (memInfo & uvaFlag::isStale);
   }
+  //====================================
+
 
   //---[ memory ]-----------------------
   memory::memory() :
-    modeMemory(NULL) {}
+      modeMemory(NULL) {}
 
   memory::memory(void *uvaPtr) :
-    modeMemory(NULL) {
+      modeMemory(NULL) {
     ptrRangeMap::iterator it = uvaMap.find(uvaPtr);
     if (it != uvaMap.end()) {
       setModeMemory(it->second);
@@ -83,7 +85,7 @@ namespace occa {
   }
 
   memory::memory(modeMemory_t *modeMemory_) :
-    modeMemory(NULL) {
+      modeMemory(NULL) {
     setModeMemory(modeMemory_);
   }
 
@@ -187,9 +189,9 @@ namespace occa {
 
   memory::operator kernelArg() const {
     if (modeMemory) {
-      return modeMemory->makeKernelArg();
+        return modeMemory->makeKernelArg();
     }
-    return kernelArg((void*) NULL);
+    return nullKernelArg;
   }
 
   const std::string& memory::mode() const {
@@ -586,6 +588,9 @@ namespace occa {
     delete modeMemory;
     modeMemory = NULL;
   }
+
+  memory null;
+  //====================================
 
   std::ostream& operator << (std::ostream &out,
                              const occa::memory &memory) {


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description

`occa::null` is of type `occa::memory` to avoid casting issues. Same as uninitialized `occa::memory` objects, but more descriptive in its use.