### PR TITLE
[C] Use bool from stdbool.h for boolean types

### DIFF
--- a/include/occa/c/types.h
+++ b/include/occa/c/types.h
@@ -2,6 +2,7 @@
 #define OCCA_C_TYPES_HEADER
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include <occa/c/defines.h>
@@ -19,7 +20,7 @@ typedef struct {
   int magicHeader;
   int type;
   occaUDim_t bytes;
-  char needsFree;
+  bool needsFree;
 
   union {
     uint8_t  uint8_;
@@ -99,7 +100,7 @@ OCCA_LFUNC int OCCA_RFUNC occaIsDefault(occaType value);
 
 OCCA_LFUNC occaType OCCA_RFUNC occaPtr(void *value);
 
-OCCA_LFUNC occaType OCCA_RFUNC occaBool(int value);
+OCCA_LFUNC occaType OCCA_RFUNC occaBool(bool value);
 
 OCCA_LFUNC occaType OCCA_RFUNC occaInt8(int8_t value);
 OCCA_LFUNC occaType OCCA_RFUNC occaUInt8(uint8_t value);

--- a/src/c/types.cpp
+++ b/src/c/types.cpp
@@ -667,8 +667,8 @@ OCCA_LFUNC occaType OCCA_RFUNC occaPtr(void *value) {
   return occa::c::newOccaType(value);
 }
 
-OCCA_LFUNC occaType OCCA_RFUNC occaBool(int value) {
-  return occa::c::newOccaType((bool) value);
+OCCA_LFUNC occaType OCCA_RFUNC occaBool(bool value) {
+  return occa::c::newOccaType(value);
 }
 
 OCCA_LFUNC occaType OCCA_RFUNC occaInt8(int8_t value) {


### PR DESCRIPTION
Use `bool` from `stdbool.h` for boolean types. 

This header was introduced in C99, for more details see:
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stdbool.h.html

I tested this change by running the C examples, which use this functionality. All work as expected.