### PR TITLE
[OpenMP] Avoid generating same kernel hash as Serial mode

### DIFF
--- a/src/modes/openmp/device.cpp
+++ b/src/modes/openmp/device.cpp
@@ -12,6 +12,7 @@ namespace occa {
     hash_t device::kernelHash(const occa::properties &props) const {
       return (
         occa::hash(props["vendor"])
+        ^ occa::hash("openmp")
         ^ props["compiler"]
         ^ props["compiler_flags"]
         ^ props["compiler_env_script"]


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description
Small change to inject information about using an OpenMP device when generating kernel hash. Without this, the same kernel hash is generated in both Serial and OpenMP modes and cached kernels are incorrectly found. 
