### PR TITLE
[Preprocessor] Stringifies tokens inside concat

### DIFF
--- a/include/occa/lang/macro.hpp
+++ b/include/occa/lang/macro.hpp
@@ -47,6 +47,8 @@ namespace occa {
       virtual bool expand(tokenVector &newTokens,
                           token_t *source,
                           std::vector<tokenVector> &args) = 0;
+
+      void expandDefinedTokens(tokenVector &tokens);
     };
 
     class macroRawToken : public macroToken {

--- a/include/occa/lang/preprocessor.hpp
+++ b/include/occa/lang/preprocessor.hpp
@@ -65,6 +65,9 @@ namespace occa {
       //================================
 
       //---[ Misc ]---------------------
+      tokenizer_t *tokenizer;
+      bool hasLoadedTokenizer;
+
       strVector includePaths;
       //================================
 
@@ -117,6 +120,14 @@ namespace occa {
 
       strVector getDependencyFilenames() const;
       //================================
+
+      void loadTokenizer();
+
+      bool expandDefinedToken(token_t *token,
+                              tokenVector &outputTokens);
+
+      void expandDefinedTokens(tokenVector &inputTokens,
+                               tokenVector &outputTokens);
 
       void expandMacro(identifierToken &source,
                        macro_t &macro);

--- a/src/lang/macro.cpp
+++ b/src/lang/macro.cpp
@@ -60,6 +60,17 @@ namespace occa {
       return newToken;
     }
 
+    void macroToken::expandDefinedTokens(tokenVector &tokens) {
+      tokenVector expandedTokens;
+      pp.expandDefinedTokens(tokens, expandedTokens);
+
+      // Update tokens with expanded tokens
+      tokens.swap(expandedTokens);
+
+      // Free old tokens
+      freeTokenVector(expandedTokens);
+    }
+
     macroRawToken::macroRawToken(preprocessor_t &pp_,
                                  token_t *thisToken_) :
       macroToken(pp_, thisToken_) {}
@@ -144,6 +155,9 @@ namespace occa {
         return false;
       }
 
+      // Make sure to expand defined variables
+      expandDefinedTokens(stringTokens);
+
       const std::string rawValue = stringifyTokens(stringTokens, true);
 
       // Escape double quotes
@@ -199,6 +213,9 @@ namespace occa {
           return false;
         }
       }
+
+      // Make sure to expand defined variables
+      expandDefinedTokens(concatTokens);
 
       // Combine tokens to create one token identifier
       const std::string concatValue = stringifyTokens(concatTokens, false);

--- a/src/lang/preprocessor.cpp
+++ b/src/lang/preprocessor.cpp
@@ -91,6 +91,9 @@ namespace occa {
 
       warnings = 0;
       errors   = 0;
+
+      tokenizer = NULL;
+      hasLoadedTokenizer = false;
     }
 
     void preprocessor_t::clear() {
@@ -101,6 +104,9 @@ namespace occa {
     void preprocessor_t::clear_() {
       errors   = 0;
       warnings = 0;
+
+      tokenizer = NULL;
+      hasLoadedTokenizer = false;
 
       while (inputCache.size()) {
         delete inputCache.front();
@@ -329,10 +335,50 @@ namespace occa {
     }
     //==================================
 
+    void preprocessor_t::loadTokenizer() {
+      if (!hasLoadedTokenizer) {
+        tokenizer = (tokenizer_t*) getInput("tokenizer_t");
+        hasLoadedTokenizer = true;
+      }
+    }
+
+
+    bool preprocessor_t::expandDefinedToken(token_t *token, tokenVector &tokens) {
+      if (!(token_t::safeType(token) & tokenType::identifier)) {
+        return false;
+      }
+
+      identifierToken &idToken = token->to<identifierToken>();
+      macro_t *macro = getMacro(idToken.value);
+      if (!macro) {
+        return false;
+      }
+
+      macro->expand(tokens, idToken);
+      return true;
+    }
+
+    void preprocessor_t::expandDefinedTokens(tokenVector &inputTokens,
+                                             tokenVector &outputTokens) {
+      const int inputTokenCount = (int) inputTokens.size();
+      for (int i = 0; i < inputTokenCount; ++i) {
+        token_t *token = inputTokens[i];
+        tokenVector expandedTokens;
+
+        if (expandDefinedToken(token, expandedTokens)) {
+          const int expandedTokenCount = (int) expandedTokens.size();
+          for (int j = 0; j < expandedTokenCount; ++j) {
+            outputTokens.push_back(expandedTokens[j]);
+          }
+        } else {
+          outputTokens.push_back(token->clone());
+        }
+      }
+    }
+
     void preprocessor_t::expandMacro(identifierToken &source,
                                      macro_t &macro) {
       tokenVector tokens;
-
       macro.expand(tokens, source);
 
       const int tokenCount = (int) tokens.size();
@@ -518,7 +564,6 @@ namespace occa {
       );
     }
 
-
     void preprocessor_t::processIdentifier(identifierToken &token) {
       // Ignore tokens inside disabled #if/#elif/#else regions
       if (status & ppStatus::ignoring) {
@@ -649,7 +694,7 @@ namespace occa {
       outputCache.clear();
 
       // Make sure we have a tokenizer
-      tokenizer_t *tokenizer = (tokenizer_t*) getInput("tokenizer_t");
+      loadTokenizer();
       if (!tokenizer) {
         warningOn(directiveToken,
                   "Unable to apply @directive due to the lack of a tokenizer");
@@ -1103,7 +1148,7 @@ namespace occa {
 
     void preprocessor_t::processInclude(identifierToken &directive) {
       // Don't cache since the input might change
-      tokenizer_t *tokenizer = (tokenizer_t*) getInput("tokenizer_t");
+      loadTokenizer();
       if (!tokenizer) {
         warningOn(&directive,
                   "Unable to apply #include due to the lack of a tokenizer");
@@ -1213,10 +1258,7 @@ namespace occa {
       getExpandedLineTokens(lineTokens);
 
       // Don't cache since the input might change
-      tokenizer_t *tokenizer = (tokenizer_t*) getInput("tokenizer_t");
-      if (!tokenizer) {
-        tokenizer = (tokenizer_t*) getInput("tokenizer_t");
-      }
+      loadTokenizer();
       if (!tokenizer) {
         warningOn(&directive,
                   "Unable to apply #line due to the lack of a tokenizer");

--- a/tests/src/lang/preprocessor.cpp
+++ b/tests/src/lang/preprocessor.cpp
@@ -144,7 +144,8 @@ void testMacroDefines() {
             pp.errors);
 
   // Make sure we can handle recursive macros
-#define identifier (token->to<identifierToken>().value)
+#define identifier  (token->to<identifierToken>().value)
+#define stringValue (token->to<stringToken>().value)
   setStream(
     "#define foo foo\n"
     "foo"
@@ -166,6 +167,17 @@ void testMacroDefines() {
             identifier);
   getToken();
   ASSERT_EQ("foo2",
+            identifier);
+
+  // Test concat with defines
+  setStream(
+    "#define ONE 1\n"
+    "#define TWO 2\n"
+    "#define ONE_TWO_FUNC(FUNC) FUNC ## _ ## ONE ## _ ## TWO\n"
+    "ONE_TWO_FUNC(hi)\n"
+  );
+  getToken();
+  ASSERT_EQ("hi_1_2",
             identifier);
 
 #undef identifier


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description

```c
#define ONE 1
#define TWO 2
#define ONE_TWO_FUNC(FUNC) FUNC ## _ ## ONE ## _ ## TWO
ONE_TWO_FUNC(hi)
```

was being expanded to

```
hi_ONE_TWO
```

instead of

```
hi_1_2
```