### PR TITLE
[C] Allows occaNull to be passed to kernels

### DIFF
--- a/include/occa/c/types.hpp
+++ b/include/occa/c/types.hpp
@@ -8,36 +8,37 @@ namespace occa {
     namespace typeType {
       static const int undefined     = 0;
       static const int default_      = 1;
+      static const int null_         = 2;
 
-      static const int ptr           = 2;
+      static const int ptr           = 3;
 
-      static const int bool_         = 3;
+      static const int bool_         = 4;
 
-      static const int int8_         = 4;
-      static const int uint8_        = 5;
-      static const int int16_        = 6;
-      static const int uint16_       = 7;
-      static const int int32_        = 8;
-      static const int uint32_       = 9;
-      static const int int64_        = 10;
-      static const int uint64_       = 11;
-      static const int float_        = 12;
-      static const int double_       = 13;
+      static const int int8_         = 5;
+      static const int uint8_        = 6;
+      static const int int16_        = 7;
+      static const int uint16_       = 8;
+      static const int int32_        = 9;
+      static const int uint32_       = 10;
+      static const int int64_        = 11;
+      static const int uint64_       = 12;
+      static const int float_        = 13;
+      static const int double_       = 14;
 
-      static const int struct_       = 14;
-      static const int string        = 15;
+      static const int struct_       = 15;
+      static const int string        = 16;
 
-      static const int device        = 16;
-      static const int kernel        = 17;
-      static const int kernelBuilder = 18;
-      static const int memory        = 19;
-      static const int stream        = 20;
-      static const int streamTag     = 21;
+      static const int device        = 17;
+      static const int kernel        = 18;
+      static const int kernelBuilder = 19;
+      static const int memory        = 20;
+      static const int stream        = 21;
+      static const int streamTag     = 22;
 
-      static const int dtype         = 22;
-      static const int scope         = 23;
-      static const int json          = 24;
-      static const int properties    = 25;
+      static const int dtype         = 23;
+      static const int scope         = 24;
+      static const int json          = 25;
+      static const int properties    = 26;
     }
 
     occaType defaultOccaType();

--- a/src/c/kernel.cpp
+++ b/src/c/kernel.cpp
@@ -97,9 +97,13 @@ void OCCA_RFUNC occaKernelSetRunDims(occaKernel kernel,
 
 OCCA_LFUNC void OCCA_RFUNC occaKernelPushArg(occaKernel kernel,
                                              occaType arg) {
-  occa::c::kernel(kernel).pushArg(
-    occa::c::kernelArg(arg)
-  );
+  if (&arg != &occaNull) {
+    occa::c::kernel(kernel).pushArg(
+      occa::c::kernelArg(arg)
+    );
+  } else {
+    occa::c::kernel(kernel).pushArg(occa::null);
+  }
 }
 
 OCCA_LFUNC void OCCA_RFUNC occaKernelClearArgs(occaKernel kernel) {

--- a/src/c/types.cpp
+++ b/src/c/types.cpp
@@ -32,6 +32,15 @@ namespace occa {
       return oType;
     }
 
+    occaType nullOccaType() {
+      occaType oType;
+      oType.magicHeader = OCCA_C_TYPE_MAGIC_HEADER;
+      oType.type = occa::c::typeType::null_;
+      oType.value.ptr = NULL;
+      oType.needsFree = false;
+      return oType;
+    }
+
     occaType newOccaType(void *value) {
       occaType oType;
       oType.magicHeader = OCCA_C_TYPE_MAGIC_HEADER;
@@ -429,6 +438,9 @@ namespace occa {
       case occa::c::typeType::memory: {
         return occa::kernelArg(occa::c::memory(value));
       }
+      case occa::c::typeType::null_: {
+        return occa::kernelArg(occa::null);
+      }
       default:
         OCCA_FORCE_ERROR("An invalid occaType or non-occaType argument was passed");
       }
@@ -593,6 +605,7 @@ OCCA_START_EXTERN_C
 //---[ Type Flags ]---------------------
 const int OCCA_UNDEFINED     = occa::c::typeType::undefined;
 const int OCCA_DEFAULT       = occa::c::typeType::default_;
+const int OCCA_NULL          = occa::c::typeType::null_;
 
 const int OCCA_PTR           = occa::c::typeType::ptr;
 
@@ -626,9 +639,9 @@ const int OCCA_PROPERTIES    = occa::c::typeType::properties;
 //======================================
 
 //---[ Globals & Flags ]----------------
-const occaType occaNull       = occa::c::newOccaType((void*) NULL);
 const occaType occaUndefined  = occa::c::undefinedOccaType();
 const occaType occaDefault    = occa::c::defaultOccaType();
+const occaType occaNull       = occa::c::nullOccaType();
 const occaUDim_t occaAllBytes = -1;
 //======================================
 
@@ -636,6 +649,10 @@ const occaUDim_t occaAllBytes = -1;
 OCCA_LFUNC int OCCA_RFUNC occaIsUndefined(occaType value) {
   return ((value.magicHeader == OCCA_C_TYPE_UNDEFINED_HEADER) ||
           (value.magicHeader != OCCA_C_TYPE_MAGIC_HEADER));
+}
+
+OCCA_LFUNC int OCCA_RFUNC occaIsNull(occaType value) {
+  return (value.type == occa::c::typeType::null_);
 }
 
 OCCA_LFUNC int OCCA_RFUNC occaIsDefault(occaType value) {

--- a/tests/files/argKernel.okl
+++ b/tests/files/argKernel.okl
@@ -1,6 +1,6 @@
-@kernel void argKernel(char *mem,
+@kernel void argKernel(void *null,
+                       char *mem,
                        char *uvaPtr,
-                       void *null,
                        int i8,
                        int u8,
                        int i16,
@@ -16,9 +16,9 @@
   for (int i = 0; i < 1; ++i; @tile(1, @outer, @inner)) {
     // Note: NULL is not 0 because some backends don't handle NULL arguments properly
     printf(
+      "null: %p\n"
       "mem: %d\n"
       "uvaPtr: %d\n"
-      "null: %p\n"
       "i8: %d\n"
       "u8: %d\n"
       "i16: %d\n"
@@ -31,9 +31,9 @@
       "d: %f\n"
       "xy: [%d, %d]\n"
       "str: %s\n",
-      mem[0],
-      uvaPtr[0],
       null,
+      (int) mem[0],
+      (int) uvaPtr[0],
       (int) i8,
       (int) u8,
       (int) i16,
@@ -47,5 +47,8 @@
       xy[0], xy[1],
       str
     );
+    if (i8 != 2) {
+      throw 1;
+    }
   }
 }

--- a/tests/src/c/kernel.cpp
+++ b/tests/src/c/kernel.cpp
@@ -114,7 +114,8 @@ void testRun() {
 
   // Good argument types
   occaKernelRunN(
-    argKernel, 14,
+    argKernel, 15,
+    occaNull,
     mem,
     occaPtr(uvaPtr),
     occaInt8(2),
@@ -133,6 +134,7 @@ void testRun() {
 
   // Manual argument insertion
   occaKernelClearArgs(argKernel);
+  occaKernelPushArg(argKernel, occaNull);
   occaKernelPushArg(argKernel, mem);
   occaKernelPushArg(argKernel, occaPtr(uvaPtr));
   occaKernelPushArg(argKernel, occaInt8(2));


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description

- Just like we can pass `occa::null` to kernels in the C++ API, allow `occaNull` to be passed to kernels in the C API