### PR TITLE
[Core] Add support for OCCA_INCLUDE_PATH and OCCA_LIBRARY_PATH

### DIFF
--- a/include/occa/modes/cuda/device.hpp
+++ b/include/occa/modes/cuda/device.hpp
@@ -65,7 +65,8 @@ namespace occa {
                                                    const occa::properties &kernelProps,
                                                    io::lock_t lock);
 
-      void setArchCompilerFlags(occa::properties &kernelProps);
+      void setArchCompilerFlags(const occa::properties &kernelProps,
+                                std::string &compilerFlags);
 
       void compileKernel(const std::string &hashDir,
                          const std::string &kernelName,

--- a/include/occa/tools/env.hpp
+++ b/include/occa/tools/env.hpp
@@ -15,7 +15,8 @@ namespace occa {
 
     extern std::string OCCA_DIR, OCCA_CACHE_DIR;
     extern size_t      OCCA_MEM_BYTE_ALIGN;
-    extern strVector   OCCA_PATH;
+    extern strVector   OCCA_INCLUDE_PATH;
+    extern strVector   OCCA_LIBRARY_PATH;
     extern bool        OCCA_COLOR_ENABLED;
 
     properties& baseSettings();

--- a/include/occa/tools/sys.hpp
+++ b/include/occa/tools/sys.hpp
@@ -94,7 +94,11 @@ namespace occa {
     std::string compilerSharedBinaryFlags(const std::string &compiler);
     std::string compilerSharedBinaryFlags(const int vendor_);
 
+    void addCompilerIncludeFlags(std::string &compilerFlags);
+    void addCompilerLibraryFlags(std::string &compilerFlags);
+
     void addCompilerFlags(std::string &compilerFlags, const std::string &flags);
+    void addCompilerFlags(std::string &compilerFlags, const strVector &flags);
     //==================================
 
     //---[ Dynamic Methods ]------------

--- a/src/lang/preprocessor.cpp
+++ b/src/lang/preprocessor.cpp
@@ -28,24 +28,23 @@ namespace occa {
       init();
       initDirectives();
 
-      if (!settings_.has("okl/include_paths")) {
-        return;
-      }
+      includePaths = env::OCCA_INCLUDE_PATH;
 
-      json paths = settings_["okl/include_paths"];
-      if (!paths.isArray()) {
-        return;
-      }
-
-      jsonArray pathArray = paths.array();
-      const int pathCount = (int) pathArray.size();
-      for (int i = 0; i < pathCount; ++i) {
-        json path = pathArray[i];
-        if (path.isString()) {
-          std::string pathStr = path;
-          io::endWithSlash(pathStr);
-          includePaths.push_back(pathStr);
+      json oklIncludePaths = settings_["okl/include_paths"];
+      if (oklIncludePaths.isArray()) {
+        jsonArray pathArray = oklIncludePaths.array();
+        const int pathCount = (int) pathArray.size();
+        for (int i = 0; i < pathCount; ++i) {
+          json path = pathArray[i];
+          if (path.isString()) {
+            includePaths.push_back(path);
+          }
         }
+      }
+
+      const int includePathCount = (int) includePaths.size();
+      for (int i = 0; i < includePathCount; ++i) {
+        io::endWithSlash(includePaths[i]);
       }
     }
 

--- a/src/modes/serial/device.cpp
+++ b/src/modes/serial/device.cpp
@@ -265,6 +265,7 @@ namespace occa {
 
       std::string sourceFilename;
       lang::sourceMetadata_t metadata;
+      const bool compilingOkl = kernelProps.get("okl/enabled", true);
       const bool compilingCpp = (
         ((int) kernelProps["compiler_language"]) == sys::language::CPP
       );
@@ -286,7 +287,7 @@ namespace occa {
                         assembleKernelHeader(kernelProps))
         );
 
-        if (kernelProps.get("okl/enabled", true)) {
+        if (compilingOkl) {
           const std::string outputFile = hashDir + kc::sourceFile;
           bool valid = parseFile(sourceFilename,
                                  outputFile,
@@ -316,6 +317,11 @@ namespace occa {
       std::string compilerSharedFlags = kernelProps["compiler_shared_flags"];
 
       sys::addCompilerFlags(compilerFlags, compilerSharedFlags);
+
+      if (!compilingOkl) {
+        sys::addCompilerIncludeFlags(compilerFlags);
+        sys::addCompilerLibraryFlags(compilerFlags);
+      }
 
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
       command << compiler

--- a/src/tools/env.cpp
+++ b/src/tools/env.cpp
@@ -22,7 +22,8 @@ namespace occa {
 
     std::string OCCA_DIR, OCCA_CACHE_DIR;
     size_t      OCCA_MEM_BYTE_ALIGN;
-    strVector   OCCA_PATH;
+    strVector   OCCA_INCLUDE_PATH;
+    strVector   OCCA_LIBRARY_PATH;
     bool        OCCA_COLOR_ENABLED;
 
     properties& baseSettings() {
@@ -49,7 +50,6 @@ namespace occa {
       loadConfig();
 
       setupCachePath();
-      setupIncludePath();
       registerFileOpeners();
 
       isInitialized = true;
@@ -78,6 +78,9 @@ namespace occa {
 
       OCCA_CACHE_DIR     = env::var("OCCA_CACHE_DIR");
       OCCA_COLOR_ENABLED = env::get<bool>("OCCA_COLOR_ENABLED", true);
+
+      OCCA_INCLUDE_PATH = split(env::var("OCCA_INCLUDE_PATH"), ':', '\\');
+      OCCA_LIBRARY_PATH = split(env::var("OCCA_LIBRARY_PATH"), ':', '\\');
 
       io::endWithSlash(HOME);
       io::endWithSlash(CWD);
@@ -145,37 +148,6 @@ namespace occa {
 
       if (!io::isDir(env::OCCA_CACHE_DIR)) {
         sys::mkpath(env::OCCA_CACHE_DIR);
-      }
-    }
-
-    void envInitializer_t::setupIncludePath() {
-      std::string envPath = env::var("OCCA_PATH");
-      if (!envPath.size()) {
-        return;
-      }
-
-      // Override OCCA_PATH with environment variable
-      env::OCCA_PATH.clear();
-
-      const char *cStart = envPath.c_str();
-      const char *cEnd;
-      while(cStart[0] != '\0') {
-        cEnd = cStart;
-#if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
-        lex::skipTo(cEnd, ':');
-#else
-        lex::skipTo(cEnd, ';');
-#endif
-
-        if (0 < (cEnd - cStart)) {
-          std::string newPath(cStart, cEnd - cStart);
-          newPath = io::filename(newPath);
-          io::endWithSlash(newPath);
-
-          env::OCCA_PATH.push_back(newPath);
-        }
-
-        cStart = (cEnd + (cEnd[0] != '\0'));
       }
     }
 

--- a/src/tools/sys.cpp
+++ b/src/tools/sys.cpp
@@ -772,12 +772,39 @@ namespace occa {
       return "";
     }
 
-    void addCompilerFlags(std::string &compilerFlags, const std::string &flags) {
-      strVector compilerFlagsVec = split(compilerFlags, ' ');
-      const strVector flagsVec = split(flags, ' ');
+    void addCompilerIncludeFlags(std::string &compilerFlags) {
+      strVector includeDirs = env::OCCA_INCLUDE_PATH;
 
-      for (int i = 0; i < (int) flagsVec.size(); ++i) {
-        const std::string &flag = flagsVec[i];
+      const int count = (int) includeDirs.size();
+      for (int i = 0; i < count; ++i) {
+        includeDirs[i] = "-I" + includeDirs[i];
+      }
+
+      addCompilerFlags(compilerFlags, includeDirs);
+    }
+
+    void addCompilerLibraryFlags(std::string &compilerFlags) {
+      strVector libraryDirs = env::OCCA_LIBRARY_PATH;
+
+      const int count = (int) libraryDirs.size();
+      for (int i = 0; i < count; ++i) {
+        libraryDirs[i] = "-L" + libraryDirs[i];
+      }
+
+      addCompilerFlags(compilerFlags, libraryDirs);
+    }
+
+    void addCompilerFlags(std::string &compilerFlags, const std::string &flags) {
+      const strVector flagsVec = split(flags, ' ');
+      addCompilerFlags(compilerFlags, flagsVec);
+    }
+
+    void addCompilerFlags(std::string &compilerFlags, const strVector &flags) {
+      strVector compilerFlagsVec = split(compilerFlags, ' ');
+
+      const int flagCount = (int) flags.size();
+      for (int i = 0; i < flagCount; ++i) {
+        const std::string &flag = flags[i];
         if (indexOf(compilerFlagsVec, flag) < 0) {
           compilerFlagsVec.push_back(flag);
         }


### PR DESCRIPTION
## Description

OKL kernels will now also look at `OCCA_INCLUDE_PATH` to find `#include` directories

Native kernels will add `-I` for each passed in `OCCA_INCLUDE_PATH` as well as `-L` for each passed in `OCCA_LIBRARY_PATH`

## Example

```
> OCCA_INCLUDE_PATH="i1:i2:i3" OCCA_LIBRARY_PATH="l1:l2:l3"  a -v
Compiling [addVectors]
nvcc -O3 -arch=sm_61 -Ii1 -Ii2 -Ii3 -Ll1 -Ll2 -Ll3 ...
```
