### PR TITLE
[Test] Fix @rpath issues with MacOS tests

### DIFF
--- a/tests/run_examples
+++ b/tests/run_examples
@@ -83,6 +83,10 @@ for mode in $("${OCCA_DIR}/bin/occa" modes); do
         cd "${EXAMPLE_DIR}/${example_dir}"
         make clean; make
 
+        if [[ $(uname -s) == "Darwin" || "${TRAVIS_OS_NAME}" == "osx" ]]; then
+            install_name_tool -change "@rpath/libocca.dyld" "${OCCA_DIR}/lib/libocca.dylib" main
+        fi
+
         output=$(./main "${flags[@]}" 2>&1)
 
         # Check for example failures


### PR DESCRIPTION
<!-- Thank you for contributing :) -->

### Description

Fixes these issues from Travis CI on MacOS tests

```
dyld: Library not loaded: @rpath/libocca.dylib
  Referenced from: <OCCA_DIR>/examples/cpp/02_background_device/./main
  Reason: image not found
```
