### PR TITLE
[OKL][CUDA] Fixes const -> __constant__ replacement on typedef statements

### DIFF
--- a/src/lang/modes/cuda.cpp
+++ b/src/lang/modes/cuda.cpp
@@ -66,7 +66,7 @@ namespace occa {
           const int declCount = declSmnt.declarations.size();
           for (int di = 0; di < declCount; ++di) {
             variable_t &var = *(declSmnt.declarations[di].variable);
-            if (var.has(const_)) {
+            if (var.has(const_) && !var.has(typedef_)) {
               var -= const_;
               var += constant;
             }


### PR DESCRIPTION

<!-- Thank you for contributing :) -->

## Description

Global `const` statements are replaced with `__constant__` memory. This shouldn't be the case for `typedefs`

### Example

```cpp
typedef const void* const_void
```

shouldn't be translated to

```cpp
typedef __constant__ void* const_void
```