### PR TITLE
Seperate streamTag creation from queuing 

### DIFF
--- a/include/occa/c/base.h
+++ b/include/occa/c/base.h
@@ -33,7 +33,9 @@ OCCA_LFUNC occaStream OCCA_RFUNC occaGetStream();
 
 OCCA_LFUNC void OCCA_RFUNC occaSetStream(occaStream stream);
 
-OCCA_LFUNC occaStreamTag OCCA_RFUNC occaTagStream();
+OCCA_LFUNC occaStreamTag OCCA_RFUNC occaCreateStreamTag();
+
+OCCA_LFUNC void OCCA_RFUNC occaTagStream(occaStreamTag tag);
 
 OCCA_LFUNC void OCCA_RFUNC occaWaitForTag(occaStreamTag tag);
 

--- a/include/occa/c/device.h
+++ b/include/occa/c/device.h
@@ -38,7 +38,10 @@ OCCA_LFUNC occaStream OCCA_RFUNC occaDeviceGetStream(occaDevice device);
 OCCA_LFUNC void OCCA_RFUNC occaDeviceSetStream(occaDevice device,
                                                occaStream stream);
 
-OCCA_LFUNC occaStreamTag OCCA_RFUNC occaDeviceTagStream(occaDevice device);
+OCCA_LFUNC occaStreamTag OCCA_RFUNC occaDeviceCreateStreamTag(occaDevice device);
+
+OCCA_LFUNC void OCCA_RFUNC occaDeviceTagStream(occaDevice device,
+                                               occaStreamTag tag);
 
 OCCA_LFUNC void OCCA_RFUNC occaDeviceWaitForTag(occaDevice device,
                                                 occaStreamTag tag);

--- a/include/occa/core/base.hpp
+++ b/include/occa/core/base.hpp
@@ -33,6 +33,9 @@ namespace occa {
 
   void finish();
 
+  streamTag createStreamTag();
+  void tagStream(const streamTag &tag);
+
   void waitFor(streamTag tag);
 
   double timeBetween(const streamTag &startTag,
@@ -41,8 +44,6 @@ namespace occa {
   stream createStream(const occa::properties &props = occa::properties());
   stream getStream();
   void setStream(stream s);
-
-  streamTag tagStream();
   //====================================
 
   //---[ Kernel Functions ]-------------

--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -91,7 +91,8 @@ namespace occa {
     //  |---[ Stream ]------------------
     virtual modeStream_t* createStream(const occa::properties &props) = 0;
 
-    virtual streamTag tagStream() = 0;
+    virtual streamTag createStreamTag() = 0;
+    virtual void tagStream(const streamTag &tag) = 0;
     virtual void waitFor(streamTag tag) = 0;
     virtual double timeBetween(const streamTag &startTag,
                                const streamTag &endTag) = 0;
@@ -202,7 +203,8 @@ namespace occa {
     stream getStream();
     void setStream(stream s);
 
-    streamTag tagStream();
+    streamTag createStreamTag();
+    void tagStream(const streamTag &tag);
     void waitFor(streamTag tag);
     double timeBetween(const streamTag &startTag,
                        const streamTag &endTag);

--- a/include/occa/modes/cuda/device.hpp
+++ b/include/occa/modes/cuda/device.hpp
@@ -39,7 +39,8 @@ namespace occa {
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::properties &props);
 
-      virtual streamTag tagStream();
+      virtual streamTag createStreamTag();
+      virtual void tagStream(const streamTag &tag);
       virtual void waitFor(streamTag tag);
       virtual double timeBetween(const streamTag &startTag,
                                  const streamTag &endTag);

--- a/include/occa/modes/hip/device.hpp
+++ b/include/occa/modes/hip/device.hpp
@@ -38,7 +38,8 @@ namespace occa {
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::properties &props);
 
-      virtual streamTag tagStream();
+      virtual streamTag createStreamTag();
+      virtual void tagStream(const streamTag &tag);
       virtual void waitFor(streamTag tag);
       virtual double timeBetween(const streamTag &startTag,
                                  const streamTag &endTag);

--- a/include/occa/modes/metal/device.hpp
+++ b/include/occa/modes/metal/device.hpp
@@ -35,7 +35,8 @@ namespace occa {
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::properties &props);
 
-      virtual streamTag tagStream();
+      virtual streamTag createStreamTag();
+      virtual void tagStream(const streamTag &tag);
       virtual void waitFor(streamTag tag);
       virtual double timeBetween(const streamTag &startTag,
                                  const streamTag &endTag);

--- a/include/occa/modes/opencl/device.hpp
+++ b/include/occa/modes/opencl/device.hpp
@@ -36,7 +36,8 @@ namespace occa {
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::properties &props);
 
-      virtual streamTag tagStream();
+      virtual streamTag createStreamTag();
+      virtual void tagStream(const streamTag &tag);
       virtual void waitFor(streamTag tag);
       virtual double timeBetween(const streamTag &startTag,
                                  const streamTag &endTag);

--- a/include/occa/modes/serial/device.hpp
+++ b/include/occa/modes/serial/device.hpp
@@ -24,7 +24,8 @@ namespace occa {
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::properties &props);
 
-      virtual streamTag tagStream();
+      virtual streamTag createStreamTag();
+      virtual void tagStream(const streamTag &tag);
       virtual void waitFor(streamTag tag);
       virtual double timeBetween(const streamTag &startTag,
                                  const streamTag &endTag);

--- a/src/c/base.cpp
+++ b/src/c/base.cpp
@@ -65,11 +65,15 @@ void OCCA_RFUNC occaSetStream(occaStream stream) {
   occa::setStream(occa::c::stream(stream));
 }
 
-occaStreamTag OCCA_RFUNC occaTagStream() {
-  occa::streamTag tag = occa::tagStream();
+occaStreamTag OCCA_RFUNC occaCreateStreamTag() {
+  occa::streamTag tag = occa::createStreamTag();
   tag.dontUseRefs();
 
   return occa::c::newOccaType(tag);
+}
+
+void OCCA_RFUNC occaTagStream(occaStreamTag tag) {
+  occa::tagStream(occa::c::streamTag(tag));
 }
 
 void OCCA_RFUNC occaWaitForTag(occaStreamTag tag) {

--- a/src/c/device.cpp
+++ b/src/c/device.cpp
@@ -98,12 +98,18 @@ void OCCA_RFUNC occaDeviceSetStream(occaDevice device,
   device_.setStream(occa::c::stream(stream));
 }
 
-occaStreamTag OCCA_RFUNC occaDeviceTagStream(occaDevice device) {
+occaStreamTag OCCA_RFUNC occaDeviceCreateStreamTag(occaDevice device) {
   occa::device device_ = occa::c::device(device);
-  occa::streamTag tag = device_.tagStream();
+  occa::streamTag tag = device_.createStreamTag();
   tag.dontUseRefs();
 
   return occa::c::newOccaType(tag);
+}
+
+void OCCA_RFUNC occaDeviceTagStream(occaDevice device,
+                                    occaStreamTag tag) {
+  occa::device device_ = occa::c::device(device);
+  device_.tagStream(occa::c::streamTag(tag));
 }
 
 void OCCA_RFUNC occaDeviceWaitForTag(occaDevice device,

--- a/src/core/base.cpp
+++ b/src/core/base.cpp
@@ -66,8 +66,12 @@ namespace occa {
     getDevice().setStream(s);
   }
 
-  streamTag tagStream() {
-    return getDevice().tagStream();
+  streamTag createStreamTag() {
+    return getDevice().createStreamTag();
+  }
+
+  void tagStream(const streamTag &tag) {
+    getDevice().tagStream(tag);
   }
 
   //---[ Kernel Functions ]-------------

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -348,9 +348,14 @@ namespace occa {
     modeDevice->currentStream = s;
   }
 
-  streamTag device::tagStream() {
+  streamTag device::createStreamTag() {
     assertInitialized();
-    return modeDevice->tagStream();
+    return modeDevice->createStreamTag();
+  }
+
+  void device::tagStream(const streamTag &tag) {
+    assertInitialized();
+    modeDevice->tagStream(tag);
   }
 
   void device::waitFor(streamTag tag) {

--- a/src/modes/cuda/device.cpp
+++ b/src/modes/cuda/device.cpp
@@ -114,7 +114,7 @@ namespace occa {
       return new stream(this, props, cuStream);
     }
 
-    occa::streamTag device::tagStream() {
+    occa::streamTag device::createStreamTag() {
       CUevent cuEvent;
 
       OCCA_CUDA_ERROR("Device: Setting Context",
@@ -122,10 +122,17 @@ namespace occa {
       OCCA_CUDA_ERROR("Device: Tagging Stream (Creating Tag)",
                       cuEventCreate(&cuEvent,
                                     CU_EVENT_DEFAULT));
-      OCCA_CUDA_ERROR("Device: Tagging Stream",
-                      cuEventRecord(cuEvent, 0));
 
       return new occa::cuda::streamTag(this, cuEvent);
+    }
+
+    void device::tagStream(const occa::streamTag &tag) {
+      occa::cuda::streamTag *cuTag = (
+        dynamic_cast<occa::cuda::streamTag*>(tag.getModeStreamTag())
+      );
+
+      OCCA_CUDA_ERROR("Device: Tagging Stream",
+                      cuEventRecord(cuTag->cuEvent, getCuStream()));
     }
 
     void device::waitFor(occa::streamTag tag) {

--- a/src/modes/hip/device.cpp
+++ b/src/modes/hip/device.cpp
@@ -121,17 +121,24 @@ namespace occa {
       return new stream(this, props, hipStream);
     }
 
-    occa::streamTag device::tagStream() {
+    occa::streamTag device::createStreamTag() {
       hipEvent_t hipEvent;
 
       OCCA_HIP_ERROR("Device: Setting Device",
                      hipSetDevice(deviceID));
       OCCA_HIP_ERROR("Device: Tagging Stream (Creating Tag)",
                      hipEventCreate(&hipEvent));
-      OCCA_HIP_ERROR("Device: Tagging Stream",
-                     hipEventRecord(hipEvent, getHipStream()));
 
       return new occa::hip::streamTag(this, hipEvent);
+    }
+
+    void device::tagStream(const occa::streamTag &tag) {
+      occa::hip::streamTag *hipTag = (
+        dynamic_cast<occa::hip::streamTag*>(tag.getModeStreamTag())
+      );
+
+      OCCA_HIP_ERROR("Device: Tagging Stream",
+                     hipEventRecord(hipTag->hipEvent, getHipStream()));
     }
 
     void device::waitFor(occa::streamTag tag) {

--- a/src/modes/metal/device.cpp
+++ b/src/modes/metal/device.cpp
@@ -73,11 +73,23 @@ namespace occa {
       return new stream(this, props, metalCommandQueue);
     }
 
-    occa::streamTag device::tagStream() {
+    occa::streamTag device::createStreamTag() {
       metal::stream &stream = (
         *((metal::stream*) (currentStream.getModeStream()))
       );
       return new occa::metal::streamTag(this, stream.metalCommandQueue.createEvent());
+    }
+
+    void device::tagStream(const occa::streamTag &tag) {
+      occa::metal::streamTag *metalTag = (
+        dynamic_cast<occa::metal::streamTag*>(tag.getModeStreamTag())
+      );
+
+      metal::stream &stream = (
+        *((metal::stream*) (currentStream.getModeStream()))
+      );
+      occa::metal::streamTag newTag(this, stream.metalCommandQueue.createEvent());
+      metalTag->time = newTag.getTime();
     }
 
     void device::waitFor(occa::streamTag tag) {

--- a/src/modes/opencl/device.cpp
+++ b/src/modes/opencl/device.cpp
@@ -106,20 +106,25 @@ namespace occa {
       return new stream(this, props, commandQueue);
     }
 
-    occa::streamTag device::tagStream() {
+    occa::streamTag device::createStreamTag() {
       cl_event clEvent;
+      return new occa::opencl::streamTag(this, clEvent);
+    }
+
+    void device::tagStream(const occa::streamTag &tag) {
+      occa::opencl::streamTag *clTag = (
+        dynamic_cast<occa::opencl::streamTag*>(tag.getModeStreamTag())
+      );
 
 #ifdef CL_VERSION_1_2
       OCCA_OPENCL_ERROR("Device: Tagging Stream",
                         clEnqueueMarkerWithWaitList(getCommandQueue(),
-                                                    0, NULL, &clEvent));
+                                                    0, NULL, &(clTag->clEvent)));
 #else
       OCCA_OPENCL_ERROR("Device: Tagging Stream",
                         clEnqueueMarker(getCommandQueue(),
-                                        &clEvent));
+                                        &(clTag->clEvent)));
 #endif
-
-      return new occa::opencl::streamTag(this, clEvent);
     }
 
     void device::waitFor(occa::streamTag tag) {

--- a/src/modes/serial/device.cpp
+++ b/src/modes/serial/device.cpp
@@ -115,8 +115,16 @@ namespace occa {
       return new stream(this, props);
     }
 
-    occa::streamTag device::tagStream() {
-      return new occa::serial::streamTag(this, sys::currentTime());
+    occa::streamTag device::createStreamTag() {
+      return new occa::serial::streamTag(this, 0.0);
+    }
+
+    void device::tagStream(const occa::streamTag &tag) {
+      occa::serial::streamTag *srTag = (
+        dynamic_cast<occa::serial::streamTag*>(tag.getModeStreamTag())
+      );
+
+      srTag->time = sys::currentTime();
     }
 
     void device::waitFor(occa::streamTag tag) {}

--- a/tests/src/c/base.cpp
+++ b/tests/src/c/base.cpp
@@ -156,8 +156,11 @@ void testStreamMethods() {
             occa::c::stream(occaGetStream()).getModeStream());
 
   // Start tagging
+  occaStreamTag startTag = occaCreateStreamTag();
+  occaStreamTag endTag = occaCreateStreamTag();
+
   double outerStart = occa::sys::currentTime();
-  occaStreamTag startTag = occaTagStream();
+  occaTagStream(startTag);
   double innerStart = occa::sys::currentTime();
 
   // Wait 0.3 - 0.5 seconds
@@ -165,7 +168,7 @@ void testStreamMethods() {
 
   // End tagging
   double innerEnd = occa::sys::currentTime();
-  occaStreamTag endTag = occaTagStream();
+  occaTagStream(endTag);
   occaWaitForTag(endTag);
   double outerEnd = occa::sys::currentTime();
 

--- a/tests/src/c/device.cpp
+++ b/tests/src/c/device.cpp
@@ -234,9 +234,12 @@ void testStreamMethods() {
   ASSERT_EQ(stream.getModeStream(),
             occa::c::stream(occaDeviceGetStream(device)).getModeStream());
 
+  occaStreamTag startTag = occaDeviceCreateStreamTag(device);
+  occaStreamTag endTag = occaDeviceCreateStreamTag(device);
+
   // Start tagging
   double outerStart = occa::sys::currentTime();
-  occaStreamTag startTag = occaDeviceTagStream(device);
+  occaDeviceTagStream(device, startTag);
   double innerStart = occa::sys::currentTime();
 
   // Wait 0.3 - 0.5 seconds
@@ -244,7 +247,7 @@ void testStreamMethods() {
 
   // End tagging
   double innerEnd = occa::sys::currentTime();
-  occaStreamTag endTag = occaDeviceTagStream(device);
+  occaDeviceTagStream(device, endTag);
   occaDeviceWaitForTag(device, endTag);
   double outerEnd = occa::sys::currentTime();
 


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description
This PR is a minor change to how stream tags are created/queued in device streams. Rather than immediately queuing tags into streams at tag creation, and at no other time, this PR instead implements separate creation/queuing methods: device::createStreamTag() and device::tagStream(streamTag&). 

~The main reason this is beneficial is that in GPU-supported modes' stream tags are primarily used to measure timings of kernels being executed in particular streams. However, the underlying event creation in the CUDA, HIP, and OpenCL modes (cuEventCreate, etc)  is an implicitly synchronizing API function, and hence it flushes all work in all streams before creating the event, which can lead to inaccurate kernel timings.~ **Correction**: Event creation doesn't trigger a global synchronization, so this change has little effect other than letting the user potentially reuse streamTags at multiple points when gathering timing data. 

PS I wasn't sure how to best incorporate these changes in the Metal mode, so that may require some additional changes during review.   