### PR TITLE
[Core] Fix memory reference double-free with slices

### DIFF
--- a/src/modes/cuda/memory.cpp
+++ b/src/modes/cuda/memory.cpp
@@ -13,21 +13,16 @@ namespace occa {
       isUnified(false) {}
 
     memory::~memory() {
-      if (!isOrigin) {
-        cuPtr = 0;
-        mappedPtr = NULL;
-        size = 0;
-        return;
+      if (isOrigin) {
+        if (mappedPtr) {
+          OCCA_CUDA_ERROR("Device: mappedFree()",
+                          cuMemFreeHost(mappedPtr));
+        } else if (cuPtr) {
+          cuMemFree(cuPtr);
+        }
       }
-
-      if (mappedPtr) {
-        OCCA_CUDA_ERROR("Device: mappedFree()",
-                        cuMemFreeHost(mappedPtr));
-        mappedPtr = NULL;
-      } else if (cuPtr) {
-        cuMemFree(cuPtr);
-        cuPtr = 0;
-      }
+      cuPtr = 0;
+      mappedPtr = NULL;
       size = 0;
     }
 

--- a/src/modes/hip/memory.cpp
+++ b/src/modes/hip/memory.cpp
@@ -20,21 +20,16 @@ namespace occa {
       mappedPtr(NULL) {}
 
     memory::~memory() {
-      if (!isOrigin) {
-        hipPtr = 0;
-        mappedPtr = NULL;
-        size = 0;
-        return;
+      if (isOrigin) {
+        if (mappedPtr) {
+          OCCA_HIP_ERROR("Device: mappedFree()",
+                         hipHostFree(mappedPtr));
+        } else if (hipPtr) {
+          hipFree((void*) hipPtr);
+        }
       }
-
-      if (mappedPtr) {
-        OCCA_HIP_ERROR("Device: mappedFree()",
-                       hipHostFree(mappedPtr));
-        mappedPtr = NULL;
-      } else if (hipPtr) {
-        hipFree((void*) hipPtr);
-        hipPtr = 0;
-      }
+      hipPtr = 0;
+      mappedPtr = NULL;
       size = 0;
     }
 

--- a/src/modes/metal/memory.cpp
+++ b/src/modes/metal/memory.cpp
@@ -11,7 +11,10 @@ namespace occa {
         bufferOffset(0) {}
 
     memory::~memory() {
-      metalBuffer.free();
+      if (isOrigin) {
+        metalBuffer.free();
+      }
+      size = 0;
     }
 
     kernelArg memory::makeKernelArg() const {

--- a/src/modes/opencl/memory.cpp
+++ b/src/modes/opencl/memory.cpp
@@ -12,19 +12,23 @@ namespace occa {
       mappedPtr(NULL) {}
 
     memory::~memory() {
-      if (mappedPtr) {
-        OCCA_OPENCL_ERROR("Mapped Free: clEnqueueUnmapMemObject",
-                          clEnqueueUnmapMemObject(getCommandQueue(),
-                                                  clMem,
-                                                  mappedPtr,
-                                                  0, NULL, NULL));
+      if (isOrigin) {
+        if (mappedPtr) {
+          OCCA_OPENCL_ERROR("Mapped Free: clEnqueueUnmapMemObject",
+                            clEnqueueUnmapMemObject(getCommandQueue(),
+                                                    clMem,
+                                                    mappedPtr,
+                                                    0, NULL, NULL));
+        }
+        if (size) {
+          // Free mapped-host pointer
+          OCCA_OPENCL_ERROR("Mapped Free: clReleaseMemObject",
+                            clReleaseMemObject(clMem));
+        }
       }
-      if (size) {
-        // Free mapped-host pointer
-        OCCA_OPENCL_ERROR("Mapped Free: clReleaseMemObject",
-                          clReleaseMemObject(clMem));
-        size = 0;
-      }
+      clMem = NULL;
+      mappedPtr = NULL;
+      size = 0;
     }
 
     cl_command_queue& memory::getCommandQueue() const {

--- a/src/modes/serial/memory.cpp
+++ b/src/modes/serial/memory.cpp
@@ -10,13 +10,11 @@ namespace occa {
       occa::modeMemory_t(modeDevice_, size_, properties_) {}
 
     memory::~memory() {
-      if (ptr) {
-        if (isOrigin) {
-          sys::free(ptr);
-        }
-        ptr = NULL;
-        size = 0;
+      if (ptr && isOrigin) {
+        sys::free(ptr);
       }
+      ptr = NULL;
+      size = 0;
     }
 
     kernelArg memory::makeKernelArg() const {


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description

OpenCL wasn't considering `isOrigin` when reference counting with slices (Thanks @stgeke!)