### PR TITLE
[CUDA] Adds pseudo-NULL pointer

### DIFF
--- a/include/occa/modes/cuda/device.hpp
+++ b/include/occa/modes/cuda/device.hpp
@@ -9,12 +9,16 @@
 namespace occa {
   namespace cuda {
     class kernel;
+    class memory;
 
     class device : public occa::launchedModeDevice_t {
       friend class kernel;
 
     private:
       mutable hash_t hash_;
+
+      // We can't pass null, so we reuse a 1-byte buffer instead
+      memory *nullPtr;
 
     public:
       int archMajorVersion, archMinorVersion;
@@ -35,6 +39,8 @@ namespace occa {
       virtual hash_t kernelHash(const occa::properties &props) const;
 
       virtual lang::okl::withLauncher* createParser(const occa::properties &props) const;
+
+      void* getNullPtr();
 
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::properties &props);

--- a/src/core/kernelArg.cpp
+++ b/src/core/kernelArg.cpp
@@ -44,7 +44,14 @@ namespace occa {
   }
 
   void* kernelArgData::ptr() const {
-    return ((info & kArgInfo::usePointer) ? data.void_ : (void*) &data);
+    if (!isNull()) {
+      if (info & kArgInfo::usePointer) {
+        return data.void_;
+      } else {
+        return (void*) &data;
+      }
+    }
+    return NULL;
   }
 
   bool kernelArgData::isNull() const {
@@ -84,7 +91,11 @@ namespace occa {
 
   template <>
   kernelArg::kernelArg(modeMemory_t *arg) {
-    add(arg->makeKernelArg());
+    if (arg) {
+      add(arg->makeKernelArg());
+    } else {
+      add(kernelArg(nullKernelArg));
+    }
   }
 
   template <>

--- a/src/modes/cuda/device.cpp
+++ b/src/modes/cuda/device.cpp
@@ -16,7 +16,8 @@
 namespace occa {
   namespace cuda {
     device::device(const occa::properties &properties_) :
-      occa::launchedModeDevice_t(properties_) {
+        occa::launchedModeDevice_t(properties_),
+        nullPtr(NULL) {
 
       if (!properties.has("wrapped")) {
         OCCA_ERROR("[CUDA] device not given a [device_id] integer",
@@ -111,6 +112,14 @@ namespace occa {
 
     lang::okl::withLauncher* device::createParser(const occa::properties &props) const {
       return new lang::okl::cudaParser(props);
+    }
+
+    void* device::getNullPtr() {
+      if (!nullPtr) {
+        // Auto freed through ring garbage collection
+        nullPtr = (cuda::memory*) malloc(1, NULL, occa::properties());
+      }
+      return (void*) &(nullPtr->cuPtr);
     }
 
     //---[ Stream ]---------------------
@@ -406,7 +415,6 @@ namespace occa {
     modeMemory_t* device::malloc(const udim_t bytes,
                                  const void *src,
                                  const occa::properties &props) {
-
       if (props.get("mapped", false)) {
         return mappedAlloc(bytes, src, props);
       }

--- a/src/modes/cuda/kernel.cpp
+++ b/src/modes/cuda/kernel.cpp
@@ -70,6 +70,10 @@ namespace occa {
       // Set arguments
       for (int i = 0; i < args; ++i) {
         vArgs[i] = arguments[i].ptr();
+        // Set a proper NULL pointer
+        if (!vArgs[i]) {
+          vArgs[i] = ((device*) modeDevice)->getNullPtr();
+        }
       }
 
       OCCA_CUDA_ERROR("Launching Kernel",


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description

CUDA doesn't accept `NULL` pointers as kernel arguments (even if they are not used). We let the device allocate and reuse a 1 byte array to use as a fake NULL pointer.
