### PR TITLE
[Build] Clean paths variable in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ $(COMPILED_DEFINES_CHANGED):
 #  ---[ libocca ]-------------
 $(libPath)/libocca.$(soExt):$(objects) $(headers) $(COMPILED_DEFINES)
 	mkdir -p $(libPath)
-	$(compiler) $(compilerFlags) $(sharedFlag) $(pthreadFlag) $(soNameFlag) -o $(libPath)/libocca.$(soExt) $(flags) $(objects) $(paths) $(filter-out -locca, $(linkerFlags))
+	$(compiler) $(compilerFlags) $(sharedFlag) $(pthreadFlag) $(soNameFlag) -o $(libPath)/libocca.$(soExt) $(flags) $(objects) $(paths) $(linkerFlags)
 
 $(binPath)/occa:$(OCCA_DIR)/bin/occa.cpp $(libPath)/libocca.$(soExt) $(COMPILED_DEFINES_CHANGED)
 	@mkdir -p $(binPath)

--- a/examples/c/01_add_vectors/Makefile
+++ b/examples/c/01_add_vectors/Makefile
@@ -13,7 +13,7 @@ sources = $(wildcard $(srcPath)/*.cpp)
 objects = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.c
-	$(cCompiler) $(cCompilerFlags) -Wno-variadic-macros -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.c $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(cCompiler) $(cCompilerFlags) -Wno-variadic-macros -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.c $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -Wno-variadic-macros -o $@ $(flags) -c $(paths) $<

--- a/examples/c/02_background_device/Makefile
+++ b/examples/c/02_background_device/Makefile
@@ -13,7 +13,7 @@ sources = $(wildcard $(srcPath)/*.cpp)
 objects = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.c
-	$(cCompiler) $(cCompilerFlags) -Wno-variadic-macros -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.c $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(cCompiler) $(cCompilerFlags) -Wno-variadic-macros -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.c $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -Wno-variadic-macros -o $@ $(flags) -c $(paths) $<

--- a/examples/c/03_inline_okl/Makefile
+++ b/examples/c/03_inline_okl/Makefile
@@ -13,7 +13,7 @@ sources = $(wildcard $(srcPath)/*.cpp)
 objects = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.c
-	$(cCompiler) $(cCompilerFlags) -Wno-variadic-macros -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.c $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(cCompiler) $(cCompilerFlags) -Wno-variadic-macros -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.c $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -Wno-variadic-macros -o $@ $(flags) -c $(paths) $<

--- a/examples/c/04_reduction/Makefile
+++ b/examples/c/04_reduction/Makefile
@@ -13,7 +13,7 @@ sources = $(wildcard $(srcPath)/*.cpp)
 objects = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.c
-	$(cCompiler) $(cCompilerFlags) -Wno-variadic-macros -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.c $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(cCompiler) $(cCompilerFlags) -Wno-variadic-macros -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.c $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -Wno-variadic-macros -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/01_add_vectors/Makefile
+++ b/examples/cpp/01_add_vectors/Makefile
@@ -16,7 +16,7 @@ objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 executables: ${PROJ_DIR}/main
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/02_background_device/Makefile
+++ b/examples/cpp/02_background_device/Makefile
@@ -16,7 +16,7 @@ objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 executables: ${PROJ_DIR}/main
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/03_inline_okl/Makefile
+++ b/examples/cpp/03_inline_okl/Makefile
@@ -16,7 +16,7 @@ objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 executables: ${PROJ_DIR}/main
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/04_reduction/Makefile
+++ b/examples/cpp/04_reduction/Makefile
@@ -16,7 +16,7 @@ objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 executables: ${PROJ_DIR}/main
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/05_building_kernels/Makefile
+++ b/examples/cpp/05_building_kernels/Makefile
@@ -16,7 +16,7 @@ objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 executables: ${PROJ_DIR}/main
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/06_unified_memory/Makefile
+++ b/examples/cpp/06_unified_memory/Makefile
@@ -16,7 +16,7 @@ objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 executables: ${PROJ_DIR}/main
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/07_dtypes/Makefile
+++ b/examples/cpp/07_dtypes/Makefile
@@ -16,7 +16,7 @@ objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 executables: ${PROJ_DIR}/main
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/08_arrays/Makefile
+++ b/examples/cpp/08_arrays/Makefile
@@ -16,7 +16,7 @@ objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 executables: ${PROJ_DIR}/main
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/09_streams/Makefile
+++ b/examples/cpp/09_streams/Makefile
@@ -16,7 +16,7 @@ objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 executables: ${PROJ_DIR}/main
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/10_mpi/Makefile
+++ b/examples/cpp/10_mpi/Makefile
@@ -16,7 +16,7 @@ objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 executables: ${PROJ_DIR}/main
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/11_native_cpp_kernels/Makefile
+++ b/examples/cpp/11_native_cpp_kernels/Makefile
@@ -12,7 +12,7 @@ sources = $(wildcard $(srcPath)/*.cpp)
 objects = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/12_native_c_kernels/Makefile
+++ b/examples/cpp/12_native_c_kernels/Makefile
@@ -12,7 +12,7 @@ sources = $(wildcard $(srcPath)/*.cpp)
 objects = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/13_native_cuda_kernels/Makefile
+++ b/examples/cpp/13_native_cuda_kernels/Makefile
@@ -12,7 +12,7 @@ sources = $(wildcard $(srcPath)/*.cpp)
 objects = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/14_native_opencl_kernels/Makefile
+++ b/examples/cpp/14_native_opencl_kernels/Makefile
@@ -12,7 +12,7 @@ sources = $(wildcard $(srcPath)/*.cpp)
 objects = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/15_openmp_interop/Makefile
+++ b/examples/cpp/15_openmp_interop/Makefile
@@ -16,7 +16,7 @@ executables = ${PROJ_DIR}/main
 all: $(executables)
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/16_cuda_interop/Makefile
+++ b/examples/cpp/16_cuda_interop/Makefile
@@ -18,7 +18,7 @@ executables = ${PROJ_DIR}/main
 all: $(executables)
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/17_opencl_interop/Makefile
+++ b/examples/cpp/17_opencl_interop/Makefile
@@ -16,7 +16,7 @@ executables = ${PROJ_DIR}/main
 all: $(executables)
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/18_finite_difference/Makefile
+++ b/examples/cpp/18_finite_difference/Makefile
@@ -26,7 +26,7 @@ objects = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 flags += -I$(PROJ_DIR)/include
 
 ${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/examples/cpp/19_mandelbulb/Makefile
+++ b/examples/cpp/19_mandelbulb/Makefile
@@ -36,7 +36,7 @@ sources = $(wildcard $(srcPath)/*.cpp)
 objects = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
 
 ${PROJ_DIR}/main: $(objPath) $(objects) $(headers) ${PROJ_DIR}/main.cpp
-	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) -L${OCCA_DIR}/lib $(linkerFlags)
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
 
 $(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -122,12 +122,17 @@ linkerFlags = $(LDFLAGS)
 
 
 #---[ Paths/Flags ]-------------------------------
-paths = -I$(OCCA_DIR)/include
+# OCCA (global) include and library paths
+paths  = -I$(OCCA_DIR)/include
+paths += -L$(OCCA_DIR)/lib
+
+# Extra (user-supplied) include and library paths
 paths += $(foreach path, $(subst :, ,$(OCCA_INCLUDE_PATH)), -I$(path))
 paths += $(foreach path, $(subst :, ,$(OCCA_LIBRARY_PATH)), -L$(path))
 
-ifneq (,$(wildcard ./$(incPath)/*))
-  paths += -I./$(incPath)
+# Project (local) include path
+ifneq (,$(strip $(wildcard $(incPath)/*)))
+  paths += -I$(incPath)
 endif
 
 linkerFlags += -locca


### PR DESCRIPTION
## Description

The `paths` variable (defined in `scripts/Makefile`) did not include `-L$(OCCA_DIR)/lib` and the logic around including `-I$(incPath)` was broken. The former issue was especially confusing given the comments in the project [`Makefile`](https://github.com/libocca/occa/blob/f906041240eb36e51b80ba542682975314db03a4/Makefile#L26)

This PR fixes both issues and modifies the project and example Makefiles accordingly. 

All tests passed on my local machine (Fedora Linux using GCC 9).

<!-- Thank you for contributing! -->
