### PR TITLE
[Core] Tweak behaviour of isSafeToRmrf

### DIFF
--- a/src/tools/sys.cpp
+++ b/src/tools/sys.cpp
@@ -272,9 +272,13 @@ namespace occa {
       int depth = 0;
 
       strVector path = split(expFilename, '/', '\0');
+      bool foundOcca = false;
       const int pathSize = (int) path.size();
       for (int i = 0; i < pathSize; ++i) {
         const std::string &dir = path[i];
+
+        foundOcca |= dir == "occa" || dir == ".occa";
+
         if (!dir.size() ||
             (dir == ".")) {
           continue;
@@ -286,7 +290,7 @@ namespace occa {
         }
       }
 
-      return depth > 2;
+      return depth > 1 && foundOcca;
     }
 
     int mkdir(const std::string &dir) {

--- a/tests/src/tools/sys.cpp
+++ b/tests/src/tools/sys.cpp
@@ -17,12 +17,13 @@ int main(const int argc, const char **argv) {
 }
 
 void testRmrf() {
-  ASSERT_TRUE(occa::sys::isSafeToRmrf("/a/b/c"));
-  ASSERT_TRUE(occa::sys::isSafeToRmrf("/a/b/../b/c"));
-  ASSERT_TRUE(occa::sys::isSafeToRmrf("/../../../../../a/b/c"));
-  ASSERT_TRUE(occa::sys::isSafeToRmrf("~/c"));
+  ASSERT_TRUE(occa::sys::isSafeToRmrf("/a/occa/b"));
+  ASSERT_TRUE(occa::sys::isSafeToRmrf("/a/b/../b/.occa"));
+  ASSERT_TRUE(occa::sys::isSafeToRmrf("/../../../../../occa/a/b"));
+  ASSERT_TRUE(occa::sys::isSafeToRmrf("~/c/.cache/occa"));
   ASSERT_TRUE(occa::sys::isSafeToRmrf("occa://lib"));
 
+  ASSERT_FALSE(occa::sys::isSafeToRmrf("/occa/a/.."));
   ASSERT_FALSE(occa::sys::isSafeToRmrf("/a/b/c/.."));
   ASSERT_FALSE(occa::sys::isSafeToRmrf("/a/b/c/../"));
   ASSERT_FALSE(occa::sys::isSafeToRmrf("/../../../../../a/b"));


### PR DESCRIPTION
A path is now considered safe to remove if any component of
it is 'occa' or '.occa', and if the final depth > 1.

## Description

Attempts to fix #326 .


<!-- Thank you for contributing! -->
