### PR TITLE
[C] Update occaFree

### DIFF
--- a/examples/c/01_add_vectors/main.c
+++ b/examples/c/01_add_vectors/main.c
@@ -105,13 +105,13 @@ int main(int argc, const char **argv) {
   free(ab);
 
   // Free device memory and occa objects
-  occaFree(args);
-  occaFree(props);
-  occaFree(addVectors);
-  occaFree(o_a);
-  occaFree(o_b);
-  occaFree(o_ab);
-  occaFree(device);
+  occaFree(&args);
+  occaFree(&props);
+  occaFree(&addVectors);
+  occaFree(&o_a);
+  occaFree(&o_b);
+  occaFree(&o_ab);
+  occaFree(&device);
 }
 
 occaJson parseArgs(int argc, const char **argv) {

--- a/examples/c/02_background_device/main.c
+++ b/examples/c/02_background_device/main.c
@@ -67,8 +67,8 @@ int main(int argc, const char **argv) {
     }
   }
 
-  occaFree(args);
-  occaFree(addVectors);
+  occaFree(&args);
+  occaFree(&addVectors);
   occaFreeUvaPtr(a);
   occaFreeUvaPtr(b);
   occaFreeUvaPtr(ab);

--- a/examples/c/03_inline_okl/main.c
+++ b/examples/c/03_inline_okl/main.c
@@ -69,9 +69,9 @@ int main(int argc, const char **argv) {
     }
   }
 
-  occaFree(args);
-  occaFree(props);
-  occaFree(scope);
+  occaFree(&args);
+  occaFree(&props);
+  occaFree(&scope);
   occaFreeUvaPtr(a);
   occaFreeUvaPtr(b);
   occaFreeUvaPtr(ab);

--- a/examples/c/04_reduction/main.c
+++ b/examples/c/04_reduction/main.c
@@ -87,11 +87,11 @@ int main(int argc, const char **argv) {
   free(vec);
   free(blockSum);
 
-  occaFree(args);
-  occaFree(reductionProps);
-  occaFree(reduction);
-  occaFree(o_vec);
-  occaFree(o_blockSum);
+  occaFree(&args);
+  occaFree(&reductionProps);
+  occaFree(&reduction);
+  occaFree(&o_vec);
+  occaFree(&o_blockSum);
 
   return 0;
 }

--- a/include/occa/c/types.h
+++ b/include/occa/c/types.h
@@ -137,7 +137,7 @@ OCCA_LFUNC occaType OCCA_RFUNC occaStruct(const void *value,
 OCCA_LFUNC occaType OCCA_RFUNC occaString(const char *str);
 //======================================
 
-OCCA_LFUNC void OCCA_RFUNC occaFree(occaType value);
+OCCA_LFUNC void OCCA_RFUNC occaFree(occaType *value);
 
 OCCA_END_EXTERN_C
 

--- a/src/c/types.cpp
+++ b/src/c/types.cpp
@@ -767,56 +767,58 @@ OCCA_LFUNC occaType OCCA_RFUNC occaString(const char *str) {
 }
 //======================================
 
-OCCA_LFUNC void OCCA_RFUNC occaFree(occaType value) {
-  if (occaIsUndefined(value)) {
+OCCA_LFUNC void OCCA_RFUNC occaFree(occaType *value) {
+  occaType &valueRef = *value;
+
+  if (occaIsUndefined(valueRef)) {
     return;
   }
-  switch (value.type) {
+  switch (valueRef.type) {
   case occa::c::typeType::device: {
-    occa::c::device(value).free();
+    occa::c::device(valueRef).free();
     break;
   }
   case occa::c::typeType::kernel: {
-    occa::c::kernel(value).free();
+    occa::c::kernel(valueRef).free();
     break;
   }
   case occa::c::typeType::kernelBuilder: {
-    occa::c::kernelBuilder(value).free();
+    occa::c::kernelBuilder(valueRef).free();
     break;
   }
   case occa::c::typeType::memory: {
-    occa::c::memory(value).free();
+    occa::c::memory(valueRef).free();
     break;
   }
   case occa::c::typeType::stream: {
-    occa::c::stream(value).free();
+    occa::c::stream(valueRef).free();
     break;
   }
   case occa::c::typeType::streamTag: {
-    occa::c::streamTag(value).free();
+    occa::c::streamTag(valueRef).free();
     break;
   }
   case occa::c::typeType::dtype: {
-    delete &occa::c::dtype(value);
+    delete &occa::c::dtype(valueRef);
     break;
   }
   case occa::c::typeType::scope: {
-    delete &occa::c::scope(value);
+    delete &occa::c::scope(valueRef);
     break;
   }
   case occa::c::typeType::json: {
-    if (value.needsFree) {
-      delete &occa::c::json(value);
+    if (valueRef.needsFree) {
+      delete &occa::c::json(valueRef);
     }
     break;
   }
   case occa::c::typeType::properties: {
-    if (value.needsFree) {
-      delete &occa::c::properties(value);
+    if (valueRef.needsFree) {
+      delete &occa::c::properties(valueRef);
     }
     break;
   }}
-  value.magicHeader = occaUndefined.magicHeader;
+  valueRef.magicHeader = occaUndefined.magicHeader;
 }
 
 OCCA_END_EXTERN_C

--- a/tests/run_examples
+++ b/tests/run_examples
@@ -9,6 +9,10 @@ ASAN_OPTIONS+=':detect_container_overflow=0'
 
 HEADER_CHARS=80
 
+if [[ $(uname -s) == "Darwin" || "${TRAVIS_OS_NAME}" == "osx" ]]; then
+    export DYLD_LIBRARY_PATH="${OCCA_DIR}/lib:${DYLD_LIBRARY_PATH}"
+fi
+
 declare -a examples=(
   cpp/01_add_vectors
   cpp/02_background_device
@@ -82,10 +86,6 @@ for mode in $("${OCCA_DIR}/bin/occa" modes); do
 
         cd "${EXAMPLE_DIR}/${example_dir}"
         make clean; make
-
-        if [[ $(uname -s) == "Darwin" || "${TRAVIS_OS_NAME}" == "osx" ]]; then
-            install_name_tool -change "@rpath/libocca.dyld" "${OCCA_DIR}/lib/libocca.dylib" main
-        fi
 
         output=$(./main "${flags[@]}" 2>&1)
 

--- a/tests/src/c/base.cpp
+++ b/tests/src/c/base.cpp
@@ -68,14 +68,14 @@ void testMemoryMethods() {
                               occaDefault);
   ASSERT_EQ(occaMemorySize(mem),
             bytes);
-  occaFree(mem);
+  occaFree(&mem);
 
   mem = occaMalloc(bytes,
                    NULL,
                    props);
   ASSERT_EQ(occaMemorySize(mem),
             bytes);
-  occaFree(mem);
+  occaFree(&mem);
 
   // umalloc
   void *ptr = occaUMalloc(bytes,
@@ -88,7 +88,7 @@ void testMemoryMethods() {
                     props);
   occaFreeUvaPtr(ptr);
 
-  occaFree(props);
+  occaFree(&props);
 }
 
 void testKernelMethods() {
@@ -111,36 +111,36 @@ void testKernelMethods() {
     occa::c::kernel(addVectors).binaryFilename()
   );
 
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   addVectors = occaBuildKernel(addVectorsFile.c_str(),
                                "addVectors",
                                props);
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   // occaBuildFromString
   addVectors = occaBuildKernelFromString(addVectorsSource.c_str(),
                                          "addVectors",
                                          occaDefault);
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   addVectors = occaBuildKernelFromString(addVectorsSource.c_str(),
                                          "addVectors",
                                          props);
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   // occaBuildFromBinary
   addVectors = occaBuildKernelFromBinary(addVectorsBinaryFile.c_str(),
                                          "addVectors",
                                          occaDefault);
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   addVectors = occaBuildKernelFromBinary(addVectorsBinaryFile.c_str(),
                                          "addVectors",
                                          props);
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
-  occaFree(props);
+  occaFree(&props);
 }
 
 void testStreamMethods() {
@@ -176,5 +176,5 @@ void testStreamMethods() {
   ASSERT_LE(innerEnd - innerStart,
             tagTime);
 
-  occaFree(cStream);
+  occaFree(&cStream);
 }

--- a/tests/src/c/device.cpp
+++ b/tests/src/c/device.cpp
@@ -39,7 +39,7 @@ int main(const int argc, const char **argv) {
   testKernelMethods();
   testStreamMethods();
 
-  occaFree(props);
+  occaFree(&props);
 
   return 0;
 }
@@ -55,7 +55,7 @@ void testInit() {
   ASSERT_EQ(device.type,
             OCCA_DEVICE);
 
-  occaFree(device);
+  occaFree(&device);
 
   device = occaCreateDevice(
     occaString(deviceStr.c_str())
@@ -69,7 +69,7 @@ void testInit() {
 
   occaDeviceFinish(device);
 
-  occaFree(device);
+  occaFree(&device);
 }
 void testProperties() {
   occaDevice device = occaUndefined;
@@ -91,7 +91,7 @@ void testProperties() {
   occaProperties memoryProps = occaDeviceGetMemoryProperties(device);
   ASSERT_TRUE(occaPropertiesHas(memoryProps, "mkey"));
 
-  occaFree(device);
+  occaFree(&device);
 }
 
 void testMemoryMethods() {
@@ -134,13 +134,13 @@ void testMemoryMethods() {
             allocatedBytes);
 
   // Free
-  occaFree(mem1);
+  occaFree(&mem1);
   allocatedBytes -= memBytes;
 
   ASSERT_EQ((size_t) occaDeviceMemoryAllocated(device),
             allocatedBytes);
 
-  occaFree(mem2);
+  occaFree(&mem2);
   allocatedBytes -= memBytes;
 
   ASSERT_EQ((size_t) occaDeviceMemoryAllocated(device),
@@ -159,7 +159,7 @@ void testMemoryMethods() {
   ASSERT_EQ((size_t) occaDeviceMemoryAllocated(device),
             allocatedBytes);
 
-  occaFree(device);
+  occaFree(&device);
 }
 
 void testKernelMethods() {
@@ -182,41 +182,41 @@ void testKernelMethods() {
     occa::c::kernel(addVectors).binaryFilename()
   );
 
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   addVectors = occaDeviceBuildKernel(device,
                                      addVectorsFile.c_str(),
                                      "addVectors",
                                      props);
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   // occaBuildFromString
   addVectors = occaDeviceBuildKernelFromString(device,
                                                addVectorsSource.c_str(),
                                                "addVectors",
                                                occaDefault);
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   addVectors = occaDeviceBuildKernelFromString(device,
                                                addVectorsSource.c_str(),
                                                "addVectors",
                                                props);
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   // occaBuildFromBinary
   addVectors = occaDeviceBuildKernelFromBinary(device,
                                                addVectorsBinaryFile.c_str(),
                                                "addVectors",
                                                occaDefault);
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   addVectors = occaDeviceBuildKernelFromBinary(device,
                                                addVectorsBinaryFile.c_str(),
                                                "addVectors",
                                                props);
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
-  occaFree(device);
+  occaFree(&device);
 }
 
 void testStreamMethods() {
@@ -255,6 +255,6 @@ void testStreamMethods() {
   ASSERT_LE(innerEnd - innerStart,
             tagTime);
 
-  occaFree(cStream);
-  occaFree(device);
+  occaFree(&cStream);
+  occaFree(&device);
 }

--- a/tests/src/c/dtype.cpp
+++ b/tests/src/c/dtype.cpp
@@ -92,12 +92,12 @@ void testDtype() {
     occaDtypesMatch(foo3, foo4)
   );
 
-  occaFree(fakeFloat);
-  occaFree(fakeDouble);
-  occaFree(foo1);
-  occaFree(foo2);
-  occaFree(foo3);
-  occaFree(foo4);
+  occaFree(&fakeFloat);
+  occaFree(&fakeDouble);
+  occaFree(&foo1);
+  occaFree(&foo2);
+  occaFree(&foo3);
+  occaFree(&foo4);
 }
 
 void testJsonMethods() {
@@ -162,11 +162,11 @@ void testJsonMethods() {
   ::free((void*) fooJsonStr);
   ::free((void*) rawFooJsonStr);
 
-  occaFree(doubleJson);
-  occaFree(rawDoubleJson);
-  occaFree(foo);
-  occaFree(fooJson);
-  occaFree(rawFooJson);
-  occaFree(foo2);
-  occaFree(foo3);
+  occaFree(&doubleJson);
+  occaFree(&rawDoubleJson);
+  occaFree(&foo);
+  occaFree(&fooJson);
+  occaFree(&rawFooJson);
+  occaFree(&foo2);
+  occaFree(&foo3);
 }

--- a/tests/src/c/json.cpp
+++ b/tests/src/c/json.cpp
@@ -32,7 +32,7 @@ int main(const int argc, const char **argv) {
   testSerialization();
   testCasting();
 
-  occaFree(cJson);
+  occaFree(&cJson);
 
   return 0;
 }
@@ -81,7 +81,7 @@ void testTypeChecking() {
   ASSERT_TRUE(occaJsonObjectHas(cJson2, "string"));
   ASSERT_TRUE(occaJsonObjectHas(cJson2, "array"));
 
-  occaFree(cJson2);
+  occaFree(&cJson2);
 }
 
 void testTypes() {
@@ -179,7 +179,7 @@ void testTypes() {
   ASSERT_TRUE(occaJsonIsObject(propValue));
   ASSERT_TRUE(occaJsonObjectHas(propValue, "value"));
 
-  occaFree(cJson2);
+  occaFree(&cJson2);
 }
 
 void testArray() {
@@ -238,7 +238,7 @@ void testArray() {
   occaJsonArrayClear(array);
   ASSERT_EQ(occaJsonArraySize(array), 0);
 
-  occaFree(array);
+  occaFree(&array);
 }
 
 void testBadType() {
@@ -286,7 +286,7 @@ void testSerialization() {
   ASSERT_EQ(props,
             props2);
 
-  occaFree(cJson2);
+  occaFree(&cJson2);
 }
 
 void testCasting() {
@@ -307,5 +307,5 @@ void testCasting() {
   occaJsonCastToObject(cJson2);
   ASSERT_TRUE(occaJsonIsObject(cJson2));
 
-  occaFree(cJson2);
+  occaFree(&cJson2);
 }

--- a/tests/src/c/kernel.cpp
+++ b/tests/src/c/kernel.cpp
@@ -23,7 +23,7 @@ int main(const int argc, const char **argv) {
   testInfo();
   testRun();
 
-  occaFree(addVectors);
+  occaFree(&addVectors);
 
   return 0;
 }
@@ -92,7 +92,7 @@ void testRun() {
                     "argKernel",
                     kernelProps)
   );
-  occaFree(kernelProps);
+  occaFree(&kernelProps);
 
   // Dummy dims
   occaDim outerDims, innerDims;

--- a/tests/src/c/memory.cpp
+++ b/tests/src/c/memory.cpp
@@ -72,9 +72,9 @@ void testInit() {
   ASSERT_EQ(ptr[0], 1);
   ASSERT_EQ(ptr[1], 2);
 
-  occaFree(props);
-  occaFree(subMem);
-  occaFree(mem);
+  occaFree(&props);
+  occaFree(&subMem);
+  occaFree(&mem);
 
   delete [] data;
 }
@@ -117,7 +117,7 @@ void testUvaMethods() {
   occaMemorySyncToDevice(mem, occaAllBytes, 0);
   occaMemorySyncToHost(mem, occaAllBytes, 0);
 
-  occaFree(mem);
+  occaFree(&mem);
 }
 
 void testCopyMethods() {
@@ -190,8 +190,8 @@ void testCopyMethods() {
                    props);
   ASSERT_EQ(ptr2[1], 1);
 
-  occaFree(mem2);
-  occaFree(mem4);
+  occaFree(&mem2);
+  occaFree(&mem4);
 
   // UVA memory copy
   int *o_data2 = (int*) occaUMalloc(bytes2, data2, occaDefault);
@@ -228,7 +228,7 @@ void testCopyMethods() {
   delete [] data4;
   occaFreeUvaPtr(o_data2);
   occaFreeUvaPtr(o_data4);
-  occaFree(props);
+  occaFree(&props);
 }
 
 void testInteropMethods() {
@@ -275,7 +275,7 @@ void testInteropMethods() {
                            bytes,
                            props);
 
-  occaFree(mem1);
-  occaFree(mem2);
-  occaFree(props);
+  occaFree(&mem1);
+  occaFree(&mem2);
+  occaFree(&props);
 }

--- a/tests/src/c/properties.cpp
+++ b/tests/src/c/properties.cpp
@@ -27,7 +27,7 @@ int main(const int argc, const char **argv) {
   testKeyMiss();
   testSerialization();
 
-  occaFree(cProps);
+  occaFree(&cProps);
 
   return 0;
 }
@@ -127,7 +127,7 @@ void testTypes() {
   ASSERT_TRUE(occaJsonIsObject(propValue));
   ASSERT_TRUE(occaJsonObjectHas(propValue, "value"));
 
-  occaFree(cProps2);
+  occaFree(&cProps2);
 }
 
 void testBadType() {
@@ -175,7 +175,7 @@ void testSerialization() {
   ASSERT_EQ(props,
             props2);
 
-  occaFree(cProps2);
+  occaFree(&cProps2);
 }
 
 void testCasting() {
@@ -196,5 +196,5 @@ void testCasting() {
   occaJsonCastToObject(cProps2);
   ASSERT_TRUE(occaJsonIsObject(cProps2));
 
-  occaFree(cProps2);
+  occaFree(&cProps2);
 }

--- a/tests/src/c/types.cpp
+++ b/tests/src/c/types.cpp
@@ -18,7 +18,7 @@ void testNewOccaTypes() {
   do {                                          \
     occaType v = occa::c::newOccaType(VALUE);   \
     ASSERT_EQ(v.type, OCCA_TYPE);               \
-    occaFree(v);                                \
+    occaFree(&v);                                \
   } while (0)
 
   occaType value = occaUndefined;
@@ -46,13 +46,13 @@ void testNewOccaTypes() {
   {
     occaType v = occa::c::newOccaType(*(new occa::properties()), true);
     ASSERT_EQ(v.type, OCCA_PROPERTIES);
-    occaFree(v);
+    occaFree(&v);
   }
   {
     occa::properties props;
     occaType v = occa::c::newOccaType(props, false);
     ASSERT_EQ(v.type, OCCA_PROPERTIES);
-    occaFree(v);
+    occaFree(&v);
   }
 
   occaProperties cProps = (
@@ -63,7 +63,7 @@ void testNewOccaTypes() {
             1);
   ASSERT_EQ((int) props["b"],
             2);
-  occaFree(cProps);
+  occaFree(&cProps);
 
 #undef TEST_OCCA_TYPE
 }


### PR DESCRIPTION
## Description

`occaFree` used to take an `occaType` argument by value which didn't properly set the magic headers to `undefined` afterwards. This changes the function signature from

```c
void occaFree(occaType value);
```

->

```c
void occaFree(occaType *value);
```

<!-- Thank you for contributing! -->
