### PR TITLE
[Build] Fix compiler flags for OpenMP

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -230,13 +230,11 @@ endif
 #---[ OpenMP ]--------------------------
 ifdef OCCA_OPENMP_ENABLED
   openmpEnabled  = $(OCCA_OPENMP_ENABLED)
-  fOpenmpEnabled = $(OCCA_OPENMP_ENABLED)
 else
   openmpEnabled  = $(call compilerSupportsOpenMP)
-
-  ifeq ($(openmpEnabled),1)
-    flags += $(call compilerOpenMPFlag)
-  endif
+endif
+ifeq ($(openmpEnabled),1)
+  flags += $(call compilerOpenMPFlag)
 endif
 
 


### PR DESCRIPTION
## Description

This fixes the compiler flags for OpenMP in case `OCCA_OPENMP_ENABLED` was specified explicitly. Previously, the following would fail with a linker errror:
``` sh
make OCCA_OPENMP_ENABLED=1
```


<!-- Thank you for contributing! -->
