### PR TITLE
[Build] Add -march=native to GCC/LLVM flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,14 @@ jobs:
             CC: gcc-8
             CXX: g++-8
             OCCA_COVERAGE: 1
+            OCCA_CI_FIX_GCC_FLAGS: 1
 
           - name: (Ubuntu) gcc-9
             os: ubuntu-18.04
             CC: gcc-9
             CXX: g++-9
             OCCA_COVERAGE: 1
+            OCCA_CI_FIX_GCC_FLAGS: 1
 
           - name: (Ubuntu) clang-6
             os: ubuntu-18.04
@@ -54,6 +56,7 @@ jobs:
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
       OCCA_COVERAGE: ${{ matrix.OCCA_COVERAGE }}
+      OCCA_CI_FIX_GCC_FLAGS: ${{ matrix.OCCA_CI_FIX_GCC_FLAGS }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Compiler info
+      run: make -j info
+
     - name: Compile library
       run: make -j
 

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,7 @@ info:
 	$(info LDFLAGS        = $(or $(LDFLAGS),(empty)))
 	$(info --------------------------------)
 	$(info compiler       = $(value compiler))
+	$(info vendor         = $(vendor))
 	$(info compilerFlags  = $(compilerFlags))
 	$(info flags          = $(flags))
 	$(info paths          = $(paths))

--- a/include/occa/scripts/shellTools.sh
+++ b/include/occa/scripts/shellTools.sh
@@ -381,13 +381,13 @@ function compilerReleaseFlags {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM)   echo " -O3 -D __extern_always_inline=inline"     ;;
-        INTEL)      echo " -O3 -xHost"                               ;;
-        CRAY)       echo " -O3 -h intrinsics -fast"                  ;;
-        IBM)        echo " -O3 -qhot=simd"                           ;;
-        PGI)        echo " -O3 -fast -Mipa=fast,inline -Msmartalloc" ;;
-        PATHSCALE)  echo " -O3 -march=auto"                          ;;
-        HP)         echo " +O3"                                      ;;
+        GCC|LLVM)   echo " -O3 -march=native -D __extern_always_inline=inline" ;;
+        INTEL)      echo " -O3 -xHost"                                         ;;
+        CRAY)       echo " -O3 -h intrinsics -fast"                            ;;
+        IBM)        echo " -O3 -qhot=simd"                                     ;;
+        PGI)        echo " -O3 -fast -Mipa=fast,inline -Msmartalloc"           ;;
+        PATHSCALE)  echo " -O3 -march=auto"                                    ;;
+        HP)         echo " +O3"                                                ;;
         *)          ;;
     esac
 }

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -170,6 +170,16 @@ cpp11Flags   = $(call compilerCpp11Flags)
 picFlag      = $(call compilerPicFlag)
 sharedFlag   = $(call compilerSharedFlag)
 pthreadFlag  = $(call compilerPthreadFlag)
+
+# Workaround for Continuous Integration tests on Ubuntu using GCC 8 and 9.
+ifdef CI
+  ifneq (,$(findstring $(GITHUB_WORKFLOW),'(Ubuntu) gcc-8'-'(Ubuntu) gcc-9'))
+    releaseFlags := $(filter-out -march=native,$(releaseFlags))
+  endif
+  # DEBUG
+  $(info 'GCC w/o -march=native: ' $(shell g++               -Q --help=target | egrep -- '-march=|-mtune'))
+  $(info 'GCC w/  -march=native: ' $(shell g++ -march=native -Q --help=target | egrep -- '-march=|-mtune'))
+endif
 #=================================================
 
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -150,6 +150,7 @@ endif
 libraryFlagsFor = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; libraryFlags "$1")
 includeFlagsFor = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; headerFlags  "$1")
 
+compilerVendor       = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerVendor       "$(compiler)")
 compilerReleaseFlags = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerReleaseFlags "$(compiler)")
 compilerDebugFlags   = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerDebugFlags   "$(compiler)")
 compilerCpp11Flags   = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerCpp11Flags   "$(compiler)")
@@ -164,6 +165,7 @@ compilerOpenMPFlag     = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.s
 
 
 #---[ Compiler Info ]-----------------------------
+vendor       = $(call compilerVendor)
 debugFlags   = $(call compilerDebugFlags)
 releaseFlags = $(call compilerReleaseFlags)
 cpp11Flags   = $(call compilerCpp11Flags)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -171,8 +171,13 @@ picFlag      = $(call compilerPicFlag)
 sharedFlag   = $(call compilerSharedFlag)
 pthreadFlag  = $(call compilerPthreadFlag)
 
-# Workaround for Continuous Integration tests on Ubuntu using GCC 8 and 9.
-ifdef CI
+# Workaround for GitHub Actions CI tests on Ubuntu using GCC 8 and 9.
+# https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
+$(info GITHUB_ACTIONS  = $(GITHUB_ACTIONS))
+$(info GITHUB_ACTION   = $(GITHUB_ACTION))
+$(info GITHUB_WORKFLOW = $(GITHUB_WORKFLOW))
+$(info GITHUB_RUN_ID   = $(GITHUB_RUN_ID))
+ifdef GITHUB_ACTIONS
   ifneq (,$(findstring $(GITHUB_WORKFLOW),'(Ubuntu) gcc-8'-'(Ubuntu) gcc-9'))
     releaseFlags := $(filter-out -march=native,$(releaseFlags))
   endif

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -173,17 +173,10 @@ pthreadFlag  = $(call compilerPthreadFlag)
 
 # Workaround for GitHub Actions CI tests on Ubuntu using GCC 8 and 9.
 # https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
-$(info GITHUB_ACTIONS  = $(GITHUB_ACTIONS))
-$(info GITHUB_ACTION   = $(GITHUB_ACTION))
-$(info GITHUB_WORKFLOW = $(GITHUB_WORKFLOW))
-$(info GITHUB_RUN_ID   = $(GITHUB_RUN_ID))
 ifdef GITHUB_ACTIONS
-  ifneq (,$(findstring $(GITHUB_WORKFLOW),'(Ubuntu) gcc-8'-'(Ubuntu) gcc-9'))
+  ifeq ($(OCCA_CI_FIX_GCC_FLAGS),1)
     releaseFlags := $(filter-out -march=native,$(releaseFlags))
   endif
-  # DEBUG
-  $(info 'GCC w/o -march=native: ' $(shell g++               -Q --help=target | egrep -- '-march=|-mtune'))
-  $(info 'GCC w/  -march=native: ' $(shell g++ -march=native -Q --help=target | egrep -- '-march=|-mtune'))
 endif
 #=================================================
 


### PR DESCRIPTION
## Description

This adds the `-march=native` option to the GCC/LLVM flags, similar to the options for INTEL, PGI, PATHSCALE, and others.


<!-- Thank you for contributing! -->
