### PR TITLE
[CMake] Let CMake determine which compiler flags should / can be used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ project (occa
   HOMEPAGE_URL "https://github.com/libocca/occa/"
   LANGUAGES C CXX)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 include(OS)
 
 option(ALLOW_CUDA "Allow CUDA" OFF)
@@ -25,7 +31,6 @@ option(ALLOW_HIP "Allow HIP" OFF)
 option(ENABLE_TESTS "Enable tests" OFF)
 
 find_package(Threads REQUIRED)
-set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 
 if (ALLOW_OPENMP)
   include(OpenMP)
@@ -40,6 +45,7 @@ if (ALLOW_CUDA)
   set(OCCA_CUDA_ENABLED 1)
   set(WITH_CUDA 1)
   enable_language(CUDA)
+  set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 endif()
 
 # searches for MPI if allowed
@@ -59,15 +65,13 @@ endif()
 
 add_definitions(-DUSE_CMAKE)
 
+include(SetCompilerFlags)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-c++11-long-long")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++11-long-long")
+if (ALLOW_OPENMP)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 endif()
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 
 include_directories(${PROJECT_BINARY_DIR}/include)
 set(OCCA_BUILD_DIR ${PROJECT_BINARY_DIR})

--- a/cmake/SetCompilerFlags.cmake
+++ b/cmake/SetCompilerFlags.cmake
@@ -1,0 +1,44 @@
+include(CheckCXXCompilerFlag)
+
+function(set_optional_cxx_flag var)
+  foreach(flag ${ARGN})
+    string(MAKE_C_IDENTIFIER "Allowed_CXX_Flag${flag}" check_var)
+    check_cxx_compiler_flag("${flag}" ${check_var})
+    if (${${check_var}})
+      set(${var} "${${var}} ${flag}")
+    endif()
+  endforeach()
+  set(${var} "${${var}}" PARENT_SCOPE)
+endfunction(set_optional_cxx_flag)
+
+# Enable warnings
+set_optional_cxx_flag(SUPPORTED_WARN_CXX_FLAGS "-Wall -Wextra")
+set_optional_cxx_flag(SUPPORTED_WARN_CXX_FLAGS "-Wunused-function -Wunused-variable")
+set_optional_cxx_flag(SUPPORTED_WARN_CXX_FLAGS "-Wwrite-strings -Wfloat-equal" "-Wcast-align -Wlogical-op" "-Wshadow")
+# set_optional_cxx_flag(SUPPORTED_WARN_CXX_FLAGS "-Wstrict-prototypes -Wmissing-prototypes" "-Wundef")
+# Disable warnings
+set_optional_cxx_flag(SUPPORTED_WARN_CXX_FLAGS "-Wno-unused-parameter")
+set_optional_cxx_flag(SUPPORTED_WARN_CXX_FLAGS "-Wno-c++11-long-long")
+set_optional_cxx_flag(SUPPORTED_WARN_CXX_FLAGS "-diag-disable 11074 -diag-disable 11076")   # Intel: Disable warnings about inline limits reached
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SUPPORTED_WARN_CXX_FLAGS}")
+
+include(CheckCCompilerFlag)
+
+function(set_optional_c_flag var)
+  foreach(flag ${ARGN})
+    string(MAKE_C_IDENTIFIER "Allowed_C_Flag${flag}" check_var)
+    check_c_compiler_flag("${flag}" ${check_var})
+    if (${${check_var}})
+      set(${var} "${${var}} ${flag}")
+    endif()
+  endforeach()
+  set(${var} "${${var}}" PARENT_SCOPE)
+endfunction(set_optional_c_flag)
+
+# Enable warnings
+set_optional_c_flag(SUPPORTED_WARN_C_FLAGS "-Wall -Wextra")
+# Disble warnings
+set_optional_c_flag(SUPPORTED_WARN_C_FLAGS "-Wno-c++11-long-long")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SUPPORTED_WARN_C_FLAGS}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,4 @@ endif()
 
 target_link_libraries(libocca ${LIBOCCA_LIBRARIES})
 
-target_compile_features(libocca PUBLIC cxx_std_11)
-target_compile_options(libocca PRIVATE -Wall -Wextra -Wno-c++11-extensions -Wno-unused-parameter)
-
 install(TARGETS libocca DESTINATION lib)


### PR DESCRIPTION
## Description

Attempts to fix #320:

* Set the C++11 standard globally.
* Same for no C++11 extensions.
* Add functions to test if flags are accepted by the compiler and add only those that are.
* Add more warning flags.

Although I have automated tests set up for clang / gnu / Intel I only use Linux, so maybe @JamesEggleton can check if this works for him on MacOS?

<!-- Thank you for contributing! -->
