### PR TITLE
[GC] Fixes refs on launched kernels

### DIFF
--- a/include/occa/tools/gc.hpp
+++ b/include/occa/tools/gc.hpp
@@ -51,6 +51,8 @@ namespace occa {
       void removeRef(entry_t *entry);
 
       bool needsFree() const;
+
+      int length() const;
     };
 
     template <class entry_t>

--- a/include/occa/tools/gc.tpp
+++ b/include/occa/tools/gc.tpp
@@ -20,7 +20,7 @@ namespace occa {
 
     template <class entry_t>
     void ring_t<entry_t>::addRef(entry_t *entry) {
-      if (!entry) {
+      if (!entry || head == entry) {
         return;
       }
       entry->removeRef();
@@ -37,12 +37,15 @@ namespace occa {
 
     template <class entry_t>
     void ring_t<entry_t>::removeRef(entry_t *entry) {
+      // Check if the ring is empty
       if (!entry || !head) {
         return;
       }
       ringEntry_t *tail = head->leftRingEntry;
+      // Remove the entry ref from its ring
       entry->removeRef();
       if (head == entry) {
+        // Change the head to the tail if entry happened to be the old head
         head = ((tail != entry)
                 ? tail
                 : NULL);
@@ -51,7 +54,23 @@ namespace occa {
 
     template <class entry_t>
     bool ring_t<entry_t>::needsFree() const {
+      // Object has no more references, safe to free now
       return useRefs && (head == NULL);
+    }
+
+    template <class entry_t>
+    int ring_t<entry_t>::length() const {
+      if (!head) {
+        return 0;
+      }
+
+      ringEntry_t *ptr = head->rightRingEntry;
+      int count = 1;
+      while (ptr != head) {
+        ++count;
+        ptr = ptr->rightRingEntry;
+      }
+      return count;
     }
 
     //---[ multiRing_t ]----------------

--- a/src/core/kernel.cpp
+++ b/src/core/kernel.cpp
@@ -24,9 +24,9 @@ namespace occa {
   modeKernel_t::~modeKernel_t() {
     // NULL all wrappers
     while (kernelRing.head) {
-      kernel *mem = (kernel*) kernelRing.head;
-      kernelRing.removeRef(mem);
-      mem->modeKernel = NULL;
+      kernel *k = (kernel*) kernelRing.head;
+      kernelRing.removeRef(k);
+      k->modeKernel = NULL;
     }
     // Remove ref from device
     if (modeDevice) {

--- a/src/core/kernelBuilder.cpp
+++ b/src/core/kernelBuilder.cpp
@@ -116,6 +116,7 @@ namespace occa {
       it->second.free();
       ++it;
     }
+    kernelMap.clear();
   }
   //====================================
 

--- a/src/core/launchedDevice.cpp
+++ b/src/core/launchedDevice.cpp
@@ -72,7 +72,14 @@ namespace occa {
       std::vector<modeKernel_t*> &deviceKernels = kernel->deviceKernels;
       const int kernelCount = (int) deviceKernels.size();
       for (int i = 0; i < kernelCount; ++i) {
-        deviceKernels[i]->properties["type_validation"] = false;
+        modeKernel_t *deviceKernel = deviceKernels[i];
+
+        // The launchedKernel handles deleting the launcher + device kernels
+        removeKernelRef(deviceKernel);
+        deviceKernel->dontUseRefs();
+
+        // Some backends inject additional arguments
+        deviceKernel->properties["type_validation"] = false;
       }
     }
 

--- a/src/core/launchedKernel.cpp
+++ b/src/core/launchedKernel.cpp
@@ -17,7 +17,7 @@ namespace occa {
     delete launcherKernel;
     launcherKernel = NULL;
 
-    int kernelCount = (int) deviceKernels.size();
+    const int kernelCount = (int) deviceKernels.size();
     for (int i = 0; i < kernelCount; ++i) {
       delete deviceKernels[i];
     }

--- a/src/modes/cuda/device.cpp
+++ b/src/modes/cuda/device.cpp
@@ -374,7 +374,6 @@ namespace occa {
                                       cuModule,
                                       cuFunction,
                                       kernelProps);
-        cuKernel->dontUseRefs();
         cuKernel->metadata = metadata;
         k.deviceKernels.push_back(cuKernel);
       }

--- a/src/modes/hip/device.cpp
+++ b/src/modes/hip/device.cpp
@@ -351,7 +351,6 @@ namespace occa {
                                        hipModule,
                                        hipFunction,
                                        kernelProps);
-        hipKernel->dontUseRefs();
         hipKernel->metadata = metadata;
         k.deviceKernels.push_back(hipKernel);
       }

--- a/src/modes/metal/device.cpp
+++ b/src/modes/metal/device.cpp
@@ -236,7 +236,6 @@ namespace occa {
                                           metalDevice,
                                           metalFunction,
                                           kernelProps);
-        deviceKernel->dontUseRefs();
         deviceKernel->metadata = metadata;
         k.deviceKernels.push_back(deviceKernel);
       }

--- a/src/modes/opencl/device.cpp
+++ b/src/modes/opencl/device.cpp
@@ -280,7 +280,6 @@ namespace occa {
                                       clDevice,
                                       clInfo.clKernel,
                                       kernelProps);
-        clKernel->dontUseRefs();
         clKernel->metadata = metadata;
         k.deviceKernels.push_back(clKernel);
       }


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description

- Internal kernels on launched kernels (launcher + device kernels) shouldn't attach their refs to the device since the launched kernel will delete them in its destructor