### PR TITLE
[Build][CI] Add -march=native for gcc and fix CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Compiler info
+      run: make -j info
+
     - name: Compile library
       run: make -j
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,10 @@ jobs:
             CXX: clang++-9
             OCCA_COVERAGE: 0
 
-          - name: (MacOS) gcc
+          - name: (MacOS) gcc-9
             os: macos-10.15
-            CC: gcc
-            CXX: g++
+            CC: gcc-9
+            CXX: g++-9
             OCCA_COVERAGE: 1
 
           - name: (MacOS) clang

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,7 @@ info:
 	$(info LDFLAGS        = $(or $(LDFLAGS),(empty)))
 	$(info --------------------------------)
 	$(info compiler       = $(value compiler))
+	$(info vendor         = $(vendor))
 	$(info compilerFlags  = $(compilerFlags))
 	$(info flags          = $(flags))
 	$(info paths          = $(paths))

--- a/include/occa/scripts/shellTools.sh
+++ b/include/occa/scripts/shellTools.sh
@@ -381,13 +381,13 @@ function compilerReleaseFlags {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM)   echo " -O3 -D __extern_always_inline=inline"     ;;
-        INTEL)      echo " -O3 -xHost"                               ;;
-        CRAY)       echo " -O3 -h intrinsics -fast"                  ;;
-        IBM)        echo " -O3 -qhot=simd"                           ;;
-        PGI)        echo " -O3 -fast -Mipa=fast,inline -Msmartalloc" ;;
-        PATHSCALE)  echo " -O3 -march=auto"                          ;;
-        HP)         echo " +O3"                                      ;;
+        GCC|LLVM)   echo " -O3 -march=native -D __extern_always_inline=inline" ;;
+        INTEL)      echo " -O3 -xHost"                                         ;;
+        CRAY)       echo " -O3 -h intrinsics -fast"                            ;;
+        IBM)        echo " -O3 -qhot=simd"                                     ;;
+        PGI)        echo " -O3 -fast -Mipa=fast,inline -Msmartalloc"           ;;
+        PATHSCALE)  echo " -O3 -march=auto"                                    ;;
+        HP)         echo " +O3"                                                ;;
         *)          ;;
     esac
 }

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -150,6 +150,7 @@ endif
 libraryFlagsFor = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; libraryFlags "$1")
 includeFlagsFor = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; headerFlags  "$1")
 
+compilerVendor       = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerVendor       "$(compiler)")
 compilerReleaseFlags = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerReleaseFlags "$(compiler)")
 compilerDebugFlags   = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerDebugFlags   "$(compiler)")
 compilerCpp11Flags   = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerCpp11Flags   "$(compiler)")
@@ -164,6 +165,7 @@ compilerOpenMPFlag     = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.s
 
 
 #---[ Compiler Info ]-----------------------------
+vendor       = $(call compilerVendor)
 debugFlags   = $(call compilerDebugFlags)
 releaseFlags = $(call compilerReleaseFlags)
 cpp11Flags   = $(call compilerCpp11Flags)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -172,6 +172,15 @@ cpp11Flags   = $(call compilerCpp11Flags)
 picFlag      = $(call compilerPicFlag)
 sharedFlag   = $(call compilerSharedFlag)
 pthreadFlag  = $(call compilerPthreadFlag)
+
+# Workaround for GitHub Actions CI tests on Ubuntu using GCC.
+ifdef GITHUB_ACTIONS
+  ifeq ($(usingLinux),1)
+    ifeq ($(vendor),GCC)
+      releaseFlags := $(filter-out -march=native,$(releaseFlags))
+    endif
+  endif
+endif
 #=================================================
 
 


### PR DESCRIPTION
## Description

This PR adds the `-march=native` option to the GCC/LLVM flags, similar to the options for INTEL, PGI, PATHSCALE, and others. This supersedes PR #334 and contains a proper workaround for the CI tests on Ubuntu using GCC.

This also includes minor changes in order to print out the compiler vendor in the CI tests, and contains further a fix for the MacOS runs with GCC.


<!-- Thank you for contributing! -->
