### PR TITLE
Fix typo in include path

### DIFF
--- a/examples/cpp/17_opencl_interop/main.cpp
+++ b/examples/cpp/17_opencl_interop/main.cpp
@@ -2,7 +2,7 @@
 
 #include <occa.hpp>
 // Has OpenCL includes
-#include <occa/mode/opencl/utils.hpp>
+#include <occa/modes/opencl/utils.hpp>
 
 int main(int argc, char **argv) {
   int entries = 5;


### PR DESCRIPTION
### Description
Fix include path in examples/cpp/17_opencl_interop/main.cpp