### PR TITLE
Add Fortran interface

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
       FC: ${{ matrix.FC }}
       OCCA_COVERAGE: ${{ matrix.OCCA_COVERAGE }}
       OCCA_FORTRAN_ENABLED: ${{ matrix.OCCA_FORTRAN_ENABLED }}
+      FORTRAN_EXAMPLES: ${{ matrix.OCCA_FORTRAN_ENABLED }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
     env:
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
+      FC: ${{ matrix.FC }}
       OCCA_COVERAGE: ${{ matrix.OCCA_COVERAGE }}
       OCCA_FORTRAN_ENABLED: ${{ matrix.OCCA_FORTRAN_ENABLED }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,17 @@ jobs:
             os: ubuntu-18.04
             CC: gcc-8
             CXX: g++-8
+            FC: gfortran-8
             OCCA_COVERAGE: 1
+            OCCA_FORTRAN_ENABLED: 1
 
           - name: (Ubuntu) gcc-9
             os: ubuntu-18.04
             CC: gcc-9
             CXX: g++-9
+            FC: gfortran-9
             OCCA_COVERAGE: 1
+            OCCA_FORTRAN_ENABLED: 1
 
           - name: (Ubuntu) clang-6
             os: ubuntu-18.04
@@ -54,6 +58,7 @@ jobs:
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
       OCCA_COVERAGE: ${{ matrix.OCCA_COVERAGE }}
+      OCCA_FORTRAN_ENABLED: ${{ matrix.OCCA_FORTRAN_ENABLED }}
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ $(OCCA_DIR)/obj/%.o:$(OCCA_DIR)/src/%.cpp $(COMPILED_DEFINES_CHANGED)
 	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<
 
 # Fortran sources
+include $(OCCA_DIR)/scripts/Make.fortran_rules
 $(OCCA_DIR)/obj/%.o:$(OCCA_DIR)/src/%.f90
 	@mkdir -p $(modPath)
 	@mkdir -p $(abspath $(dir $@))

--- a/examples/fortran/01_add_vectors/Makefile
+++ b/examples/fortran/01_add_vectors/Makefile
@@ -1,0 +1,24 @@
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifndef OCCA_DIR
+  OCCA_DIR=$(PROJ_DIR)/../../..
+endif
+include $(OCCA_DIR)/scripts/Makefile
+
+
+#---[ COMPILATION ]-------------------------------
+all: main
+
+%: %.f90
+	@mkdir -p $(abspath $(dir $@))
+	$(fCompiler) $(fCompilerFlags) -o $@ $^ $(flags) $(fPaths) $(fLinkerFlags)
+
+clean:
+	rm -rf $(PROJ_DIR)/main
+#=================================================
+
+
+#---[ RUN ]---------------------------------------
+run: main
+	$(PROJ_DIR)/main --verbose
+#=================================================

--- a/examples/fortran/01_add_vectors/addVectors.okl
+++ b/examples/fortran/01_add_vectors/addVectors.okl
@@ -1,0 +1,8 @@
+@kernel void addVectors(const int entries,
+                        const float *a,
+                        const float *b,
+                        float *ab) {
+  for (int i = 0; i < entries; ++i; @tile(16, @outer, @inner)) {
+    ab[i] = a[i] + b[i];
+  }
+}

--- a/examples/fortran/01_add_vectors/main.f90
+++ b/examples/fortran/01_add_vectors/main.f90
@@ -1,0 +1,121 @@
+program main
+  use occa
+
+  implicit none
+
+  integer :: alloc_err, i
+  integer(occaUDim_t) :: entries = 5
+  character(len=1024) :: arg, info
+
+  real(C_float), allocatable, target :: a(:), b(:), ab(:)
+
+  ! OCCA device, kernel, memory and property objects
+  type(occaDevice)     :: device
+  type(occaKernel)     :: addVectors
+  type(occaMemory)     :: o_a, o_b, o_ab
+  type(occaProperties) :: props
+
+  ! Set default OCCA device info
+  info = "mode: 'Serial'"
+  !info = "mode: 'OpenMP', schedule: 'compact', chunk: 10"
+  !info = "mode: 'CUDA'  , device_id: 0"
+  !info = "mode: 'OpenCL', platform_id: 0, device_id: 0"
+
+  ! Parse command arguments
+  i = 1
+  do while (i .le. command_argument_count())
+    call get_command_argument(i, arg)
+
+    select case (arg)
+      case ("-v", "--verbose")
+        call occaPropertiesSet(occaSettings(), "kernel/verbose", occaTrue)
+      case ("-d", "--device")
+        i = i+1
+        call get_command_argument(i, info)
+      case ("-h", "--help")
+        call print_help()
+        stop
+      case default
+        write(*,'(2a, /)') "Unrecognised command-line option: ", arg
+        stop
+    end select
+    i = i+1
+  end do
+
+  ! Allocate host memory
+  allocate(a(1:entries), b(1:entries), ab(1:entries), stat=alloc_err)
+  if (alloc_err /= 0) stop "*** Not enough memory ***"
+
+  ! Initialise host arrays
+  do i=1,entries
+    a(i) = real(i)-1
+    b(i) = 2-real(i)
+  end do
+  ab = 0
+
+  ! Print device infos
+  call occaPrintModeInfo()
+
+  ! Create OCCA device
+  device = occaCreateDeviceFromString(F_C_str(info))
+
+  ! Print device mode
+  write(*,'(a,a)') "occaDeviceMode: ", C_F_str(occaDeviceMode(device))
+
+  ! Allocate memory on the device
+  o_a  = occaDeviceTypedMalloc(device, entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  o_b  = occaDeviceTypedMalloc(device, entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+
+  ! We can also allocate memory without a dtype
+  ! WARNING: This will disable runtime type checking
+  o_ab = occaDeviceMalloc(device, entries*C_float, C_NULL_ptr, occaDefault)
+
+  ! Setup properties that can be passed to the kernel
+  props = occaCreateProperties()
+  call occaPropertiesSet(props, F_C_str("defines/TILE_SIZE"), occaInt(10))
+
+  ! Compile the kernel at run-time
+  addVectors = occaDeviceBuildKernel(device, &
+                                     F_C_str("addVectors.okl"), &
+                                     F_C_str("addVectors"), &
+                                     props)
+
+  ! Copy memory to the device
+  call occaCopyPtrToMem(o_a, C_loc(a), entries*C_float, 0_occaUDim_t, occaDefault)
+  call occaCopyPtrToMem(o_b, C_loc(b), occaAllBytes   , 0_occaUDim_t, occaDefault)
+
+  ! Launch device kernel
+  call occaKernelRun(addVectors, occaInt(entries), o_a, o_b, o_ab)
+
+  ! Copy result to the host
+  call occaCopyMemToPtr(C_loc(ab), o_ab, occaAllBytes, 0_occaUDim_t, occaDefault)
+
+  ! Assert values
+  do i=1,entries
+    write(*,'(a,i2,a,f3.1)') "ab(", i, ") = ", ab(i)
+  end do
+  do i=1,entries
+    if (ab(i) .ne. (a(i) + b(i))) stop "*** Wrong result ***"
+  end do
+
+  ! Free host memory
+  deallocate(a, b, ab, stat=alloc_err)
+  if (alloc_err /= 0) stop "*** Deallocation not successful ***"
+
+  ! Free device memory and OCCA objects
+  call occaFree(props)
+  call occaFree(addVectors)
+  call occaFree(o_a)
+  call occaFree(o_b)
+  call occaFree(o_ab)
+  call occaFree(device)
+
+contains
+  subroutine print_help()
+    write(*,'(a, /)') "Example adding two vectors"
+    write(*,'(a, /)') "command-line options:"
+    write(*,'(a)')    "  -v, --verbose     Compile kernels in verbose mode"
+    write(*,'(a)')    "  -d, --device      Device properties (default: ""mode: 'Serial'"")"
+    write(*,'(a)')    "  -h, --help        Print this information and exit"
+  end subroutine print_help
+end program main

--- a/examples/fortran/02_background_device/Makefile
+++ b/examples/fortran/02_background_device/Makefile
@@ -1,0 +1,24 @@
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifndef OCCA_DIR
+  OCCA_DIR=$(PROJ_DIR)/../../..
+endif
+include $(OCCA_DIR)/scripts/Makefile
+
+
+#---[ COMPILATION ]-------------------------------
+all: main
+
+%: %.f90
+	@mkdir -p $(abspath $(dir $@))
+	$(fCompiler) $(fCompilerFlags) -o $@ $^ $(flags) $(fPaths) $(fLinkerFlags)
+
+clean:
+	rm -rf $(PROJ_DIR)/main
+#=================================================
+
+
+#---[ RUN ]---------------------------------------
+run: main
+	$(PROJ_DIR)/main --verbose
+#=================================================

--- a/examples/fortran/02_background_device/addVectors.okl
+++ b/examples/fortran/02_background_device/addVectors.okl
@@ -1,0 +1,8 @@
+@kernel void addVectors(const int entries,
+                        const float *a,
+                        const float *b,
+                        float *ab) {
+  for (int i = 0; i < entries; ++i; @tile(16, @outer, @inner)) {
+    ab[i] = a[i] + b[i];
+  }
+}

--- a/examples/fortran/02_background_device/main.f90
+++ b/examples/fortran/02_background_device/main.f90
@@ -1,0 +1,115 @@
+program main
+  use, intrinsic :: iso_c_binding, &
+      C_void_ptr => C_ptr
+  use occa
+
+  implicit none
+
+  integer :: i
+  integer(occaUDim_t) :: entries = 5
+  character(len=1024) :: arg, info
+
+  ! OCCA device, kernel, memory and property objects
+  type(occaKernel)     :: addVectors
+  type(C_void_ptr)     :: a, b, ab
+  real(C_float), pointer :: a_ptr(:), b_ptr(:), ab_ptr(:)
+
+  ! Set default OCCA device info
+  info = "mode: 'Serial'"
+  !info = "mode: 'OpenMP', schedule: 'compact', chunk: 10"
+  !info = "mode: 'CUDA'  , device_id: 0"
+  !info = "mode: 'OpenCL', platform_id: 0, device_id: 0"
+
+  ! Parse command arguments
+  i = 1
+  do while (i .le. command_argument_count())
+    call get_command_argument(i, arg)
+
+    select case (arg)
+      case ("-v", "--verbose")
+        call occaPropertiesSet(occaSettings(), "kernel/verbose", occaTrue)
+      case ("-d", "--device")
+        i = i+1
+        call get_command_argument(i, info)
+      case ("-h", "--help")
+        call print_help()
+        stop
+      case default
+        write(*,'(2a, /)') "Unrecognised command-line option: ", arg
+        stop
+    end select
+    i = i+1
+  end do
+
+  ! Print device infos
+  call occaPrintModeInfo()
+
+  ! Create OCCA device
+  call occaSetDeviceFromString(F_C_str(info))
+
+  ! umalloc: [U]nified [M]emory [Alloc]ation
+  ! Allocate host memory that auto-syncs with the device between before kernel
+  ! calls and occaFinish() if needed.
+  a  = occaTypedUMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  b  = occaTypedUMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  ab = occaTypedUMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+
+  ! Assign Fortran pointers to the (host) memory
+  if (C_associated(a)) then
+    call C_F_pointer(a,a_ptr,[entries])
+  end if
+  if (C_associated(b)) then
+    call C_F_pointer(b,b_ptr,[entries])
+  end if
+  if (C_associated(ab)) then
+    call C_F_pointer(ab,ab_ptr,[entries])
+  end if
+
+  ! Initialise host arrays
+  do i=1,entries
+    a_ptr(i) = real(i)-1
+    b_ptr(i) = 2-real(i)
+  end do
+  ab_ptr = 0
+
+  ! Compile the kernel at run-time
+  addVectors = occaBuildKernel(F_C_str("addVectors.okl"), &
+                               F_C_str("addVectors"), &
+                               occaDefault)
+
+  ! Launch device kernel
+  ! Arrays a, b, and ab are now resident on the device
+  call occaKernelRun(addVectors, occaInt(entries), occaPtr(a), occaPtr(b), occaPtr(ab))
+
+  ! a and b are const in the kernel, so we can use `dontSync` to manually force
+  ! a and b to not sync
+  call occaDontSync(a)
+  call occaDontSync(b)
+
+  ! Finish work queued up on the device, synchronizing a, b, and ab and making
+  ! it safe to use them again
+  call occaFinish()
+
+  ! Assert values
+  do i=1,entries
+    write(*,'(a,i2,a,f3.1)') "ab(", i, ") = ", ab_ptr(i)
+  end do
+  do i=1,entries
+    if (ab_ptr(i) .ne. (a_ptr(i) + b_ptr(i))) stop "*** Wrong result ***"
+  end do
+
+  ! Free device memory and OCCA objects
+  call occaFree(addVectors)
+  call occaFreeUvaPtr(a)
+  call occaFreeUvaPtr(b)
+  call occaFreeUvaPtr(ab)
+
+contains
+  subroutine print_help()
+    write(*,'(a, /)') "Example showing how to use background devices, allowing passing of the device implicitly"
+    write(*,'(a, /)') "command-line options:"
+    write(*,'(a)')    "  -v, --verbose     Compile kernels in verbose mode"
+    write(*,'(a)')    "  -d, --device      Device properties (default: ""mode: 'Serial'"")"
+    write(*,'(a)')    "  -h, --help        Print this information and exit"
+  end subroutine print_help
+end program main

--- a/examples/fortran/03_static_compilation/Makefile
+++ b/examples/fortran/03_static_compilation/Makefile
@@ -1,0 +1,39 @@
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifndef OCCA_DIR
+  OCCA_DIR=$(PROJ_DIR)/../../..
+endif
+include $(OCCA_DIR)/scripts/Makefile
+
+# The OCCA source directory
+libSrcPath = $(OCCA_DIR)/src
+
+# Here we want to statically compile the example, thus remove libocca_fortran
+# from the linker flags and set the module path to the local object directory
+fLinkerFlags := $(filter-out -locca_fortran, $(fLinkerFlags))
+fPaths += $(fModuleDirFlag)$(objPath)/fortran
+
+
+#---[ COMPILATION ]-------------------------------
+all: main
+
+main: $(fObjects)
+
+%: %.f90
+	@mkdir -p $(abspath $(dir $@))
+	$(fCompiler) $(fCompilerFlags) -o $@ $^ $(flags) $(fPaths) $(fLinkerFlags)
+
+$(objPath)/%.o: $(libSrcPath)/%.f90
+	@mkdir -p $(abspath $(dir $@))
+	$(fCompiler) $(fCompilerFlags) -o $@ $(flags) -c $(fPaths) $<
+
+clean:
+	rm -rf $(objPath)/*
+	rm -rf $(PROJ_DIR)/main
+#=================================================
+
+
+#---[ RUN ]---------------------------------------
+run: main
+	$(PROJ_DIR)/main --verbose
+#=================================================

--- a/examples/fortran/03_static_compilation/Makefile
+++ b/examples/fortran/03_static_compilation/Makefile
@@ -9,8 +9,10 @@ include $(OCCA_DIR)/scripts/Makefile
 libSrcPath = $(OCCA_DIR)/src
 
 # Here we want to statically compile the example, thus remove libocca_fortran
-# from the linker flags and set the module path to the local object directory
+# from the linker flags, the global include path from fPaths and set the module
+# path to the local object directory
 fLinkerFlags := $(filter-out -locca_fortran, $(fLinkerFlags))
+fPaths := $(filter-out -I$(subst $(PROJ_DIR),$(OCCA_DIR),$(modPath)), $(fPaths))
 fPaths += $(fModuleDirFlag)$(objPath)/fortran
 
 
@@ -18,6 +20,8 @@ fPaths += $(fModuleDirFlag)$(objPath)/fortran
 all: main
 
 main: $(fObjects)
+
+include $(OCCA_DIR)/scripts/Make.fortran_rules
 
 %: %.f90
 	@mkdir -p $(abspath $(dir $@))

--- a/examples/fortran/03_static_compilation/addVectors.okl
+++ b/examples/fortran/03_static_compilation/addVectors.okl
@@ -1,0 +1,8 @@
+@kernel void addVectors(const int entries,
+                        const float *a,
+                        const float *b,
+                        float *ab) {
+  for (int i = 0; i < entries; ++i; @tile(16, @outer, @inner)) {
+    ab[i] = a[i] + b[i];
+  }
+}

--- a/examples/fortran/03_static_compilation/main.f90
+++ b/examples/fortran/03_static_compilation/main.f90
@@ -1,0 +1,121 @@
+program main
+  use occa
+
+  implicit none
+
+  integer :: alloc_err, i
+  integer(occaUDim_t) :: entries = 5
+  character(len=1024) :: arg, info
+
+  real(C_float), allocatable, target :: a(:), b(:), ab(:)
+
+  ! OCCA device, kernel, memory and property objects
+  type(occaDevice)     :: device
+  type(occaKernel)     :: addVectors
+  type(occaMemory)     :: o_a, o_b, o_ab
+  type(occaProperties) :: props
+
+  ! Set default OCCA device info
+  info = "mode: 'Serial'"
+  !info = "mode: 'OpenMP', schedule: 'compact', chunk: 10"
+  !info = "mode: 'CUDA'  , device_id: 0"
+  !info = "mode: 'OpenCL', platform_id: 0, device_id: 0"
+
+  ! Parse command arguments
+  i = 1
+  do while (i .le. command_argument_count())
+    call get_command_argument(i, arg)
+
+    select case (arg)
+      case ("-v", "--verbose")
+        call occaPropertiesSet(occaSettings(), "kernel/verbose", occaTrue)
+      case ("-d", "--device")
+        i = i+1
+        call get_command_argument(i, info)
+      case ("-h", "--help")
+        call print_help()
+        stop
+      case default
+        write(*,'(2a, /)') "Unrecognised command-line option: ", arg
+        stop
+    end select
+    i = i+1
+  end do
+
+  ! Allocate host memory
+  allocate(a(1:entries), b(1:entries), ab(1:entries), stat=alloc_err)
+  if (alloc_err /= 0) stop "*** Not enough memory ***"
+
+  ! Initialise host arrays
+  do i=1,entries
+    a(i) = real(i)-1
+    b(i) = 2-real(i)
+  end do
+  ab = 0
+
+  ! Print device infos
+  call occaPrintModeInfo()
+
+  ! Create OCCA device
+  device = occaCreateDeviceFromString(F_C_str(info))
+
+  ! Print device mode
+  write(*,'(a,a)') "occaDeviceMode: ", C_F_str(occaDeviceMode(device))
+
+  ! Allocate memory on the device
+  o_a  = occaDeviceTypedMalloc(device, entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  o_b  = occaDeviceTypedMalloc(device, entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+
+  ! We can also allocate memory without a dtype
+  ! WARNING: This will disable runtime type checking
+  o_ab = occaDeviceMalloc(device, entries*C_float, C_NULL_ptr, occaDefault)
+
+  ! Setup properties that can be passed to the kernel
+  props = occaCreateProperties()
+  call occaPropertiesSet(props, F_C_str("defines/TILE_SIZE"), occaInt(10))
+
+  ! Compile the kernel at run-time
+  addVectors = occaDeviceBuildKernel(device, &
+                                     F_C_str("addVectors.okl"), &
+                                     F_C_str("addVectors"), &
+                                     props)
+
+  ! Copy memory to the device
+  call occaCopyPtrToMem(o_a, C_loc(a), entries*C_float, 0_occaUDim_t, occaDefault)
+  call occaCopyPtrToMem(o_b, C_loc(b), occaAllBytes   , 0_occaUDim_t, occaDefault)
+
+  ! Launch device kernel
+  call occaKernelRun(addVectors, occaInt(entries), o_a, o_b, o_ab)
+
+  ! Copy result to the host
+  call occaCopyMemToPtr(C_loc(ab), o_ab, occaAllBytes, 0_occaUDim_t, occaDefault)
+
+  ! Assert values
+  do i=1,entries
+    write(*,'(a,i2,a,f3.1)') "ab(", i, ") = ", ab(i)
+  end do
+  do i=1,entries
+    if (ab(i) .ne. (a(i) + b(i))) stop "*** Wrong result ***"
+  end do
+
+  ! Free host memory
+  deallocate(a, b, ab, stat=alloc_err)
+  if (alloc_err /= 0) stop "*** Deallocation not successful ***"
+
+  ! Free device memory and OCCA objects
+  call occaFree(props)
+  call occaFree(addVectors)
+  call occaFree(o_a)
+  call occaFree(o_b)
+  call occaFree(o_ab)
+  call occaFree(device)
+
+contains
+  subroutine print_help()
+    write(*,'(a, /)') "Example showing how to statically compile a program"
+    write(*,'(a, /)') "command-line options:"
+    write(*,'(a)')    "  -v, --verbose     Compile kernels in verbose mode"
+    write(*,'(a)')    "  -d, --device      Device properties (default: ""mode: 'Serial'"")"
+    write(*,'(a)')    "  -h, --help        Print this information and exit"
+  end subroutine print_help
+end program main

--- a/examples/fortran/04_reduction/Makefile
+++ b/examples/fortran/04_reduction/Makefile
@@ -1,0 +1,24 @@
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifndef OCCA_DIR
+  OCCA_DIR=$(PROJ_DIR)/../../..
+endif
+include $(OCCA_DIR)/scripts/Makefile
+
+
+#---[ COMPILATION ]-------------------------------
+all: main
+
+%: %.f90
+	@mkdir -p $(abspath $(dir $@))
+	$(fCompiler) $(fCompilerFlags) -o $@ $^ $(flags) $(fPaths) $(fLinkerFlags)
+
+clean:
+	rm -rf $(PROJ_DIR)/main
+#=================================================
+
+
+#---[ RUN ]---------------------------------------
+run: main
+	$(PROJ_DIR)/main --verbose
+#=================================================

--- a/examples/fortran/04_reduction/main.f90
+++ b/examples/fortran/04_reduction/main.f90
@@ -1,0 +1,111 @@
+program main
+  use occa
+
+  implicit none
+
+  integer :: alloc_err, i
+  integer(occaUDim_t), parameter :: entries = 10000
+  integer(occaUDim_t), parameter :: blk = 256
+  integer(occaUDim_t), parameter :: blks = (entries + blk - 1)/blk
+  character(len=1024) :: arg, info
+
+  real(C_float), allocatable, target :: vec(:), blockSum(:)
+  real(C_float) :: sig
+
+  ! OCCA device, kernel, memory and property objects
+  type(occaKernel)     :: reduction
+  type(occaMemory)     :: o_vec, o_blockSum
+  type(occaProperties) :: reductionProps
+
+  ! Set default OCCA device info
+  info = "mode: 'Serial'"
+  !info = "mode: 'OpenMP', schedule: 'compact', chunk: 10"
+  !info = "mode: 'CUDA'  , device_id: 0"
+  !info = "mode: 'OpenCL', platform_id: 0, device_id: 0"
+
+  ! Parse command arguments
+  i = 1
+  do while (i .le. command_argument_count())
+    call get_command_argument(i, arg)
+
+    select case (arg)
+      case ("-v", "--verbose")
+        call occaPropertiesSet(occaSettings(), "kernel/verbose", occaTrue)
+      case ("-d", "--device")
+        i = i+1
+        call get_command_argument(i, info)
+      case ("-h", "--help")
+        call print_help()
+        stop
+      case default
+        write(*,'(2a, /)') "Unrecognised command-line option: ", arg
+        stop
+    end select
+    i = i+1
+  end do
+
+  ! Allocate host memory
+  allocate(vec(1:entries), blockSum(1:blks), stat=alloc_err)
+  if (alloc_err /= 0) stop "*** Not enough memory ***"
+
+  ! Initialize host memory
+  vec = 1
+  blockSum = 0
+  sig = sum(vec)
+
+  ! Print device infos
+  call occaPrintModeInfo()
+
+  ! Create OCCA device
+  call occaSetDeviceFromString(F_C_str(info))
+
+  ! Allocate memory on the device
+  o_vec      = occaTypedMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  o_blockSum = occaTypedMalloc(blks,    occaDtypeFloat, C_NULL_ptr, occaDefault)
+
+  ! Pass value of 'block' at kernel compile-time
+  reductionProps = occaCreateProperties()
+  call occaPropertiesSet(reductionProps, F_C_str("defines/block"), occaInt(blk))
+
+  reduction = occaBuildKernel(F_C_str("reduction.okl"), &
+                              F_C_str("reduction"), &
+                              reductionProps)
+
+  ! Host -> Device
+  call occaCopyPtrToMem(o_vec, C_loc(vec), occaAllBytes, 0_occaUDim_t, occaDefault)
+
+  call occaKernelRun(reduction, occaInt(entries), o_vec, o_blockSum)
+
+  ! Host <- Device
+  call occaCopyMemToPtr(C_loc(blockSum), o_blockSum, occaAllBytes, 0_occaUDim_t, occaDefault)
+
+  blockSum(1) = sum(blockSum)
+
+  ! Validate
+  if (blockSum(1) /= sig) then
+    write(*,*) "sum      = ", sig
+    write(*,*) "blockSum = ", blockSum(1)
+    stop "*** Reduction failed ***"
+  else
+    write(*,*) "Reduction = ", blockSum(1)
+  end if
+
+  ! Free host memory
+  deallocate(vec, blockSum, stat=alloc_err)
+  if (alloc_err /= 0) stop "*** Deallocation not successful ***"
+
+  ! Free device memory and OCCA objects
+  call occaFree(reductionProps)
+  call occaFree(reduction)
+  call occaFree(o_vec)
+  call occaFree(o_blockSum)
+
+contains
+  subroutine print_help()
+    write(*,'(a, /)') "Example of a reduction kernel which sums a vector in parallel"
+    write(*,'(a, /)') "command-line options:"
+    write(*,'(a)')    "  -v, --verbose     Compile kernels in verbose mode"
+    write(*,'(a)')    "  -d, --device      Device properties (default: ""mode: 'Serial'"")"
+    write(*,'(a)')    "  -h, --help        Print this information and exit"
+  end subroutine print_help
+end program main

--- a/examples/fortran/04_reduction/reduction.okl
+++ b/examples/fortran/04_reduction/reduction.okl
@@ -1,0 +1,31 @@
+@kernel void reduction(const int entries,
+                       const float *vec,
+                       float *blockSum) {
+
+  // Partial reduction of vector using loop tiles of size block (power of 2)
+  for (int group = 0; group < ((entries + block - 1) / block); ++group; @outer) {
+    @shared float s_vec[block];
+
+    for (int item = 0; item < block; ++item; @inner) {
+      if ((group * block + item) < entries) {
+        s_vec[item] = vec[group * block + item];
+      } else {
+        s_vec[item] = 0;
+      }
+    }
+
+    for (int alive = ((block + 1) / 2); 0 < alive; alive /= 2) {
+      for (int item = 0; item < block; ++item; @inner) {
+        if (item < alive) {
+          s_vec[item] += s_vec[item + alive];
+        }
+      }
+    }
+
+    for (int item = 0; item < block; ++item; @inner) {
+      if (item == 0) {
+        blockSum[group] = s_vec[0];
+      }
+    }
+  }
+}

--- a/examples/fortran/09_streams/Makefile
+++ b/examples/fortran/09_streams/Makefile
@@ -1,0 +1,24 @@
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifndef OCCA_DIR
+  OCCA_DIR=$(PROJ_DIR)/../../..
+endif
+include $(OCCA_DIR)/scripts/Makefile
+
+
+#---[ COMPILATION ]-------------------------------
+all: main
+
+%: %.f90
+	@mkdir -p $(abspath $(dir $@))
+	$(fCompiler) $(fCompilerFlags) -o $@ $^ $(flags) $(fPaths) $(fLinkerFlags)
+
+clean:
+	rm -rf $(PROJ_DIR)/main
+#=================================================
+
+
+#---[ RUN ]---------------------------------------
+run: main
+	$(PROJ_DIR)/main --verbose
+#=================================================

--- a/examples/fortran/09_streams/addVectors.okl
+++ b/examples/fortran/09_streams/addVectors.okl
@@ -1,0 +1,8 @@
+@kernel void addVectors(const int entries,
+                        const float *a,
+                        const float *b,
+                        float *ab) {
+  for (int i = 0; i < entries; ++i; @tile(16, @outer, @inner)) {
+    ab[i] = a[i] + b[i];
+  }
+}

--- a/examples/fortran/09_streams/main.f90
+++ b/examples/fortran/09_streams/main.f90
@@ -1,0 +1,101 @@
+program main
+  use occa
+
+  implicit none
+
+  integer :: alloc_err, i
+  integer(occaUDim_t) :: entries = 5
+  character(len=1024) :: arg
+
+  real(C_float), allocatable, target :: a(:), b(:), ab(:)
+
+  ! OCCA streams, kernel, memory and property objects
+  type(occaStream)     :: streamA, streamB
+  type(occaKernel)     :: addVectors
+  type(occaMemory)     :: o_a, o_b, o_ab
+
+  ! Parse command arguments
+  i = 1
+  do while (i .le. command_argument_count())
+    call get_command_argument(i, arg)
+
+    select case (arg)
+      case ("-v", "--verbose")
+        call occaPropertiesSet(occaSettings(), "kernel/verbose", occaTrue)
+      case ("-h", "--help")
+        call print_help()
+        stop
+      case default
+        write(*,'(2a, /)') "Unrecognised command-line option: ", arg
+        stop
+    end select
+    i = i+1
+  end do
+
+  ! Allocate host memory
+  allocate(a(1:entries), b(1:entries), ab(1:entries), stat=alloc_err)
+  if (alloc_err /= 0) stop "*** Not enough memory ***"
+
+  ! Initialise host arrays
+  do i=1,entries
+    a(i) = real(i)-1
+    b(i) = 2-real(i)
+  end do
+  ab = 0
+
+  ! Print device infos
+  call occaPrintModeInfo()
+
+  ! Get/create OCCA streams
+  streamA = occaGetStream()
+  streamB = occaCreateStream(occaDefault)
+
+  ! Allocate memory on the device
+  o_a  = occaTypedMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  o_b  = occaTypedMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  o_ab = occaTypedMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+
+  addVectors = occaBuildKernel(F_C_str("addVectors.okl"), &
+                               F_C_str("addVectors"), &
+                               occaDefault)
+
+  ! Copy memory to the device
+  call occaCopyPtrToMem(o_a, C_loc(a), entries*C_float, 0_occaUDim_t, occaDefault)
+  call occaCopyPtrToMem(o_b, C_loc(b), occaAllBytes   , 0_occaUDim_t, occaDefault)
+
+  ! Set stream and launch device kernel
+  call occaSetStream(streamA)
+  call occaKernelRun(addVectors, occaInt(entries), o_a, o_b, o_ab)
+
+  call occaSetStream(streamB)
+  call occaKernelRun(addVectors, occaInt(entries), o_a, o_b, o_ab)
+
+  ! Copy result to the host
+  call occaCopyMemToPtr(C_loc(ab), o_ab, occaAllBytes, 0_occaUDim_t, occaDefault)
+
+  ! Assert values
+  do i=1,entries
+    write(*,'(a,i2,a,f3.1)') "ab(", i, ") = ", ab(i)
+  end do
+  do i=1,entries
+    if (ab(i) .ne. (a(i) + b(i))) stop "*** Wrong result ***"
+  end do
+
+  ! Free host memory
+  deallocate(a, b, ab, stat=alloc_err)
+  if (alloc_err /= 0) stop "*** Deallocation not successful ***"
+
+  ! Free device memory and OCCA objects
+  call occaFree(addVectors)
+  call occaFree(o_a)
+  call occaFree(o_b)
+  call occaFree(o_ab)
+
+contains
+  subroutine print_help()
+    write(*,'(a, /)') "Example showing the use of multiple device streams"
+    write(*,'(a, /)') "command-line options:"
+    write(*,'(a)')    "  -v, --verbose     Compile kernels in verbose mode"
+    write(*,'(a)')    "  -h, --help        Print this information and exit"
+  end subroutine print_help
+end program main

--- a/examples/fortran/10_mpi/Makefile
+++ b/examples/fortran/10_mpi/Makefile
@@ -1,0 +1,24 @@
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifndef OCCA_DIR
+  OCCA_DIR=$(PROJ_DIR)/../../..
+endif
+include $(OCCA_DIR)/scripts/Makefile
+
+
+#---[ COMPILATION ]-------------------------------
+all: main
+
+%: %.f90
+	@mkdir -p $(abspath $(dir $@))
+	$(fCompiler) $(fCompilerFlags) -o $@ $^ $(flags) $(fPaths) $(fLinkerFlags)
+
+clean:
+	rm -rf $(PROJ_DIR)/main
+#=================================================
+
+
+#---[ RUN ]---------------------------------------
+run: main
+	mpiexec -np 2 $(PROJ_DIR)/main
+#=================================================

--- a/examples/fortran/10_mpi/addVectors.okl
+++ b/examples/fortran/10_mpi/addVectors.okl
@@ -1,0 +1,8 @@
+@kernel void addVectors(const int entries,
+                        const float *a,
+                        const float *b,
+                        float *ab) {
+  for (int i = 0; i < entries; ++i; @tile(16, @outer, @inner)) {
+    ab[i] = a[i] + b[i];
+  }
+}

--- a/examples/fortran/10_mpi/main.f90
+++ b/examples/fortran/10_mpi/main.f90
@@ -1,0 +1,190 @@
+program main
+  use mpi
+  use occa
+  use, intrinsic :: iso_fortran_env, only : stdout=>output_unit, &
+                                            stderr=>error_unit
+
+  implicit none
+
+  integer :: ierr, i, id
+  integer :: myid, npes, gcomm, tag ! MPI variables
+  integer, dimension(2) :: request
+  integer, dimension(MPI_STATUS_SIZE) :: status
+  integer :: otherID, offset
+  integer(occaUDim_t) :: entries = 8
+  character(len=1024), dimension(0:1) :: info
+  real(C_float), dimension(0:1) :: ab_sum
+
+  real(C_float), allocatable, target :: a(:), b(:), ab(:)
+  real(C_float), pointer :: ab_ptr(:)
+
+  ! OCCA kernel, memory and property objects
+  type(occaDevice)     :: device
+  type(occaKernel)     :: addVectors
+  type(occaMemory)     :: o_a, o_b, o_ab
+
+  ! Initialise MPI
+  gcomm = MPI_COMM_WORLD
+  call MPI_Init(ierr)
+  if (ierr /= MPI_SUCCESS) call stop_mpi("*** MPI_Init error ***")
+  call MPI_Comm_rank(gcomm, myid,  ierr)
+  call MPI_Comm_size(gcomm, npes,  ierr)
+  if (npes /= 2) then
+    call stop_mpi("*** Example expects to run with 2 processes ***", myid)
+  end if
+
+  ! Set OCCA device info
+  !info = "mode: 'Serial'"
+  info = "mode: 'OpenMP', schedule: 'compact', chunk: 2"
+
+  ! Print device infos
+  if(myid == 0) then
+    call occaPrintModeInfo()
+  endif
+  call MPI_Barrier(gcomm, ierr)
+
+  ! Allocate host memory
+  allocate(a(1:entries), b(1:entries), ab(1:entries), stat=ierr)
+  if (ierr /= 0) call stop_mpi("*** Not enough memory ***", myid)
+
+  ! Initialise host arrays
+  do i=1,entries
+    a(i) = real(i)-1
+    b(i) = myid-real(i)
+  end do
+  ab = 0.0
+
+  ! Create OCCA device
+  device = occaCreateDeviceFromString(F_C_str(info(myid)))
+
+  ! Allocate memory on the device
+  o_a  = occaTypedMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  o_b  = occaTypedMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  o_ab = occaTypedMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+
+  ! Compile the kernel at run-time
+  addVectors = occaBuildKernel(F_C_str("addVectors.okl"), &
+                               F_C_str("addVectors"), &
+                               occaDefault)
+
+  ! Copy memory to the device
+  call occaCopyPtrToMem(o_a, C_loc(a), entries*C_float, 0_occaUDim_t, occaDefault)
+  call occaCopyPtrToMem(o_b, C_loc(b), occaAllBytes   , 0_occaUDim_t, occaDefault)
+
+  ! Launch device kernel
+  call occaKernelRun(addVectors, occaInt(entries), o_a, o_b, o_ab)
+
+  ! Get a pointer to the device memory
+  ! This only works if the device and host share a global address space, and
+  ! thus only the 'Serial' and 'OpenMP' modes can be used. For an alternative
+  ! implementation which works for other modes as well see the
+  ! '11_mpi_unified_memory' example.
+  if (occaDeviceHasSeparateMemorySpace(device)) then
+    call stop_mpi("*** Example only works in 'Serial' and 'OpenMP' mode ***", myid)
+  end if
+  if (C_associated(occaMemoryPtr(o_ab, occaDefault))) then
+    call C_F_pointer(occaMemoryPtr(o_ab, occaDefault),ab_ptr,[entries])
+  end if
+
+  ! Send/receive the result array
+  otherID = mod(myid + 1, 2)
+  offset  = entries/2
+  tag     = 123
+  request = MPI_REQUEST_NULL
+  call MPI_IRecv(ab_ptr(otherID*offset+1), &
+                 offset, &
+                 MPI_FLOAT, &
+                 otherID, &
+                 tag, &
+                 gcomm, &
+                 request(1), &
+                 ierr)
+  call MPI_ISend(ab_ptr(myid*offset+1), &
+                 offset, &
+                 MPI_FLOAT, &
+                 otherID, &
+                 tag, &
+                 gcomm, &
+                 request(2), &
+                 ierr)
+  call MPI_Wait(request(1), status, ierr)
+  call MPI_Wait(request(2), status, ierr)
+
+  ! Copy result to the host
+  call occaCopyMemToPtr(C_loc(ab), o_ab, occaAllBytes, 0_occaUDim_t, occaDefault)
+
+  ! Assert values
+  call flush(stdout)
+  ab_sum = myid
+  ab_sum(myid) = sum(ab_ptr)
+  call MPI_Gather(ab_sum(myid), 1, MPI_FLOAT, ab_sum, 1, MPI_FLOAT, 0, gcomm, ierr)
+  if (myid == 0) then
+    if (ab_sum(myid) /= ab_sum(otherID)) stop "*** Wrong result ***"
+  end if
+
+  ! Print values
+  call flush(stdout)
+  call MPI_Barrier(gcomm, ierr)
+  do id=0,npes-1
+    if (id == myid) then
+      call flush(stdout)
+      do i=1,entries
+      write(stdout,'(a,i1,a,i2,a,f5.1)') "#", id, ": ab(", i, ") = ", ab_ptr(i)
+      call flush(stdout)
+      end do
+    end if
+    call MPI_Barrier(gcomm, ierr)
+  end do
+
+  ! Free host memory
+  deallocate(a, b, ab, stat=ierr)
+  if (ierr /= 0) call stop_mpi("*** Deallocation not successful ***", myid)
+
+  ! Free device memory and OCCA objects
+  call occaFree(addVectors)
+  call occaFree(o_a)
+  call occaFree(o_b)
+  call occaFree(o_ab)
+  call occaFree(device)
+
+  ! Cleanup MPI
+  call MPI_Finalize(ierr)
+  if (ierr /= MPI_SUCCESS) call stop_mpi("*** MPI_Finalize error ***", myid)
+
+contains
+  subroutine stop_mpi(error, myid, error_code)
+    implicit none
+
+    integer, intent(in), optional :: myid, error_code
+    character(len=*), intent(in), optional :: error
+    integer :: ierr, ec
+
+    call flush(stdout)
+    call MPI_Barrier(gcomm, ierr)
+
+    if(present(error)) then
+      if(present(myid)) then
+        if(myid == 0) then
+          write(stdout,'(a)') ''
+          write(stdout,'(a)') error
+          write(stdout,'(a)') ''
+        end if
+      else
+        write(stdout,'(a)') ''
+        write(stdout,'(a)') error
+        write(stdout,'(a)') ''
+      end if
+    end if
+
+    call flush(stdout)
+    call MPI_Barrier(gcomm, ierr)
+
+    if(present(error_code)) then
+      ec = error_code
+    else
+      ec = -1
+    end if
+
+    call MPI_Abort(gcomm, ec, ierr)
+  end subroutine
+end program main

--- a/examples/fortran/11_mpi_unified_memory/Makefile
+++ b/examples/fortran/11_mpi_unified_memory/Makefile
@@ -1,0 +1,24 @@
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifndef OCCA_DIR
+  OCCA_DIR=$(PROJ_DIR)/../../..
+endif
+include $(OCCA_DIR)/scripts/Makefile
+
+
+#---[ COMPILATION ]-------------------------------
+all: main
+
+%: %.f90
+	@mkdir -p $(abspath $(dir $@))
+	$(fCompiler) $(fCompilerFlags) -o $@ $^ $(flags) $(fPaths) $(fLinkerFlags)
+
+clean:
+	rm -rf $(PROJ_DIR)/main
+#=================================================
+
+
+#---[ RUN ]---------------------------------------
+run: main
+	mpiexec -np 2 $(PROJ_DIR)/main
+#=================================================

--- a/examples/fortran/11_mpi_unified_memory/addVectors.okl
+++ b/examples/fortran/11_mpi_unified_memory/addVectors.okl
@@ -1,0 +1,8 @@
+@kernel void addVectors(const int entries,
+                        const float *a,
+                        const float *b,
+                        float *ab) {
+  for (int i = 0; i < entries; ++i; @tile(16, @outer, @inner)) {
+    ab[i] = a[i] + b[i];
+  }
+}

--- a/examples/fortran/11_mpi_unified_memory/main.f90
+++ b/examples/fortran/11_mpi_unified_memory/main.f90
@@ -1,0 +1,186 @@
+program main
+  use mpi
+  use occa
+  use, intrinsic :: iso_fortran_env, only : stdout=>output_unit, &
+                                            stderr=>error_unit
+
+  implicit none
+
+  integer :: ierr, i, id
+  integer :: myid, npes, gcomm, tag ! MPI variables
+  integer, dimension(2) :: request
+  integer, dimension(MPI_STATUS_SIZE) :: status
+  integer :: otherID, offset
+  integer(occaUDim_t) :: entries = 8
+  character(len=1024), dimension(0:1) :: info
+  real(C_float), dimension(0:1) :: ab_sum
+
+  ! OCCA kernel, memory and property objects
+  type(occaKernel)     :: addVectors
+  type(C_void_ptr)     :: a, b, ab
+  real(C_float), pointer :: a_ptr(:), b_ptr(:), ab_ptr(:)
+
+  ! Initialise MPI
+  gcomm = MPI_COMM_WORLD
+  call MPI_Init(ierr)
+  if (ierr /= MPI_SUCCESS) call stop_mpi("*** MPI_Init error ***")
+  call MPI_Comm_rank(gcomm, myid,  ierr)
+  call MPI_Comm_size(gcomm, npes,  ierr)
+  if (npes /= 2) then
+    call stop_mpi("*** Example expects to run with 2 processes ***", myid)
+  end if
+
+  ! Set OCCA device info
+  !info = "mode: 'Serial'"
+  !info = "mode: 'OpenMP', schedule: 'compact', chunk: 2"
+  !info(0) = "mode: 'OpenMP', schedule: 'compact', chunk: 2"
+  !info(1) = "mode: 'CUDA'  , device_id: 0"
+  info(0) = "mode: 'OpenMP', schedule: 'compact', chunk: 2"
+  info(1) = "mode: 'OpenCL', platform_id: 0, device_id: 0"
+
+  ! Print device infos
+  if(myid == 0) then
+    call occaPrintModeInfo()
+  endif
+  call MPI_Barrier(gcomm, ierr)
+
+  ! Create OCCA device
+  call occaSetDeviceFromString(F_C_str(info(myid)))
+
+  ! umalloc: [U]nified [M]emory [Alloc]ation
+  ! Allocate host memory that auto-syncs with the device between before kernel
+  ! calls and occaFinish() if needed.
+  a  = occaTypedUMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  b  = occaTypedUMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+  ab = occaTypedUMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)
+
+  ! Assign Fortran pointers to the (host) memory
+  if (C_associated(a)) then
+    call C_F_pointer(a,a_ptr,[entries])
+  end if
+  if (C_associated(b)) then
+    call C_F_pointer(b,b_ptr,[entries])
+  end if
+  if (C_associated(ab)) then
+    call C_F_pointer(ab,ab_ptr,[entries])
+  end if
+
+  ! Initialise host arrays
+  do i=1,entries
+    a_ptr(i) = real(i)-1
+    b_ptr(i) = myid-real(i)
+  end do
+  ab_ptr = 0
+
+  ! Compile the kernel at run-time
+  addVectors = occaBuildKernel(F_C_str("addVectors.okl"), &
+                               F_C_str("addVectors"), &
+                               occaDefault)
+
+  ! Launch device kernel
+  ! Arrays a, b, and ab are now resident on the device
+  call occaKernelRun(addVectors, occaInt(entries), occaPtr(a), occaPtr(b), occaPtr(ab))
+
+  ! a and b are const in the kernel, so we can use `dontSync` to manually force
+  ! a and b to not sync
+  call occaDontSync(a)
+  call occaDontSync(b)
+
+  ! Finish work queued up on the device, synchronizing a, b, and ab and making
+  ! it safe to use them again
+  call occaFinish()
+
+  ! Send/receive the result array
+  otherID = mod(myid + 1, 2)
+  offset  = entries/2
+  tag     = 123
+  request = MPI_REQUEST_NULL
+  call MPI_IRecv(ab_ptr(otherID*offset+1), &
+                 offset, &
+                 MPI_FLOAT, &
+                 otherID, &
+                 tag, &
+                 gcomm, &
+                 request(1), &
+                 ierr)
+  call MPI_ISend(ab_ptr(myid*offset+1), &
+                 offset, &
+                 MPI_FLOAT, &
+                 otherID, &
+                 tag, &
+                 gcomm, &
+                 request(2), &
+                 ierr)
+  call MPI_Wait(request(1), status, ierr)
+  call MPI_Wait(request(2), status, ierr)
+
+  ! Assert values
+  call flush(stdout)
+  ab_sum = myid
+  ab_sum(myid) = sum(ab_ptr)
+  call MPI_Gather(ab_sum(myid), 1, MPI_FLOAT, ab_sum, 1, MPI_FLOAT, 0, gcomm, ierr)
+  if (myid == 0) then
+    if (ab_sum(myid) /= ab_sum(otherID)) stop "*** Wrong result ***"
+  end if
+
+  ! Print values
+  call flush(stdout)
+  call MPI_Barrier(gcomm, ierr)
+  do id=0,npes-1
+    if (id == myid) then
+      call flush(stdout)
+      do i=1,entries
+      write(stdout,'(a,i1,a,i2,a,f5.1)') "#", id, ": ab(", i, ") = ", ab_ptr(i)
+      call flush(stdout)
+      end do
+    end if
+    call MPI_Barrier(gcomm, ierr)
+  end do
+
+  ! Free device memory and OCCA objects
+  call occaFree(addVectors)
+  call occaFreeUvaPtr(a)
+  call occaFreeUvaPtr(b)
+  call occaFreeUvaPtr(ab)
+
+  ! Cleanup MPI
+  call MPI_Finalize(ierr)
+  if (ierr /= MPI_SUCCESS) call stop_mpi("*** MPI_Finalize error ***", myid)
+
+contains
+  subroutine stop_mpi(error, myid, error_code)
+    implicit none
+
+    integer, intent(in), optional :: myid, error_code
+    character(len=*), intent(in), optional :: error
+    integer :: ierr, ec
+
+    call flush(stdout)
+    call MPI_Barrier(gcomm, ierr)
+
+    if(present(error)) then
+      if(present(myid)) then
+        if(myid == 0) then
+          write(stdout,'(a)') ''
+          write(stdout,'(a)') error
+          write(stdout,'(a)') ''
+        end if
+      else
+        write(stdout,'(a)') ''
+        write(stdout,'(a)') error
+        write(stdout,'(a)') ''
+      end if
+    end if
+
+    call flush(stdout)
+    call MPI_Barrier(gcomm, ierr)
+
+    if(present(error_code)) then
+      ec = error_code
+    else
+      ec = -1
+    end if
+
+    call MPI_Abort(gcomm, ec, ierr)
+  end subroutine
+end program main

--- a/include/occa/scripts/shellTools.sh
+++ b/include/occa/scripts/shellTools.sh
@@ -267,13 +267,13 @@ function compilerReleaseFlags {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM)   echo " -O3 -D __extern_always_inline=inline"     ;;
-        INTEL)      echo " -O3 -xHost"                               ;;
-        CRAY)       echo " -O3 -h intrinsics -fast"                  ;;
-        IBM)        echo " -O3 -qhot=simd"                           ;;
-        PGI)        echo " -O3 -fast -Mipa=fast,inline -Msmartalloc" ;;
-        PATHSCALE)  echo " -O3 -march=auto"                          ;;
-        HP)         echo " +O3"                                      ;;
+        GCC|LLVM)   echo " -O3 -march=native -D __extern_always_inline=inline" ;;
+        INTEL)      echo " -O3 -xHost"                                         ;;
+        CRAY)       echo " -O3 -h intrinsics -fast"                            ;;
+        IBM)        echo " -O3 -qhot=simd"                                     ;;
+        PGI)        echo " -O3 -fast -Mipa=fast,inline -Msmartalloc"           ;;
+        PATHSCALE)  echo " -O3 -march=auto"                                    ;;
+        HP)         echo " +O3"                                                ;;
         *)          ;;
     esac
 }

--- a/include/occa/scripts/tests/compiler.F90
+++ b/include/occa/scripts/tests/compiler.F90
@@ -1,0 +1,28 @@
+program compiler_fortran
+
+  implicit none
+
+#if   defined(__INTEL_COMPILER)
+  write(*,'(a)') 'INTEL'
+  stop
+#elif defined(__PGI)
+  write(*,'(a)') 'PGI'
+  stop
+#elif defined(_CRAYFTN)
+  write(*,'(a)') 'CRAY'
+  stop
+#elif defined(__GFORTRAN__)
+  write(*,'(a)') 'GCC'
+  stop
+#elif defined(__ibmxl__)
+  write(*,'(a)') 'IBM'
+  stop
+#elif defined(__PATHSCALE__)
+  write(*,'(a)') 'PATHSCALE'
+  stop
+#endif
+
+  write(*,'(a)') 'N/A'
+  stop
+
+end program

--- a/include/occa/scripts/tests/mpi.f90
+++ b/include/occa/scripts/tests/mpi.f90
@@ -1,0 +1,15 @@
+program mpi_fortran
+
+  use mpi
+  implicit none
+  integer :: ierr
+
+  call MPI_Init(ierr)
+  if (ierr /= 0) stop "*** MPI_Init error ***"
+
+  call MPI_Finalize(ierr)
+  if (ierr /= 0) stop "*** MPI_Finalize error ***"
+
+  stop 0
+
+end program

--- a/include/occa/scripts/tests/openmp.f90
+++ b/include/occa/scripts/tests/openmp.f90
@@ -1,0 +1,13 @@
+program parallel_hello_world
+
+  use omp_lib
+  implicit none
+  integer :: i
+
+  i = -1
+  i = omp_get_thread_num()
+  if (i == -1) stop "*** omp_get_thread_num error ***"
+
+  stop 0
+
+end

--- a/scripts/Make.fortran
+++ b/scripts/Make.fortran
@@ -18,23 +18,37 @@ fSoNameFlag = $(subst libocca,libocca_fortran,$(soNameFlag))
 
 #---[ Source/Object files ]-----------------------
 #  ---[ libocca_fortran ]-------------
-#  Fortran source files (ordered to account for inter-module dependencies)
-fSources = $(srcPath)/fortran/fc_string_m.f90 \
-           $(srcPath)/fortran/occa_typedefs_m.f90 \
-           $(srcPath)/fortran/occa_types_m.f90 \
-           $(srcPath)/fortran/occa_base_m.f90 \
-           $(srcPath)/fortran/occa_dtype_m.f90 \
-           $(srcPath)/fortran/occa_properties_m.f90 \
-           $(srcPath)/fortran/occa_device_m.f90 \
-           $(srcPath)/fortran/occa_memory_m.f90 \
-           $(srcPath)/fortran/occa_kernel_m.f90 \
-           $(srcPath)/fortran/occa_kernelBuilder_m.f90 \
-           $(srcPath)/fortran/occa_uva_m.f90 \
-           $(srcPath)/fortran/occa_scope_m.f90 \
-           $(srcPath)/fortran/occa_json_m.f90 \
-           $(srcPath)/fortran/occa_m.f90
+#  Fortran source files
+fSources = $(realpath $(shell find $(srcPath)/fortran -type f -name '*.f90'))
 fSrcToObject = $(subst $(srcPath),$(objPath),$(1:.f90=.o))
 fObjects = $(call fSrcToObject,$(fSources))
+
+#  Fortran module dependencies
+fObjPath = $(objPath)/fortran
+$(fObjPath)/occa_types_m.o:         $(fObjPath)/occa_typedefs_m.o
+$(fObjPath)/occa_base_m.o:          $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_dtype_m.o:         $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_properties_m.o:    $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_device_m.o:        $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_memory_m.o:        $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_kernel_m.o:        $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_kernelBuilder_m.o: $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_uva_m.o:           $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_scope_m.o:         $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_json_m.o:          $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_m.o:               $(fObjPath)/fc_string_m.o \
+                                    $(fObjPath)/occa_typedefs_m.o \
+                                    $(fObjPath)/occa_types_m.o \
+                                    $(fObjPath)/occa_base_m.o \
+                                    $(fObjPath)/occa_dtype_m.o \
+                                    $(fObjPath)/occa_properties_m.o \
+                                    $(fObjPath)/occa_device_m.o \
+                                    $(fObjPath)/occa_memory_m.o \
+                                    $(fObjPath)/occa_kernel_m.o \
+                                    $(fObjPath)/occa_kernelBuilder_m.o \
+                                    $(fObjPath)/occa_uva_m.o \
+                                    $(fObjPath)/occa_scope_m.o \
+                                    $(fObjPath)/occa_json_m.o
 #  ===================================
 
 #  ---[ Fortran tests ]---------------

--- a/scripts/Make.fortran
+++ b/scripts/Make.fortran
@@ -1,0 +1,44 @@
+#---[ Paths/Flags ]-------------------------------
+# OCCA (global) library path￼
+fPaths = -L$(OCCA_DIR)/lib
+
+# Extra (user-supplied) include and library paths
+fPaths += $(foreach path, $(subst :, ,$(OCCA_INCLUDE_PATH)), -I$(path))
+fPaths += $(foreach path, $(subst :, ,$(OCCA_LIBRARY_PATH)), -L$(path))
+
+# OCCA (global) Fortran module path - add as include path to allow for
+#   specifying a local project module path)
+fPaths += -I$(subst $(PROJ_DIR),$(OCCA_DIR),$(modPath))
+
+fLinkerFlags += $(fCppFlag) -locca -locca_fortran
+
+fSoNameFlag = $(subst libocca,libocca_fortran,$(soNameFlag))
+#=================================================
+
+
+#---[ Source/Object files ]-----------------------
+#  ---[ libocca_fortran ]-------------
+#  Fortran source files (ordered to account for inter-module dependencies)
+fSources = $(srcPath)/fortran/fc_string_m.f90 \
+           $(srcPath)/fortran/occa_typedefs_m.f90 \
+           $(srcPath)/fortran/occa_types_m.f90 \
+           $(srcPath)/fortran/occa_base_m.f90 \
+           $(srcPath)/fortran/occa_dtype_m.f90 \
+           $(srcPath)/fortran/occa_properties_m.f90 \
+           $(srcPath)/fortran/occa_device_m.f90 \
+           $(srcPath)/fortran/occa_memory_m.f90 \
+           $(srcPath)/fortran/occa_kernel_m.f90 \
+           $(srcPath)/fortran/occa_kernelBuilder_m.f90 \
+           $(srcPath)/fortran/occa_uva_m.f90 \
+           $(srcPath)/fortran/occa_scope_m.f90 \
+           $(srcPath)/fortran/occa_json_m.f90 \
+           $(srcPath)/fortran/occa_m.f90
+fSrcToObject = $(subst $(srcPath),$(objPath),$(1:.f90=.o))
+fObjects = $(call fSrcToObject,$(fSources))
+#  ===================================
+
+#  ---[ Fortran tests ]---------------
+fTestSources = $(realpath $(shell find $(PROJ_DIR)/tests/src -type f -name '*.f90'))
+fTests       = $(subst $(testPath)/src,$(testPath)/bin,$(fTestSources:.f90=))
+#  ===================================
+#=================================================

--- a/scripts/Make.fortran
+++ b/scripts/Make.fortran
@@ -19,36 +19,9 @@ fSoNameFlag = $(subst libocca,libocca_fortran,$(soNameFlag))
 #---[ Source/Object files ]-----------------------
 #  ---[ libocca_fortran ]-------------
 #  Fortran source files
-fSources = $(realpath $(shell find $(srcPath)/fortran -type f -name '*.f90'))
-fSrcToObject = $(subst $(srcPath),$(objPath),$(1:.f90=.o))
+fSources = $(shell find $(OCCA_DIR)/src/fortran -type f -iname '*.f90')
+fSrcToObject = $(subst $(OCCA_DIR)/src,$(objPath),$(1:.f90=.o))
 fObjects = $(call fSrcToObject,$(fSources))
-
-#  Fortran module dependencies
-fObjPath = $(objPath)/fortran
-$(fObjPath)/occa_types_m.o:         $(fObjPath)/occa_typedefs_m.o
-$(fObjPath)/occa_base_m.o:          $(fObjPath)/occa_types_m.o
-$(fObjPath)/occa_dtype_m.o:         $(fObjPath)/occa_types_m.o
-$(fObjPath)/occa_properties_m.o:    $(fObjPath)/occa_types_m.o
-$(fObjPath)/occa_device_m.o:        $(fObjPath)/occa_types_m.o
-$(fObjPath)/occa_memory_m.o:        $(fObjPath)/occa_types_m.o
-$(fObjPath)/occa_kernel_m.o:        $(fObjPath)/occa_types_m.o
-$(fObjPath)/occa_kernelBuilder_m.o: $(fObjPath)/occa_types_m.o
-$(fObjPath)/occa_uva_m.o:           $(fObjPath)/occa_types_m.o
-$(fObjPath)/occa_scope_m.o:         $(fObjPath)/occa_types_m.o
-$(fObjPath)/occa_json_m.o:          $(fObjPath)/occa_types_m.o
-$(fObjPath)/occa_m.o:               $(fObjPath)/fc_string_m.o \
-                                    $(fObjPath)/occa_typedefs_m.o \
-                                    $(fObjPath)/occa_types_m.o \
-                                    $(fObjPath)/occa_base_m.o \
-                                    $(fObjPath)/occa_dtype_m.o \
-                                    $(fObjPath)/occa_properties_m.o \
-                                    $(fObjPath)/occa_device_m.o \
-                                    $(fObjPath)/occa_memory_m.o \
-                                    $(fObjPath)/occa_kernel_m.o \
-                                    $(fObjPath)/occa_kernelBuilder_m.o \
-                                    $(fObjPath)/occa_uva_m.o \
-                                    $(fObjPath)/occa_scope_m.o \
-                                    $(fObjPath)/occa_json_m.o
 #  ===================================
 
 #  ---[ Fortran tests ]---------------

--- a/scripts/Make.fortran_rules
+++ b/scripts/Make.fortran_rules
@@ -1,0 +1,28 @@
+#---[ Fortran rules ]-----------------------------
+# Fortran module dependencies
+fObjPath = $(objPath)/fortran
+$(fObjPath)/occa_types_m.o:         $(fObjPath)/occa_typedefs_m.o
+$(fObjPath)/occa_base_m.o:          $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_dtype_m.o:         $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_properties_m.o:    $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_device_m.o:        $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_memory_m.o:        $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_kernel_m.o:        $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_kernelBuilder_m.o: $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_uva_m.o:           $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_scope_m.o:         $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_json_m.o:          $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_m.o:               $(fObjPath)/fc_string_m.o \
+                                    $(fObjPath)/occa_typedefs_m.o \
+                                    $(fObjPath)/occa_types_m.o \
+                                    $(fObjPath)/occa_base_m.o \
+                                    $(fObjPath)/occa_dtype_m.o \
+                                    $(fObjPath)/occa_properties_m.o \
+                                    $(fObjPath)/occa_device_m.o \
+                                    $(fObjPath)/occa_memory_m.o \
+                                    $(fObjPath)/occa_kernel_m.o \
+                                    $(fObjPath)/occa_kernelBuilder_m.o \
+                                    $(fObjPath)/occa_uva_m.o \
+                                    $(fObjPath)/occa_scope_m.o \
+                                    $(fObjPath)/occa_json_m.o
+# ================================================

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -12,6 +12,7 @@ endif
 
 binPath  = $(PROJ_DIR)/bin
 libPath  = $(PROJ_DIR)/lib
+modPath  = $(PROJ_DIR)/lib/occa/fortran/modules
 objPath  = $(PROJ_DIR)/obj
 srcPath  = $(PROJ_DIR)/src
 incPath  = $(PROJ_DIR)/include
@@ -108,16 +109,31 @@ else
   cCompilerFlags = $(CFLAGS)
 endif
 
+FC ?= gfortran
+
+ifndef FFLAGS
+  ifeq ($(debugEnabled),1)
+    fCompilerFlags = $(debugFlags)
+  else
+    fCompilerFlags = $(releaseFlags)
+  endif
+else
+  fCompilerFlags = $(FFLAGS)
+endif
+
 ifeq ($(OCCA_COVERAGE),1)
   coverageFlags = --coverage -fno-inline -fno-inline-small-functions -fno-default-inline -Wno-ignored-optimization-argument
   compilerFlags += $(coverageFlags)
   cCompilerFlags += $(coverageFlags)
+  fCompilerFlags += $(coverageFlags)
 endif
 
 compiler  = $(CXX)
 cCompiler = $(CC)
+fCompiler = $(FC)
 
 linkerFlags = $(LDFLAGS)
+fLinkerFlags = $(LDFLAGS)
 #=================================================
 
 
@@ -158,6 +174,9 @@ compilerPicFlag      = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh;
 compilerSharedFlag   = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerSharedFlag   "$(compiler)")
 compilerPthreadFlag  = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerPthreadFlag  "$(compiler)")
 
+fCompilerModuleDirFlag = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; fCompilerModuleDirFlag "$(fCompiler)")
+fCompilerCppFlag       = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; fCompilerCppFlag       "$(fCompiler)")
+
 compilerSupportsMPI    = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerSupportsMPI    "$(compiler)")
 compilerSupportsOpenMP = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerSupportsOpenMP "$(compiler)")
 compilerOpenMPFlag     = $(shell . $(OCCA_DIR)/include/occa/scripts/shellTools.sh; compilerOpenMPFlag     "$(compiler)")
@@ -172,6 +191,9 @@ cpp11Flags   = $(call compilerCpp11Flags)
 picFlag      = $(call compilerPicFlag)
 sharedFlag   = $(call compilerSharedFlag)
 pthreadFlag  = $(call compilerPthreadFlag)
+
+fModuleDirFlag = $(call fCompilerModuleDirFlag)
+fCppFlag       = $(call fCompilerCppFlag)
 
 # Workaround for GitHub Actions CI tests on Ubuntu using GCC.
 ifdef GITHUB_ACTIONS
@@ -227,12 +249,20 @@ endif
 
 
 #---[ Variable Dependencies ]---------------------
-mpiEnabled    = 0
-openmpEnabled = 0
-cudaEnabled   = 0
-hipEnabled    = 0
-openclEnabled = 0
-metalEnabled  = 0
+fortranEnabled = 0
+mpiEnabled     = 0
+openmpEnabled  = 0
+cudaEnabled    = 0
+hipEnabled     = 0
+openclEnabled  = 0
+metalEnabled   = 0
+
+
+#---[ Fortran ]-------------------------
+ifdef OCCA_FORTRAN_ENABLED
+  fortranEnabled = $(OCCA_FORTRAN_ENABLED)
+endif
+include $(OCCA_DIR)/scripts/Make.fortran
 
 
 #---[ MPI ]-----------------------------
@@ -384,10 +414,11 @@ else
   OCCA_CHECK_ENABLED := 0
 endif
 
-OCCA_MPI_ENABLED    := $(mpiEnabled)
-OCCA_OPENMP_ENABLED := $(openmpEnabled)
-OCCA_CUDA_ENABLED   := $(cudaEnabled)
-OCCA_HIP_ENABLED    := $(hipEnabled)
-OCCA_OPENCL_ENABLED := $(openclEnabled)
-OCCA_METAL_ENABLED  := $(metalEnabled)
+OCCA_FORTRAN_ENABLED := $(fortranEnabled)
+OCCA_MPI_ENABLED     := $(mpiEnabled)
+OCCA_OPENMP_ENABLED  := $(openmpEnabled)
+OCCA_CUDA_ENABLED    := $(cudaEnabled)
+OCCA_HIP_ENABLED     := $(hipEnabled)
+OCCA_OPENCL_ENABLED  := $(openclEnabled)
+OCCA_METAL_ENABLED   := $(metalEnabled)
 #=================================================

--- a/scripts/create_fortran_kernel_module.py
+++ b/scripts/create_fortran_kernel_module.py
@@ -1,0 +1,144 @@
+#! /usr/bin/env python
+
+""" Generate the Fortran kernel module (occa_kernel_m.f90)
+"""
+
+import os
+import re
+import argparse
+
+
+OCCA_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..")
+)
+
+
+EDIT_WARNING = ('''
+! --------------[ DO NOT EDIT ]--------------
+!  THIS IS AN AUTOMATICALLY GENERATED FILE
+!  EDIT:
+!    %s
+!    %s
+! ===========================================
+'''.strip() % (os.path.relpath(__file__, OCCA_DIR),
+               os.path.relpath('occa_kernel_m.f90.in', OCCA_DIR)))
+
+
+OCCA_KERNEL_RUN_N = ('''
+    subroutine occaKernelRunN%02d(kernel, argc, %s) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: %s
+    end subroutine
+''').lstrip('\n')
+
+
+OCCA_KERNEL_RUN = ('''
+  subroutine occaKernelRun%02d(kernel, %s)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: %s
+    call occaKernelRunN%02d(kernel, %2d, %s)
+  end subroutine
+''').lstrip('\n')
+
+
+if __name__ == '__main__':
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(usage=__doc__)
+    parser.add_argument("-N","--NargsMax", type=int, default=20)
+    args = parser.parse_args()
+
+    MAX_ARGS = args.NargsMax
+    if MAX_ARGS > 99:
+        raise ValueError('The format was designed for max. 99 arguments!')
+
+    with open('occa_kernel_m.f90.in', 'r') as f:
+        f_in = f.readlines()
+
+    fname = os.path.join(OCCA_DIR, 'src', 'fortran', 'occa_kernel_m.f90')
+    print('Write OCCA Fortran kernel module to: %s' % (fname))
+    with open(fname, 'w') as f:
+        # Add edit warning to the top of the file
+        f.write(EDIT_WARNING)
+        f.write('\n')
+
+        # Write header
+        line = f_in.pop(0)
+        while '@SUBROUTINE_occaKernelRunN@' not in line:
+            f.write(line)
+            line = f_in.pop(0)
+
+        # Write occaKernelRunN subroutines
+        for N in range(1, MAX_ARGS+1):
+            arg_lst = ['arg%02d' % (i) for i in range(1, N+1)]
+            if ((N-1)//4 > 0):
+                args_f = []
+                for i in range((N-1)//4 + 1):
+                    args_f.append(', '.join(arg_lst[i*4:(i+1)*4]))
+                args_f = (', &\n'+' '*46).join(args_f)
+            else:
+                args_f = ', '.join(arg_lst)
+
+            if ((N-1)//6 > 0):
+                args_d = []
+                for i in range((N-1)//6 + 1):
+                    args_d.append(', '.join(arg_lst[i*6:(i+1)*6]))
+                args_d = (', &\n'+' '*31).join(args_d)
+            else:
+                args_d = ', '.join(arg_lst)
+
+            if (N > 1): f.write('\n')
+            f.write(OCCA_KERNEL_RUN_N % (N, args_f, args_d))
+
+        # Write input file
+        line = f_in.pop(0)
+        while '@MODULE_PROCEDURE_occaKernelRun@' not in line:
+            f.write(line)
+            line = f_in.pop(0)
+
+        # Write module procedure interface for occaKernelRun
+        for N in range(1, MAX_ARGS+1):
+            f.write('    module procedure occaKernelRun%02d\n' % (N))
+
+        # Write input file
+        line = f_in.pop(0)
+        while '@SUBROUTINE_occaKernelRun@' not in line:
+            f.write(line)
+            line = f_in.pop(0)
+
+        # Write occaKernelRun subroutines
+        for N in range(1, MAX_ARGS+1):
+            arg_lst = ['arg%02d' % (i) for i in range(1, N+1)]
+            if ((N-1)//6 > 0):
+                args_f = []
+                for i in range((N-1)//6 + 1):
+                    args_f.append(', '.join(arg_lst[i*6:(i+1)*6]))
+                args_f = (', &\n'+' '*37).join(args_f)
+            else:
+                args_f = ', '.join(arg_lst)
+
+            if ((N-1)//7 > 0):
+                args_d = []
+                for i in range((N-1)//7 + 1):
+                    args_d.append(', '.join(arg_lst[i*7:(i+1)*7]))
+                args_d = (', &\n'+' '*29).join(args_d)
+            else:
+                args_d = ', '.join(arg_lst)
+
+            if ((N-1)//5 > 0):
+                args_c = []
+                for i in range((N-1)//5 + 1):
+                    args_c.append(', '.join(arg_lst[i*5:(i+1)*5]))
+                args_c = (', &\n'+' '*38).join(args_c)
+            else:
+                args_c = ', '.join(arg_lst)
+
+            if (N > 1): f.write('\n')
+            f.write(OCCA_KERNEL_RUN % (N, args_f, args_d, N, N, args_c))
+
+        # Write remainder of the input file
+        for line in f_in:
+            f.write(line)

--- a/scripts/occa_kernel_m.f90.in
+++ b/scripts/occa_kernel_m.f90.in
@@ -1,0 +1,151 @@
+module occa_kernel_m
+  ! occa/c/kernel.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! bool occaKernelIsInitialized(occaKernel kernel);
+    logical(kind=C_bool) function occaKernelIsInitialized(kernel) &
+                                  bind(C, name="occaKernelIsInitialized")
+      import occaKernel, C_bool
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! occaProperties occaKernelGetProperties(occaKernel kernel);
+    type(occaProperties) function occaKernelGetProperties(kernel) &
+                                  bind(C, name="occaKernelGetProperties")
+      import occaKernel, occaProperties
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! occaDevice occaKernelGetDevice(occaKernel kernel);
+    type(occaDevice) function occaKernelGetDevice(kernel) &
+                              bind(C, name="occaKernelGetDevice")
+      import occaKernel, occaDevice
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! const char* occaKernelName(occaKernel kernel);
+    type(C_char_ptr) function occaKernelName(kernel) &
+                              bind(C, name="occaKernelName")
+      import occaKernel, C_char_ptr
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! const char* occaKernelSourceFilename(occaKernel kernel);
+    type(C_char_ptr) function occaKernelSourceFilename(kernel) &
+                              bind(C, name="occaKernelSourceFilename")
+      import occaKernel, C_char_ptr
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! const char* occaKernelBinaryFilename(occaKernel kernel);
+    type(C_char_ptr) function occaKernelBinaryFilename(kernel) &
+                              bind(C, name="occaKernelBinaryFilename")
+      import occaKernel, C_char_ptr
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! const char* occaKernelHash(occaKernel kernel);
+    type(C_char_ptr) function occaKernelHash(kernel) &
+                              bind(C, name="occaKernelHash")
+      import occaKernel, C_char_ptr
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! const char* occaKernelFullHash(occaKernel kernel);
+    type(C_char_ptr) function occaKernelFullHash(kernel) &
+                              bind(C, name="occaKernelFullHash")
+      import occaKernel, C_char_ptr
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! bool occaKernelMaxDims(occaKernel kernel);
+    logical(kind=C_bool) function occaKernelMaxDims(kernel) &
+                                  bind(C, name="occaKernelMaxDims")
+      import occaKernel, C_bool
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! occaDim occaKernelMaxOuterDims(occaKernel kernel);
+    type(occaDim) function occaKernelMaxOuterDims(kernel) &
+                           bind(C, name="occaKernelMaxOuterDims")
+      import occaKernel, occaDim
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! occaDim occaKernelMaxInnerDims(occaKernel kernel);
+    type(occaDim) function occaKernelMaxInnerDims(kernel) &
+                           bind(C, name="occaKernelMaxInnerDims")
+      import occaKernel, occaDim
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! void occaKernelSetRunDims(occaKernel kernel,
+    !                           occaDim outerDims,
+    !                           occaDim innerDims);
+    subroutine occaKernelSetRunDims(kernel, outerDims, innerDims) &
+               bind(C, name="occaKernelSetRunDims")
+      import occaKernel, occaDim
+      implicit none
+      type(occaKernel), value :: kernel
+      type(occaDim), value :: outerDims, innerDims
+    end subroutine
+
+    ! void occaKernelPushArg(occaKernel kernel, occaType arg);
+    subroutine occaKernelPushArg(kernel, arg) bind(C, name="occaKernelPushArg")
+      import occaKernel, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      type(occaType), value :: arg
+    end subroutine
+
+    ! void occaKernelClearArgs(occaKernel kernel);
+    subroutine occaKernelClearArgs(kernel) bind(C, name="occaKernelClearArgs")
+      import occaKernel, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+    end subroutine
+
+    ! void occaKernelRunFromArgs(occaKernel kernel);
+    subroutine occaKernelRunFromArgs(kernel) &
+               bind(C, name="occaKernelRunFromArgs")
+      import occaKernel
+      implicit none
+      type(occaKernel), value :: kernel
+    end subroutine
+
+    ! void occaKernelVaRun(occaKernel kernel, const int argc, va_list args);
+    ! NOTE: There is no clean way to implement this in Fortran as there is no
+    !       clean way to map va_list (https://en.wikipedia.org/wiki/Stdarg.h)
+  end interface
+
+  interface occaKernelRunN
+    ! `occaKernelRun` is a variadic macro in C:
+    ! void occaKernelRunN(occaKernel kernel, const int argc, ...);
+    !
+    @SUBROUTINE_occaKernelRunN@
+  end interface
+
+  interface occaKernelRun
+    @MODULE_PROCEDURE_occaKernelRun@
+  end interface
+
+contains
+
+  @SUBROUTINE_occaKernelRun@
+
+end module occa_kernel_m

--- a/src/fortran/fc_string_m.f90
+++ b/src/fortran/fc_string_m.f90
@@ -1,0 +1,69 @@
+module fc_string_m
+  use, intrinsic :: iso_c_binding, &
+  ! C type aliases for pointer derived types:
+      C_ptr => C_ptr, &
+      C_char_ptr => C_ptr
+
+  implicit none
+
+  private
+
+  interface
+    !---------------------------------------------------------------------------
+    ! <string.h>
+    !---------------------------------------------------------------------------
+    ! extern size_t strlen (const char *s)
+    integer(C_size_t) pure function C_strlen(s) bind(C, name="strlen")
+      import C_char_ptr, C_size_t
+      implicit none
+      type(C_char_ptr), value, intent(in) :: s
+    end function C_strlen
+  end interface
+
+  public :: C_F_str, F_C_str
+
+contains
+
+  ! HACK: For some reason, C_associated was not defined as pure.
+  pure function C_associated_pure(ptr) result(a)
+    type(C_ptr), intent(in) :: ptr
+    integer(C_intptr_t) :: iptr
+    logical a
+    iptr = transfer(ptr,iptr)
+    a = (iptr /= 0)
+  end function C_associated_pure
+
+  pure function C_strlen_safe(s) result(length)
+    integer(C_size_t) :: length
+    type(C_char_ptr), value, intent(in) :: s
+    if (.not. C_associated_pure(s)) then
+      length = 0
+    else
+      length = C_strlen(s)
+    end if
+  end function C_strlen_safe
+
+  function C_F_str(C_string) result(F_string)
+    type(C_char_ptr), intent(in) :: C_string
+    character(len=C_strlen_safe(C_string)) :: F_string
+    character(len=1,kind=C_char), dimension(:), pointer :: p_chars
+    integer :: i, length
+    length = len(F_string)
+    if (length/=0) then
+      call C_F_pointer(C_string,p_chars,[length])
+      do i=1,length
+        F_string(i:i) = p_chars(i)
+      end do
+    end if
+  end function
+
+  pure function F_C_str(F_string) result(C_string)
+    character(len=*,kind=C_char), intent(in) :: F_string
+    character(len=:,kind=C_char), allocatable :: C_string
+    integer :: length
+    length = len_trim(F_string)+1
+    allocate(character(len=length) :: C_string)
+    C_string = trim(F_string)//C_NULL_char
+  end function
+
+end module fc_string_m

--- a/src/fortran/occa_base_m.f90
+++ b/src/fortran/occa_base_m.f90
@@ -1,0 +1,203 @@
+module occa_base_m
+  ! occa/c/base.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! ---[ Globals & Flags ]----------------
+    ! occaProperties occaSettings();
+    type(occaProperties) function occaSettings() bind(C, name="occaSettings")
+      import occaProperties
+    end function
+
+    ! void occaPrintModeInfo();
+    pure subroutine occaPrintModeInfo() bind(C, name="occaPrintModeInfo")
+    end subroutine
+    ! ======================================
+
+    ! ---[ Device ]-------------------------
+    ! occaDevice occaHost();
+    type(occaDevice) function occaHost() bind(C, name="occaHost")
+      import occaDevice
+    end function
+
+    ! occaDevice occaGetDevice();
+    type(occaDevice) function occaGetDevice() bind(C, name="occaGetDevice")
+      import occaDevice
+    end function
+
+    ! void occaSetDevice(occaDevice device);
+    subroutine occaSetDevice(device) bind(C, name="occaSetDevice")
+      import occaDevice
+      implicit none
+      type(occaDevice), value :: device
+    end subroutine
+
+    ! void occaSetDeviceFromString(const char *info);
+    subroutine occaSetDeviceFromString(info) &
+               bind(C, name="occaSetDeviceFromString")
+      import C_char
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: info
+    end subroutine
+
+    ! occaProperties occaDeviceProperties();
+    type(occaProperties) function occaDeviceProperties() &
+                                  bind(C, name="occaDeviceProperties")
+      import occaProperties
+    end function
+
+    ! void occaLoadKernels(const char *library);
+    subroutine occaLoadKernels(library) bind(C, name="occaLoadKernels")
+      import C_char
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: library
+    end subroutine
+
+    ! void occaFinish();
+    subroutine occaFinish() bind(C, name="occaFinish")
+    end subroutine
+
+    ! occaStream occaCreateStream(occaProperties props);
+    type(occaStream) function occaCreateStream(props) &
+                              bind(C, name="occaCreateStream")
+      import occaStream, occaProperties
+      implicit none
+      type(occaProperties), value :: props
+    end function
+
+    ! occaStream occaGetStream();
+    type(occaStream) function occaGetStream() bind(C, name="occaGetStream")
+      import occaStream
+    end function
+
+    ! void occaSetStream(occaStream stream);
+    subroutine occaSetStream(stream) bind(C, name="occaSetStream")
+      import occaStream
+      implicit none
+      type(occaStream), value :: stream
+    end subroutine
+
+    ! occaStreamTag occaTagStream();
+    type(occaStreamTag) function occaTagStream() bind(C, name="occaTagStream")
+      import occaStreamTag
+    end function
+
+    ! void occaWaitForTag(occaStreamTag tag);
+    subroutine occaWaitForTag(tag) bind(C, name="occaWaitForTag")
+      import occaStreamTag
+      implicit none
+      type(occaStreamTag), value :: tag
+    end subroutine
+
+    ! double occaTimeBetweenTags(occaStreamTag startTag, occaStreamTag endTag);
+    real(C_double) function occaTimeBetweenTags(startTag, endTag) &
+                            bind(C, name="occaTimeBetweenTags")
+      import occaStreamTag, C_double
+      implicit none
+      type(occaStreamTag), value :: startTag, endTag
+    end function
+    ! ======================================
+
+    ! ---[ Kernel ]-------------------------
+    ! occaKernel occaBuildKernel(const char *filename,
+    !                            const char *kernelName,
+    !                            const occaProperties props);
+    type(occaKernel) function occaBuildKernel(filename, &
+                                              kernelName, &
+                                              props) &
+                              bind(C, name="occaBuildKernel")
+      import C_char, occaKernel, occaProperties
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: filename, &
+                                                                kernelName
+      type(occaProperties), value, intent(in) :: props
+    end function
+
+    ! occaKernel occaBuildKernelFromString(const char *source,
+    !                                      const char *kernelName,
+    !                                      const occaProperties props);
+    type(occaKernel) function occaBuildKernelFromString(str, &
+                                                        kernelName, &
+                                                        props) &
+                              bind(C, name="occaBuildKernelFromString")
+      import C_char, occaKernel, occaProperties
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: str, &
+                                                                kernelName
+      type(occaProperties), value, intent(in) :: props
+    end function
+
+    ! occaKernel occaBuildKernelFromBinary(const char *filename,
+    !                                      const char *kernelName,
+    !                                      const occaProperties props);
+    type(occaKernel) function occaBuildKernelFromBinary(filename, &
+                                                        kernelName, &
+                                                        props) &
+                              bind(C, name="occaBuildKernelFromBinary")
+      import C_char, occaKernel, occaProperties
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: filename, &
+                                                                kernelName
+      type(occaProperties), value, intent(in) :: props
+    end function
+    ! ======================================
+
+    ! ---[ Memory ]-------------------------
+    ! occaMemory occaMalloc(const occaUDim_t bytes,
+    !                       const void *src,
+    !                       occaProperties props);
+    type(occaMemory) function occaMalloc(bytes, src, props) &
+                              bind(C, name="occaMalloc")
+      import occaMemory, occaUDim_t, C_void_ptr, occaProperties
+      implicit none
+      integer(occaUDim_t), value, intent(in) :: bytes
+      type(C_void_ptr), value, intent(in) :: src
+      type(occaProperties), value :: props
+    end function
+
+    ! occaMemory occaTypedMalloc(const occaUDim_t entries,
+    !                            const occaDtype type,
+    !                            const void *src,
+    !                            occaProperties props);
+    type(occaMemory) function occaTypedMalloc(entries, type, src, props) &
+                              bind(C, name="occaTypedMalloc")
+      import occaMemory, occaUDim_t, occaDtype, C_void_ptr, occaProperties
+      implicit none
+      integer(occaUDim_t), value, intent(in) :: entries
+      type(occaDtype), value, intent(in) :: type
+      type(C_void_ptr), value, intent(in) :: src
+      type(occaProperties), value :: props
+    end function
+
+    ! void* occaUMalloc(const occaUDim_t bytes,
+    !                   const void *src,
+    !                   occaProperties props);
+    type(C_void_ptr) function occaUMalloc(bytes, src, props) &
+                              bind(C, name="occaUMalloc")
+      import occaUDim_t, C_void_ptr, occaProperties
+      implicit none
+      integer(occaUDim_t), value, intent(in) :: bytes
+      type(C_void_ptr), value, intent(in) :: src
+      type(occaProperties), value :: props
+    end function
+
+    ! void* occaTypedUMalloc(const occaUDim_t entries,
+    !                        const occaDtype type,
+    !                        const void *src,
+    !                        occaProperties props);
+    type(C_void_ptr) function occaTypedUMalloc(entries, type, src, props) &
+                              bind(C, name="occaTypedUMalloc")
+      import occaUDim_t, occaDtype, C_void_ptr, occaProperties
+      implicit none
+      integer(occaUDim_t), value, intent(in) :: entries
+      type(occaDtype), value, intent(in) :: type
+      type(C_void_ptr), value, intent(in) :: src
+      type(occaProperties), value :: props
+    end function
+    ! ======================================
+  end interface
+
+end module occa_base_m

--- a/src/fortran/occa_device_m.f90
+++ b/src/fortran/occa_device_m.f90
@@ -1,0 +1,286 @@
+module occa_device_m
+  ! occa/c/device.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! occaDevice occaCreateDevice(occaType info);
+    type(occaDevice) function occaCreateDevice(info) &
+                              bind(C, name="occaCreateDevice")
+      import occaType, occaDevice
+      implicit none
+      type(occaType) :: info
+    end function
+
+    ! occaDevice occaCreateDeviceFromString(const char *info);
+    type(occaDevice) function occaCreateDeviceFromString(info) &
+                              bind(C, name="occaCreateDeviceFromString")
+      import C_char, occaDevice
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: info
+    end function
+
+    ! bool occaDeviceIsInitialized(occaDevice device);
+    logical(kind=C_bool) function occaDeviceIsInitialized(device) &
+                                  bind(C, name="occaDeviceIsInitialized")
+      import occaDevice, C_bool
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! const char* occaDeviceMode(occaDevice device);
+    type(C_char_ptr) function occaDeviceMode(device) &
+                              bind(C, name="occaDeviceMode")
+      import occaDevice, C_char_ptr
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! occaProperties occaDeviceGetProperties(occaDevice device);
+    type(occaProperties) function occaDeviceGetProperties(device) &
+                                  bind(C, name="occaDeviceGetProperties")
+      import occaProperties, occaDevice
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! occaProperties occaDeviceGetKernelProperties(occaDevice device);
+    type(occaProperties) function occaDeviceGetKernelProperties(device) &
+                                  bind(C, name="occaDeviceGetKernelProperties")
+      import occaProperties, occaDevice
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! occaProperties occaDeviceGetMemoryProperties(occaDevice device);
+    type(occaProperties) function occaDeviceGetMemoryProperties(device) &
+                                  bind(C, name="occaDeviceGetMemoryProperties")
+      import occaProperties, occaDevice
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! occaProperties occaDeviceGetStreamProperties(occaDevice device);
+    type(occaProperties) function occaDeviceGetStreamProperties(device) &
+                                  bind(C, name="occaDeviceGetStreamProperties")
+      import occaProperties, occaDevice
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! occaUDim_t occaDeviceMemorySize(occaDevice device);
+    integer(occaUDim_t) function occaDeviceMemorySize(device) &
+                                 bind(C, name="occaDeviceMemorySize")
+      import occaDevice, occaUDim_t
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! occaUDim_t occaDeviceMemoryAllocated(occaDevice device);
+    integer(occaUDim_t) function occaDeviceMemoryAllocated(device) &
+                                 bind(C, name="occaDeviceMemoryAllocated")
+      import occaDevice, occaUDim_t
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! void occaDeviceFinish(occaDevice device);
+    subroutine occaDeviceFinish(device) bind(C, name="occaDeviceFinish")
+      import occaDevice
+      implicit none
+      type(occaDevice), value :: device
+    end subroutine
+
+    ! bool occaDeviceHasSeparateMemorySpace(occaDevice device);
+    logical(kind=C_bool) function occaDeviceHasSeparateMemorySpace(device) &
+                                  bind(C, name="occaDeviceHasSeparateMemorySpace")
+      import occaDevice, C_bool
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! ---[ Stream ]-------------------------
+    ! occaStream occaDeviceCreateStream(occaDevice device,
+    !                                   occaProperties props);
+    type(occaStream) function occaDeviceCreateStream(device, props) &
+                              bind(C, name="occaDeviceCreateStream")
+      import occaProperties, occaDevice, occaStream
+      implicit none
+      type(occaDevice), value :: device
+      type(occaProperties), value :: props
+    end function
+
+    ! occaStream occaDeviceGetStream(occaDevice device);
+    type(occaStream) function occaDeviceGetStream(device) &
+                              bind(C, name="occaDeviceGetStream")
+      import occaDevice, occaStream
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! void occaDeviceSetStream(occaDevice device, occaStream stream);
+    subroutine occaDeviceSetStream(device, stream) &
+               bind(C, name="occaDeviceSetStream")
+      import occaDevice, occaStream
+      implicit none
+      type(occaDevice), value :: device
+      type(occaStream), value :: stream
+    end subroutine
+
+    ! occaStreamTag occaDeviceTagStream(occaDevice device);
+    type(occaStreamTag) function occaDeviceTagStream(device) &
+                                 bind(C, name="occaDeviceTagStream")
+      import occaDevice, occaStreamTag
+      implicit none
+      type(occaDevice), value :: device
+    end function
+
+    ! void occaDeviceWaitForTag(occaDevice device, occaStreamTag tag);
+    subroutine occaDeviceWaitForTag(device, tag) &
+               bind(C, name="occaDeviceWaitForTag")
+      import occaDevice, occaStreamTag
+      implicit none
+      type(occaDevice), value :: device
+      type(occaStreamTag), value :: tag
+    end subroutine
+
+    ! double occaDeviceTimeBetweenTags(occaDevice device,
+    !                                  occaStreamTag startTag,
+    !                                  occaStreamTag endTag);
+    real(C_double) function occaDeviceTimeBetweenTags(device, startTag, endTag) &
+                            bind(C, name="occaDeviceTimeBetweenTags")
+      import occaDevice, occaStreamTag, C_double
+      implicit none
+      type(occaDevice), value :: device
+      type(occaStreamTag), value :: startTag, endTag
+    end function
+    ! ======================================
+
+    ! ---[ Kernel ]-------------------------
+    ! occaKernel occaDeviceBuildKernel(occaDevice device,
+    !                                  const char *filename,
+    !                                  const char *kernelName,
+    !                                  const occaProperties props);
+    type(occaKernel) function occaDeviceBuildKernel(device, &
+                                                    filename, &
+                                                    kernelName, &
+                                                    props) &
+                              bind(C, name="occaDeviceBuildKernel")
+      import C_char, occaKernel, occaDevice, occaProperties
+      implicit none
+      type(occaDevice), value :: device
+      character(len=1,kind=C_char), dimension(*), intent(in) :: filename, &
+                                                                kernelName
+      type(occaProperties), value, intent(in) :: props
+    end function
+
+    ! occaKernel occaDeviceBuildKernelFromString(occaDevice device,
+    !                                            const char *str,
+    !                                            const char *kernelName,
+    !                                            const occaProperties props);
+    type(occaKernel) function occaDeviceBuildKernelFromString(device, &
+                                                              str, &
+                                                              kernelName, &
+                                                              props) &
+                              bind(C, name="occaDeviceBuildKernelFromString")
+      import C_char, occaKernel, occaDevice, occaProperties
+      implicit none
+      type(occaDevice), value :: device
+      character(len=1,kind=C_char), dimension(*), intent(in) :: str, &
+                                                                kernelName
+      type(occaProperties), value, intent(in) :: props
+    end function
+
+    ! occaKernel occaDeviceBuildKernelFromBinary(occaDevice device,
+    !                                            const char *filename,
+    !                                            const char *kernelName,
+    !                                            const occaProperties props);
+    type(occaKernel) function occaDeviceBuildKernelFromBinary(device, &
+                                                              filename, &
+                                                              kernelName, &
+                                                              props) &
+                              bind(C, name="occaDeviceBuildKernelFromBinary")
+      import C_char, occaKernel, occaDevice, occaProperties
+      implicit none
+      type(occaDevice), value :: device
+      character(len=1,kind=C_char), dimension(*), intent(in) :: filename, &
+                                                                kernelName
+      type(occaProperties), value, intent(in) :: props
+    end function
+    ! ======================================
+
+    ! ---[ Memory ]-------------------------
+    ! occaMemory occaDeviceMalloc(occaDevice device,
+    !                             const occaUDim_t bytes,
+    !                             const void *src,
+    !                             occaProperties props);
+    type(occaMemory) function occaDeviceMalloc(device, bytes, src, props) &
+                              bind(C, name="occaDeviceMalloc")
+      import C_void_ptr, occaMemory, occaDevice, occaProperties, occaUDim_t
+      implicit none
+      type(occaDevice), value :: device
+      integer(occaUDim_t), value, intent(in) :: bytes
+      type(C_void_ptr), value, intent(in) :: src
+      type(occaProperties), value :: props
+    end function
+
+    ! occaMemory occaDeviceTypedMalloc(occaDevice device,
+    !                                  const occaUDim_t entries,
+    !                                  const occaDtype dtype,
+    !                                  const void *src,
+    !                                  occaProperties props);
+    type(occaMemory) function occaDeviceTypedMalloc(device, &
+                                                    entries, &
+                                                    dtype, &
+                                                    src, &
+                                                    props) &
+                              bind(C, name="occaDeviceTypedMalloc")
+      import C_void_ptr, occaMemory, occaDevice, occaProperties, occaUDim_t, &
+             occaDtype
+      implicit none
+      type(occaDevice), value :: device
+      integer(occaUDim_t), value, intent(in) :: entries
+      type(occaDtype), value, intent(in) :: dtype
+      type(C_void_ptr), value, intent(in) :: src
+      type(occaProperties), value :: props
+    end function
+
+    ! void* occaDeviceUMalloc(occaDevice device,
+    !                         const occaUDim_t bytes,
+    !                         const void *src,
+    !                         occaProperties props);
+    type(C_void_ptr) function occaDeviceUMalloc(device, bytes, src, props) &
+                              bind(C, name="occaDeviceUMalloc")
+      import C_void_ptr, occaDevice, occaProperties, occaUDim_t
+      implicit none
+      type(occaDevice), value :: device
+      integer(occaUDim_t), value, intent(in) :: bytes
+      type(C_void_ptr), value, intent(in) :: src
+      type(occaProperties), value :: props
+    end function
+
+    ! void* occaDeviceTypedUMalloc(occaDevice device,
+    !                              const occaUDim_t entries,
+    !                              const occaDtype type,
+    !                              const void *src,
+    !                              occaProperties props);
+    type(C_void_ptr) function occaDeviceTypedUMalloc(device, &
+                                                     entries, &
+                                                     dtype, &
+                                                     src, &
+                                                     props) &
+                              bind(C, name="occaDeviceTypedUMalloc")
+      import C_void_ptr, occaDevice, occaProperties, occaUDim_t, occaDtype
+      implicit none
+      type(occaDevice), value :: device
+      integer(occaUDim_t), value, intent(in) :: entries
+      type(occaDtype), value, intent(in) :: dtype
+      type(C_void_ptr), value, intent(in) :: src
+      type(occaProperties), value :: props
+    end function
+    ! ======================================
+  end interface
+
+end module occa_device_m

--- a/src/fortran/occa_dtype_m.f90
+++ b/src/fortran/occa_dtype_m.f90
@@ -1,0 +1,176 @@
+module occa_dtype_m
+  ! occa/c/dtype.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! -----[ Methods ]----------------------
+    ! occaDtype occaCreateDtype(const char *name, const int bytes);
+    type(occaDtype) function occaCreateDtype(name, bytes) &
+                             bind(C, name="occaCreateDtype")
+      import C_char, occaDtype, C_int
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: name
+      integer(C_int), value, intent(in) :: bytes
+    end function
+
+    ! occaDtype occaCreateDtypeTuple(occaDtype dtype, const int size);
+    type(occaDtype) function occaCreateDtypeTuple(dtype, size) &
+                             bind(C, name="occaCreateDtypeTuple")
+      import occaDtype, C_int
+      implicit none
+      type(occaDtype), value :: dtype
+      integer(C_int), value, intent(in) :: size
+    end function
+
+    ! const char* occaDtypeName(occaDtype dtype);
+    type(C_char_ptr) function occaDtypeName(dtype) bind(C, name="occaDtypeName")
+      import occaDtype, C_char_ptr
+      implicit none
+      type(occaDtype), value :: dtype
+    end function
+
+    ! int occaDtypeBytes(occaDtype dtype);
+    integer(C_int) function occaDtypeBytes(dtype) bind(C, name="occaDtypeBytes")
+      import C_int, occaDtype
+      implicit none
+      type(occaDtype), value :: dtype
+    end function
+
+
+    ! void occaDtypeRegisterType(occaDtype dtype);
+    subroutine occaDtypeRegisterType(dtype) &
+               bind(C, name="occaDtypeRegisterType")
+      import occaDtype
+      implicit none
+      type(occaDtype), value :: dtype
+    end subroutine
+
+    ! bool occaDtypeIsRegistered(occaDtype dtype);
+    logical(kind=C_bool) function occaDtypeIsRegistered(dtype) &
+                                  bind(C, name="occaDtypeIsRegistered")
+      import C_bool, occaDtype
+      implicit none
+      type(occaDtype), value :: dtype
+    end function
+
+    ! void occaDtypeAddField(occaDtype dtype,
+    !                        const char *field,
+    !                        occaDtype fieldType);
+    subroutine occaDtypeAddField(dtype, field, fieldType) &
+               bind(C, name="occaDtypeAddField")
+      import occaDtype, C_char
+      implicit none
+      type(occaDtype), value :: dtype, fieldType
+      character(len=1,kind=C_char), dimension(*), intent(in) :: field
+    end subroutine
+
+    ! bool occaDtypesAreEqual(occaDtype a, occaDtype b);
+    logical(kind=C_bool) function occaDtypesAreEqual(a, b) &
+                                  bind(C, name="occaDtypesAreEqual")
+      import C_bool, occaDtype
+      implicit none
+      type(occaDtype), value :: a, b
+    end function
+
+    ! bool occaDtypesMatch(occaDtype a, occaDtype b);
+    logical(kind=C_bool) function occaDtypesMatch(a, b) &
+                                  bind(C, name="occaDtypesMatch")
+      import C_bool, occaDtype
+      implicit none
+      type(occaDtype), value :: a, b
+    end function
+
+    ! occaDtype occaDtypeFromJson(occaJson json);
+    type(occaDtype) function occaDtypeFromJson(json) &
+                             bind(C, name="occaDtypeFromJson")
+      import occaDtype, occaJson
+      implicit none
+      type(occaJson), value :: json
+    end function
+    ! occaDtype occaDtypeFromJsonString(const char *str);
+    type(occaDtype) function occaDtypeFromJsonString(str) &
+                             bind(C, name="occaDtypeFromJsonString")
+      import occaDtype, C_char
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: str
+    end function
+
+    ! occaJson occaDtypeToJson(occaDtype dtype);
+    type(occaJson) function occaDtypeToJson(dtype) &
+                            bind(C, name="occaDtypeToJson")
+      import occaDtype, occaJson
+      implicit none
+      type(occaDtype), value :: dtype
+    end function
+    ! ======================================
+  end interface
+
+  ! -----[ Builtins ]---------------------
+  type(occaDType), bind(C, name="occaDtypeNone") :: occaDtypeNone
+
+  type(occaDType), bind(C, name="occaDtypeVoid") :: occaDtypeVoid
+  type(occaDType), bind(C, name="occaDtypeByte") :: occaDtypeByte
+
+  type(occaDType), bind(C, name="occaDtypeBool") :: occaDtypeBool
+  type(occaDType), bind(C, name="occaDtypeChar") :: occaDtypeChar
+  type(occaDType), bind(C, name="occaDtypeShort") :: occaDtypeShort
+  type(occaDType), bind(C, name="occaDtypeInt") :: occaDtypeInt
+  type(occaDType), bind(C, name="occaDtypeLong") :: occaDtypeLong
+  type(occaDType), bind(C, name="occaDtypeFloat") :: occaDtypeFloat
+  type(occaDType), bind(C, name="occaDtypeDouble") :: occaDtypeDouble
+
+  type(occaDType), bind(C, name="occaDtypeInt8") :: occaDtypeInt8
+  type(occaDType), bind(C, name="occaDtypeUint8") :: occaDtypeUint8
+  type(occaDType), bind(C, name="occaDtypeInt16") :: occaDtypeInt16
+  type(occaDType), bind(C, name="occaDtypeUint16") :: occaDtypeUint16
+  type(occaDType), bind(C, name="occaDtypeInt32") :: occaDtypeInt32
+  type(occaDType), bind(C, name="occaDtypeUint32") :: occaDtypeUint32
+  type(occaDType), bind(C, name="occaDtypeInt64") :: occaDtypeInt64
+  type(occaDType), bind(C, name="occaDtypeUint64") :: occaDtypeUint64
+
+  ! OKL Primitives
+  type(occaDType), bind(C, name="occaDtypeUchar2") :: occaDtypeUchar2
+  type(occaDType), bind(C, name="occaDtypeUchar3") :: occaDtypeUchar3
+  type(occaDType), bind(C, name="occaDtypeUchar4") :: occaDtypeUchar4
+
+  type(occaDType), bind(C, name="occaDtypeChar2") :: occaDtypeChar2
+  type(occaDType), bind(C, name="occaDtypeChar3") :: occaDtypeChar3
+  type(occaDType), bind(C, name="occaDtypeChar4") :: occaDtypeChar4
+
+  type(occaDType), bind(C, name="occaDtypeUshort2") :: occaDtypeUshort2
+  type(occaDType), bind(C, name="occaDtypeUshort3") :: occaDtypeUshort3
+  type(occaDType), bind(C, name="occaDtypeUshort4") :: occaDtypeUshort4
+
+  type(occaDType), bind(C, name="occaDtypeShort2") :: occaDtypeShort2
+  type(occaDType), bind(C, name="occaDtypeShort3") :: occaDtypeShort3
+  type(occaDType), bind(C, name="occaDtypeShort4") :: occaDtypeShort4
+
+  type(occaDType), bind(C, name="occaDtypeUint2") :: occaDtypeUint2
+  type(occaDType), bind(C, name="occaDtypeUint3") :: occaDtypeUint3
+  type(occaDType), bind(C, name="occaDtypeUint4") :: occaDtypeUint4
+
+  type(occaDType), bind(C, name="occaDtypeInt2") :: occaDtypeInt2
+  type(occaDType), bind(C, name="occaDtypeInt3") :: occaDtypeInt3
+  type(occaDType), bind(C, name="occaDtypeInt4") :: occaDtypeInt4
+
+  type(occaDType), bind(C, name="occaDtypeUlong2") :: occaDtypeUlong2
+  type(occaDType), bind(C, name="occaDtypeUlong3") :: occaDtypeUlong3
+  type(occaDType), bind(C, name="occaDtypeUlong4") :: occaDtypeUlong4
+
+  type(occaDType), bind(C, name="occaDtypeLong2") :: occaDtypeLong2
+  type(occaDType), bind(C, name="occaDtypeLong3") :: occaDtypeLong3
+  type(occaDType), bind(C, name="occaDtypeLong4") :: occaDtypeLong4
+
+  type(occaDType), bind(C, name="occaDtypeFloat2") :: occaDtypeFloat2
+  type(occaDType), bind(C, name="occaDtypeFloat3") :: occaDtypeFloat3
+  type(occaDType), bind(C, name="occaDtypeFloat4") :: occaDtypeFloat4
+
+  type(occaDType), bind(C, name="occaDtypeDouble2") :: occaDtypeDouble2
+  type(occaDType), bind(C, name="occaDtypeDouble3") :: occaDtypeDouble3
+  type(occaDType), bind(C, name="occaDtypeDouble4") :: occaDtypeDouble4
+  ! ======================================
+
+end module occa_dtype_m

--- a/src/fortran/occa_json_m.f90
+++ b/src/fortran/occa_json_m.f90
@@ -1,0 +1,234 @@
+module occa_json_m
+  ! occa/c/json.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! occaJson occaCreateJson();
+    type(occaJson) function occaCreateJson() bind(C, name="occaCreateJson")
+      import occaJson
+    end function
+
+    ! ---[ Global methods ]-----------------
+    ! occaJson occaJsonParse(const char *c);
+    type(occaJson) function occaJsonParse(c) bind(C, name="occaJsonParse")
+      import occaJson, C_char
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: c
+    end function
+
+    ! occaJson occaJsonRead(const char *filename);
+    type(occaJson) function occaJsonRead(filename) bind(C, name="occaJsonRead")
+      import occaJson, C_char
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: filename
+    end function
+
+    ! void occaJsonWrite(occaJson j, const char *filename);
+    subroutine occaJsonWrite(j, filename) bind(C, name="occaJsonWrite")
+      import occaJson, C_char
+      implicit none
+      type(occaJson), value :: j
+      character(len=1,kind=C_char), dimension(*), intent(in) :: filename
+    end subroutine
+
+    ! const char* occaJsonDump(occaJson j, const int indent);
+    type(C_char_ptr) function occaJsonDump(j, indent) &
+                              bind(C, name="occaJsonDump")
+      import occaJson, C_char_ptr, C_int
+      implicit none
+      type(occaJson), value :: j
+      integer(C_int), value, intent(in) :: indent
+    end function
+    ! ======================================
+
+
+    ! ---[ Type checks ]--------------------
+    ! bool occaJsonIsBoolean(occaJson j);
+    logical(kind=C_bool) function occaJsonIsBoolean(j) &
+                                  bind(C, name="occaJsonIsBoolean")
+      import occaJson, C_bool
+      implicit none
+      type(occaJson), value :: j
+    end function
+    ! bool occaJsonIsNumber(occaJson j);
+    logical(kind=C_bool) function occaJsonIsNumber(j) &
+                                  bind(C, name="occaJsonIsNumber")
+      import occaJson, C_bool
+      implicit none
+      type(occaJson), value :: j
+    end function
+    ! bool occaJsonIsString(occaJson j);
+    logical(kind=C_bool) function occaJsonIsString(j) &
+                                  bind(C, name="occaJsonIsString")
+      import occaJson, C_bool
+      implicit none
+      type(occaJson), value :: j
+    end function
+    ! bool occaJsonIsArray(occaJson j);
+    logical(kind=C_bool) function occaJsonIsArray(j) &
+                                  bind(C, name="occaJsonIsArray")
+      import occaJson, C_bool
+      implicit none
+      type(occaJson), value :: j
+    end function
+    ! bool occaJsonIsObject(occaJson j);
+    logical(kind=C_bool) function occaJsonIsObject(j) &
+                                  bind(C, name="occaJsonIsObject")
+      import occaJson, C_bool
+      implicit none
+      type(occaJson), value :: j
+    end function
+    ! ======================================
+
+
+    ! ---[ Casters ]------------------------
+    ! void occaJsonCastToBoolean(occaJson j);
+    subroutine occaJsonCastToBoolean(j) bind(C, name="occaJsonCastToBoolean")
+      import occaJson
+      implicit none
+      type(occaJson), value :: j
+    end subroutine
+    ! void occaJsonCastToNumber(occaJson j);
+    subroutine occaJsonCastToNumber(j) bind(C, name="occaJsonCastToNumber")
+      import occaJson
+      implicit none
+      type(occaJson), value :: j
+    end subroutine
+    ! void occaJsonCastToString(occaJson j);
+    subroutine occaJsonCastToString(j) bind(C, name="occaJsonCastToString")
+      import occaJson
+      implicit none
+      type(occaJson), value :: j
+    end subroutine
+    ! void occaJsonCastToArray(occaJson j);
+    subroutine occaJsonCastToArray(j) bind(C, name="occaJsonCastToArray")
+      import occaJson
+      implicit none
+      type(occaJson), value :: j
+    end subroutine
+    ! void occaJsonCastToObject(occaJson j);
+    subroutine occaJsonCastToObject(j) bind(C, name="occaJsonCastToObject")
+      import occaJson
+      implicit none
+      type(occaJson), value :: j
+    end subroutine
+    ! ======================================
+
+
+    ! ---[ Getters ]------------------------
+    ! bool occaJsonGetBoolean(occaJson j);
+    logical(kind=C_bool) function occaJsonGetBoolean(j) &
+                                  bind(C, name="occaJsonGetBoolean")
+      import occaJson, C_bool
+      implicit none
+      type(occaJson), value :: j
+    end function
+    ! occaType occaJsonGetNumber(occaJson j, const int type);
+    type(occaType) function occaJsonGetNumber(j, type) &
+                            bind(C, name="occaJsonGetNumber")
+      import occaJson, occaType, C_int
+      implicit none
+      type(occaJson), value :: j
+      integer(C_int), value, intent(in) :: type
+    end function
+    ! const char* occaJsonGetString(occaJson j);
+    type(C_char_ptr) function occaJsonGetString(j) &
+                              bind(C, name="occaJsonGetString")
+      import occaJson, C_char_ptr
+      implicit none
+      type(occaJson), value :: j
+    end function
+    ! ======================================
+
+
+    ! ---[ Object methods ]-----------------
+    ! occaType occaJsonObjectGet(occaJson j,
+    !                            const char *key,
+    !                            occaType defaultValue);
+    type(occaType) function occaJsonObjectGet(j, key, defaultValue) &
+                            bind(C, name="occaJsonObjectGet")
+      import occaType, occaJson, C_char
+      implicit none
+      type(occaJson), value :: j
+      character(len=1,kind=C_char), dimension(*), intent(in) :: key
+      type(occaType), value :: defaultValue
+    end function
+
+    ! void occaJsonObjectSet(occaJson j, const char *key, occaType value);
+    subroutine occaJsonObjectSet(j, key, value) &
+               bind(C, name="occaJsonObjectSet")
+      import occaType, occaJson, C_char
+      implicit none
+      type(occaJson), value :: j
+      character(len=1,kind=C_char), dimension(*), intent(in) :: key
+      type(occaType), value :: value
+    end subroutine
+
+    ! bool occaJsonObjectHas(occaJson j, const char *key);
+    logical(kind=C_bool) function occaJsonObjectHas(j, key) &
+                                  bind(C, name="occaJsonObjectHas")
+      import occaJson, C_bool, C_char
+      implicit none
+      type(occaJson), value :: j
+      character(len=1,kind=C_char), dimension(*), intent(in) :: key
+    end function
+    ! ======================================
+
+
+    ! ---[ Array methods ]------------------
+    ! int occaJsonArraySize(occaJson j);
+    integer(C_int) function occaJsonArraySize(j) &
+                            bind(C, name="occaJsonArraySize")
+      import occaJson, C_int
+      implicit none
+      type(occaJson), value :: j
+    end function
+
+    ! occaType occaJsonArrayGet(occaJson j, const int index);
+    type(occaType) function occaJsonArrayGet(j, index) &
+                            bind(C, name="occaJsonArrayGet")
+      import occaType, occaJson, C_int
+      implicit none
+      type(occaJson), value :: j
+      integer(C_int), value, intent(in) :: index
+    end function
+
+    ! void occaJsonArrayPush(occaJson j, occaType value);
+    subroutine occaJsonArrayPush(j, value) &
+               bind(C, name="occaJsonArrayPush")
+      import occaType, occaJson
+      implicit none
+      type(occaJson), value :: j
+      type(occaType), value :: value
+    end subroutine
+
+    ! void occaJsonArrayPop(occaJson j);
+    subroutine occaJsonArrayPop(j) bind(C, name="occaJsonArrayPop")
+      import occaJson
+      implicit none
+      type(occaJson), value :: j
+    end subroutine
+
+    ! void occaJsonArrayInsert(occaJson j, const int index, occaType value);
+    subroutine occaJsonArrayInsert(j, index, value) &
+               bind(C, name="occaJsonArrayInsert")
+      import occaType, occaJson, C_int
+      implicit none
+      type(occaJson), value :: j
+      integer(C_int), value, intent(in) :: index
+      type(occaType), value :: value
+    end subroutine
+
+    ! void occaJsonArrayClear(occaJson j);
+    subroutine occaJsonArrayClear(j) bind(C, name="occaJsonArrayClear")
+      import occaJson
+      implicit none
+      type(occaJson), value :: j
+    end subroutine
+    ! ======================================
+  end interface
+
+end module occa_json_m

--- a/src/fortran/occa_kernelBuilder_m.f90
+++ b/src/fortran/occa_kernelBuilder_m.f90
@@ -1,0 +1,37 @@
+module occa_kernelBuilder_m
+  ! occa/c/kernelBuilder.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! occaKernelBuilder occaKernelBuilderFromInlinedOkl(
+    !   occaScope scope,
+    !   const char *kernelSource,
+    !   const char *kernelName
+    ! );
+    type(occaKernelBuilder) &
+    function occaKernelBuilderFromInlinedOkl(scope, kernelSource, kernelName) &
+             bind(C, name="occaKernelBuilderFromInlinedOkl")
+      import occaKernelBuilder, occaScope, C_char
+      implicit none
+      type(occaScope), value :: scope
+      character(len=1,kind=C_char), dimension(*), intent(in) :: kernelSource, &
+                                                                kernelName
+    end function
+
+    ! void occaKernelBuilderRun(
+    !   occaKernelBuilder kernelBuilder,
+    !   occaScope scope
+    ! );
+    subroutine occaKernelBuilderRun(kernelBuilder, scope) &
+               bind(C, name="occaKernelBuilderRun")
+      import occaKernelBuilder, occaScope
+      implicit none
+      type(occaKernelBuilder), value :: kernelBuilder
+      type(occaScope), value :: scope
+    end subroutine
+  end interface
+
+end module occa_kernelBuilder_m

--- a/src/fortran/occa_kernel_m.f90
+++ b/src/fortran/occa_kernel_m.f90
@@ -1,0 +1,609 @@
+! --------------[ DO NOT EDIT ]--------------
+!  THIS IS AN AUTOMATICALLY GENERATED FILE
+!  EDIT:
+!    scripts/create_fortran_kernel_module.py
+!    scripts/occa_kernel_m.f90.in
+! ===========================================
+module occa_kernel_m
+  ! occa/c/kernel.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! bool occaKernelIsInitialized(occaKernel kernel);
+    logical(kind=C_bool) function occaKernelIsInitialized(kernel) &
+                                  bind(C, name="occaKernelIsInitialized")
+      import occaKernel, C_bool
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! occaProperties occaKernelGetProperties(occaKernel kernel);
+    type(occaProperties) function occaKernelGetProperties(kernel) &
+                                  bind(C, name="occaKernelGetProperties")
+      import occaKernel, occaProperties
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! occaDevice occaKernelGetDevice(occaKernel kernel);
+    type(occaDevice) function occaKernelGetDevice(kernel) &
+                              bind(C, name="occaKernelGetDevice")
+      import occaKernel, occaDevice
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! const char* occaKernelName(occaKernel kernel);
+    type(C_char_ptr) function occaKernelName(kernel) &
+                              bind(C, name="occaKernelName")
+      import occaKernel, C_char_ptr
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! const char* occaKernelSourceFilename(occaKernel kernel);
+    type(C_char_ptr) function occaKernelSourceFilename(kernel) &
+                              bind(C, name="occaKernelSourceFilename")
+      import occaKernel, C_char_ptr
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! const char* occaKernelBinaryFilename(occaKernel kernel);
+    type(C_char_ptr) function occaKernelBinaryFilename(kernel) &
+                              bind(C, name="occaKernelBinaryFilename")
+      import occaKernel, C_char_ptr
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! const char* occaKernelHash(occaKernel kernel);
+    type(C_char_ptr) function occaKernelHash(kernel) &
+                              bind(C, name="occaKernelHash")
+      import occaKernel, C_char_ptr
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! const char* occaKernelFullHash(occaKernel kernel);
+    type(C_char_ptr) function occaKernelFullHash(kernel) &
+                              bind(C, name="occaKernelFullHash")
+      import occaKernel, C_char_ptr
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! bool occaKernelMaxDims(occaKernel kernel);
+    logical(kind=C_bool) function occaKernelMaxDims(kernel) &
+                                  bind(C, name="occaKernelMaxDims")
+      import occaKernel, C_bool
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! occaDim occaKernelMaxOuterDims(occaKernel kernel);
+    type(occaDim) function occaKernelMaxOuterDims(kernel) &
+                           bind(C, name="occaKernelMaxOuterDims")
+      import occaKernel, occaDim
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! occaDim occaKernelMaxInnerDims(occaKernel kernel);
+    type(occaDim) function occaKernelMaxInnerDims(kernel) &
+                           bind(C, name="occaKernelMaxInnerDims")
+      import occaKernel, occaDim
+      implicit none
+      type(occaKernel), value :: kernel
+    end function
+
+    ! void occaKernelSetRunDims(occaKernel kernel,
+    !                           occaDim outerDims,
+    !                           occaDim innerDims);
+    subroutine occaKernelSetRunDims(kernel, outerDims, innerDims) &
+               bind(C, name="occaKernelSetRunDims")
+      import occaKernel, occaDim
+      implicit none
+      type(occaKernel), value :: kernel
+      type(occaDim), value :: outerDims, innerDims
+    end subroutine
+
+    ! void occaKernelPushArg(occaKernel kernel, occaType arg);
+    subroutine occaKernelPushArg(kernel, arg) bind(C, name="occaKernelPushArg")
+      import occaKernel, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      type(occaType), value :: arg
+    end subroutine
+
+    ! void occaKernelClearArgs(occaKernel kernel);
+    subroutine occaKernelClearArgs(kernel) bind(C, name="occaKernelClearArgs")
+      import occaKernel, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+    end subroutine
+
+    ! void occaKernelRunFromArgs(occaKernel kernel);
+    subroutine occaKernelRunFromArgs(kernel) &
+               bind(C, name="occaKernelRunFromArgs")
+      import occaKernel
+      implicit none
+      type(occaKernel), value :: kernel
+    end subroutine
+
+    ! void occaKernelVaRun(occaKernel kernel, const int argc, va_list args);
+    ! NOTE: There is no clean way to implement this in Fortran as there is no
+    !       clean way to map va_list (https://en.wikipedia.org/wiki/Stdarg.h)
+  end interface
+
+  interface occaKernelRunN
+    ! `occaKernelRun` is a variadic macro in C:
+    ! void occaKernelRunN(occaKernel kernel, const int argc, ...);
+    !
+    subroutine occaKernelRunN01(kernel, argc, arg01) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01
+    end subroutine
+
+    subroutine occaKernelRunN02(kernel, argc, arg01, arg02) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02
+    end subroutine
+
+    subroutine occaKernelRunN03(kernel, argc, arg01, arg02, arg03) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03
+    end subroutine
+
+    subroutine occaKernelRunN04(kernel, argc, arg01, arg02, arg03, arg04) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04
+    end subroutine
+
+    subroutine occaKernelRunN05(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05
+    end subroutine
+
+    subroutine occaKernelRunN06(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06
+    end subroutine
+
+    subroutine occaKernelRunN07(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07
+    end subroutine
+
+    subroutine occaKernelRunN08(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08
+    end subroutine
+
+    subroutine occaKernelRunN09(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09
+    end subroutine
+
+    subroutine occaKernelRunN10(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10
+    end subroutine
+
+    subroutine occaKernelRunN11(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10, arg11) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10, arg11
+    end subroutine
+
+    subroutine occaKernelRunN12(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10, arg11, arg12) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10, arg11, arg12
+    end subroutine
+
+    subroutine occaKernelRunN13(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10, arg11, arg12, &
+                                              arg13) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10, arg11, arg12, &
+                               arg13
+    end subroutine
+
+    subroutine occaKernelRunN14(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10, arg11, arg12, &
+                                              arg13, arg14) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10, arg11, arg12, &
+                               arg13, arg14
+    end subroutine
+
+    subroutine occaKernelRunN15(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10, arg11, arg12, &
+                                              arg13, arg14, arg15) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10, arg11, arg12, &
+                               arg13, arg14, arg15
+    end subroutine
+
+    subroutine occaKernelRunN16(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10, arg11, arg12, &
+                                              arg13, arg14, arg15, arg16) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10, arg11, arg12, &
+                               arg13, arg14, arg15, arg16
+    end subroutine
+
+    subroutine occaKernelRunN17(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10, arg11, arg12, &
+                                              arg13, arg14, arg15, arg16, &
+                                              arg17) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10, arg11, arg12, &
+                               arg13, arg14, arg15, arg16, arg17
+    end subroutine
+
+    subroutine occaKernelRunN18(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10, arg11, arg12, &
+                                              arg13, arg14, arg15, arg16, &
+                                              arg17, arg18) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10, arg11, arg12, &
+                               arg13, arg14, arg15, arg16, arg17, arg18
+    end subroutine
+
+    subroutine occaKernelRunN19(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10, arg11, arg12, &
+                                              arg13, arg14, arg15, arg16, &
+                                              arg17, arg18, arg19) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10, arg11, arg12, &
+                               arg13, arg14, arg15, arg16, arg17, arg18, &
+                               arg19
+    end subroutine
+
+    subroutine occaKernelRunN20(kernel, argc, arg01, arg02, arg03, arg04, &
+                                              arg05, arg06, arg07, arg08, &
+                                              arg09, arg10, arg11, arg12, &
+                                              arg13, arg14, arg15, arg16, &
+                                              arg17, arg18, arg19, arg20) &
+               bind(C, name="occaKernelRunN")
+      import occaKernel, C_int, occaType
+      implicit none
+      type(occaKernel), value :: kernel
+      integer(C_int), value, intent(in) :: argc
+      type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, &
+                               arg07, arg08, arg09, arg10, arg11, arg12, &
+                               arg13, arg14, arg15, arg16, arg17, arg18, &
+                               arg19, arg20
+    end subroutine
+  end interface
+
+  interface occaKernelRun
+    module procedure occaKernelRun01
+    module procedure occaKernelRun02
+    module procedure occaKernelRun03
+    module procedure occaKernelRun04
+    module procedure occaKernelRun05
+    module procedure occaKernelRun06
+    module procedure occaKernelRun07
+    module procedure occaKernelRun08
+    module procedure occaKernelRun09
+    module procedure occaKernelRun10
+    module procedure occaKernelRun11
+    module procedure occaKernelRun12
+    module procedure occaKernelRun13
+    module procedure occaKernelRun14
+    module procedure occaKernelRun15
+    module procedure occaKernelRun16
+    module procedure occaKernelRun17
+    module procedure occaKernelRun18
+    module procedure occaKernelRun19
+    module procedure occaKernelRun20
+  end interface
+
+contains
+
+  subroutine occaKernelRun01(kernel, arg01)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01
+    call occaKernelRunN01(kernel,  1, arg01)
+  end subroutine
+
+  subroutine occaKernelRun02(kernel, arg01, arg02)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02
+    call occaKernelRunN02(kernel,  2, arg01, arg02)
+  end subroutine
+
+  subroutine occaKernelRun03(kernel, arg01, arg02, arg03)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03
+    call occaKernelRunN03(kernel,  3, arg01, arg02, arg03)
+  end subroutine
+
+  subroutine occaKernelRun04(kernel, arg01, arg02, arg03, arg04)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04
+    call occaKernelRunN04(kernel,  4, arg01, arg02, arg03, arg04)
+  end subroutine
+
+  subroutine occaKernelRun05(kernel, arg01, arg02, arg03, arg04, arg05)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05
+    call occaKernelRunN05(kernel,  5, arg01, arg02, arg03, arg04, arg05)
+  end subroutine
+
+  subroutine occaKernelRun06(kernel, arg01, arg02, arg03, arg04, arg05, arg06)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06
+    call occaKernelRunN06(kernel,  6, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06)
+  end subroutine
+
+  subroutine occaKernelRun07(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07
+    call occaKernelRunN07(kernel,  7, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07)
+  end subroutine
+
+  subroutine occaKernelRun08(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08
+    call occaKernelRunN08(kernel,  8, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08)
+  end subroutine
+
+  subroutine occaKernelRun09(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09
+    call occaKernelRunN09(kernel,  9, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09)
+  end subroutine
+
+  subroutine occaKernelRun10(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10
+    call occaKernelRunN10(kernel, 10, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10)
+  end subroutine
+
+  subroutine occaKernelRun11(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10, arg11)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10, arg11
+    call occaKernelRunN11(kernel, 11, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10, &
+                                      arg11)
+  end subroutine
+
+  subroutine occaKernelRun12(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10, arg11, arg12)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10, arg11, arg12
+    call occaKernelRunN12(kernel, 12, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10, &
+                                      arg11, arg12)
+  end subroutine
+
+  subroutine occaKernelRun13(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10, arg11, arg12, &
+                                     arg13)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10, arg11, arg12, arg13
+    call occaKernelRunN13(kernel, 13, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10, &
+                                      arg11, arg12, arg13)
+  end subroutine
+
+  subroutine occaKernelRun14(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10, arg11, arg12, &
+                                     arg13, arg14)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10, arg11, arg12, arg13, arg14
+    call occaKernelRunN14(kernel, 14, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10, &
+                                      arg11, arg12, arg13, arg14)
+  end subroutine
+
+  subroutine occaKernelRun15(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10, arg11, arg12, &
+                                     arg13, arg14, arg15)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10, arg11, arg12, arg13, arg14, &
+                             arg15
+    call occaKernelRunN15(kernel, 15, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10, &
+                                      arg11, arg12, arg13, arg14, arg15)
+  end subroutine
+
+  subroutine occaKernelRun16(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10, arg11, arg12, &
+                                     arg13, arg14, arg15, arg16)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10, arg11, arg12, arg13, arg14, &
+                             arg15, arg16
+    call occaKernelRunN16(kernel, 16, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10, &
+                                      arg11, arg12, arg13, arg14, arg15, &
+                                      arg16)
+  end subroutine
+
+  subroutine occaKernelRun17(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10, arg11, arg12, &
+                                     arg13, arg14, arg15, arg16, arg17)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10, arg11, arg12, arg13, arg14, &
+                             arg15, arg16, arg17
+    call occaKernelRunN17(kernel, 17, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10, &
+                                      arg11, arg12, arg13, arg14, arg15, &
+                                      arg16, arg17)
+  end subroutine
+
+  subroutine occaKernelRun18(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10, arg11, arg12, &
+                                     arg13, arg14, arg15, arg16, arg17, arg18)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10, arg11, arg12, arg13, arg14, &
+                             arg15, arg16, arg17, arg18
+    call occaKernelRunN18(kernel, 18, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10, &
+                                      arg11, arg12, arg13, arg14, arg15, &
+                                      arg16, arg17, arg18)
+  end subroutine
+
+  subroutine occaKernelRun19(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10, arg11, arg12, &
+                                     arg13, arg14, arg15, arg16, arg17, arg18, &
+                                     arg19)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10, arg11, arg12, arg13, arg14, &
+                             arg15, arg16, arg17, arg18, arg19
+    call occaKernelRunN19(kernel, 19, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10, &
+                                      arg11, arg12, arg13, arg14, arg15, &
+                                      arg16, arg17, arg18, arg19)
+  end subroutine
+
+  subroutine occaKernelRun20(kernel, arg01, arg02, arg03, arg04, arg05, arg06, &
+                                     arg07, arg08, arg09, arg10, arg11, arg12, &
+                                     arg13, arg14, arg15, arg16, arg17, arg18, &
+                                     arg19, arg20)
+    type(occaKernel), value :: kernel
+    type(occaType), value :: arg01, arg02, arg03, arg04, arg05, arg06, arg07, &
+                             arg08, arg09, arg10, arg11, arg12, arg13, arg14, &
+                             arg15, arg16, arg17, arg18, arg19, arg20
+    call occaKernelRunN20(kernel, 20, arg01, arg02, arg03, arg04, arg05, &
+                                      arg06, arg07, arg08, arg09, arg10, &
+                                      arg11, arg12, arg13, arg14, arg15, &
+                                      arg16, arg17, arg18, arg19, arg20)
+  end subroutine
+
+end module occa_kernel_m

--- a/src/fortran/occa_m.f90
+++ b/src/fortran/occa_m.f90
@@ -1,0 +1,16 @@
+module occa
+
+  use fc_string_m
+  use occa_types_m
+  use occa_base_m
+  use occa_dtype_m
+  use occa_properties_m
+  use occa_device_m
+  use occa_memory_m
+  use occa_kernel_m
+  use occa_kernelBuilder_m
+  use occa_uva_m
+  use occa_scope_m
+  use occa_json_m
+
+end module occa

--- a/src/fortran/occa_memory_m.f90
+++ b/src/fortran/occa_memory_m.f90
@@ -1,0 +1,216 @@
+module occa_memory_m
+  ! occa/c/memory.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! bool occaMemoryIsInitialized(occaMemory memory);
+    logical(kind=C_bool) function occaMemoryIsInitialized(memory) &
+                                  bind(C, name="occaMemoryIsInitialized")
+      import occaMemory, C_bool
+      implicit none
+      type(occaMemory), value :: memory
+    end function
+
+    ! void* occaMemoryPtr(occaMemory memory, occaProperties props);
+    type(C_void_ptr) function occaMemoryPtr(memory, props) &
+                              bind(C, name="occaMemoryPtr")
+      import occaMemory, occaProperties, C_void_ptr
+      implicit none
+      type(occaMemory), value :: memory
+      type(occaProperties), value :: props
+    end function
+
+    ! occaDevice occaMemoryGetDevice(occaMemory memory);
+    type(occaDevice) function occaMemoryGetDevice(memory) &
+                              bind(C, name="occaMemoryGetDevice")
+      import occaMemory, occaDevice
+      implicit none
+      type(occaMemory), value :: memory
+    end function
+
+    ! occaProperties occaMemoryGetProperties(occaMemory memory);
+    type(occaProperties) function occaMemoryGetProperties(memory) &
+                                  bind(C, name="occaMemoryGetProperties")
+      import occaMemory, occaProperties
+      implicit none
+      type(occaMemory), value :: memory
+    end function
+
+    ! occaUDim_t occaMemorySize(occaMemory memory);
+    integer(occaUDim_t) function occaMemorySize(memory) &
+                                 bind(C, name="occaMemorySize")
+      import occaMemory, occaUDim_t
+      implicit none
+      type(occaMemory), value :: memory
+    end function
+
+    ! occaMemory occaMemorySlice(occaMemory memory,
+    !                            const occaDim_t offset,
+    !                            const occaDim_t bytes);
+    type(occaMemory) function occaMemorySlice(memory, offset, bytes) &
+                              bind(C, name="occaMemorySlice")
+      import occaMemory, occaDim_t
+      implicit none
+      type(occaMemory), value :: memory
+      integer(occaDim_t), value, intent(in) :: offset, bytes
+    end function
+
+    ! ---[ UVA ]----------------------------
+    ! bool occaMemoryIsManaged(occaMemory memory);
+    logical(kind=C_bool) function occaMemoryIsManaged(memory) &
+                                  bind(C, name="occaMemoryIsManaged")
+      import occaMemory, C_bool
+      implicit none
+      type(occaMemory), value :: memory
+    end function
+
+    ! bool occaMemoryInDevice(occaMemory memory);
+    logical(kind=C_bool) function occaMemoryInDevice(memory) &
+                                  bind(C, name="occaMemoryInDevice")
+      import occaMemory, C_bool
+      implicit none
+      type(occaMemory), value :: memory
+    end function
+
+    ! bool occaMemoryIsStale(occaMemory memory);
+    logical(kind=C_bool) function occaMemoryIsStale(memory) &
+                                  bind(C, name="occaMemoryIsStale")
+      import occaMemory, C_bool
+      implicit none
+      type(occaMemory), value :: memory
+    end function
+
+    ! void occaMemoryStartManaging(occaMemory memory);
+    subroutine occaMemoryStartManaging(memory) &
+               bind(C, name="occaMemoryStartManaging")
+      import occaMemory
+      implicit none
+      type(occaMemory), value :: memory
+    end subroutine
+
+    ! void occaMemoryStopManaging(occaMemory memory);
+    subroutine occaMemoryStopManaging(memory) &
+               bind(C, name="occaMemoryStopManaging")
+      import occaMemory
+      implicit none
+      type(occaMemory), value :: memory
+    end subroutine
+
+    ! void occaMemorySyncToDevice(occaMemory memory,
+    !                             const occaDim_t bytes,
+    !                             const occaDim_t offset);
+    subroutine occaMemorySyncToDevice(memory, bytes, offset) &
+               bind(C, name="occaMemorySyncToDevice")
+      import occaMemory, occaDim_t
+      implicit none
+      type(occaMemory), value :: memory
+      integer(occaDim_t), value, intent(in) :: offset, bytes
+    end subroutine
+
+    ! void occaMemorySyncToHost(occaMemory memory,
+    !                           const occaDim_t bytes,
+    !                           const occaDim_t offset);
+    subroutine occaMemorySyncToHost(memory, bytes, offset) &
+               bind(C, name="occaMemorySyncToHost")
+      import occaMemory, occaDim_t
+      implicit none
+      type(occaMemory), value :: memory
+      integer(occaDim_t), value, intent(in) :: offset, bytes
+    end subroutine
+    ! ======================================
+
+    ! void occaMemcpy(void *dest,
+    !                 const void *src,
+    !                 const occaUDim_t bytes,
+    !                 occaProperties props);
+    subroutine occaMemcpy(dest, src, bytes, props) &
+               bind(C, name="occaMemcpy")
+      import occaMemory, C_void_ptr, occaUDim_t, occaProperties
+      implicit none
+      type(occaMemory), value :: dest
+      type(C_void_ptr), value, intent(in) :: src
+      integer(occaUDim_t), value, intent(in) :: bytes
+      type(occaProperties), value :: props
+    end subroutine
+
+    ! void occaCopyMemToMem(occaMemory dest,
+    !                       occaMemory src,
+    !                       const occaUDim_t bytes,
+    !                       const occaUDim_t destOffset,
+    !                       const occaUDim_t srcOffset,
+    !                       occaProperties props);
+    subroutine occaCopyMemToMem(dest, src, bytes, destOffset, srcOffset, props) &
+               bind(C, name="occaCopyMemToMem")
+      import occaMemory, C_void_ptr, occaUDim_t, occaProperties
+      implicit none
+      type(occaMemory), value :: dest
+      type(C_void_ptr), value, intent(in) :: src
+      integer(occaUDim_t), value, intent(in) :: bytes, destOffset, srcOffset
+      type(occaProperties), value :: props
+    end subroutine
+
+    ! void occaCopyPtrToMem(occaMemory dest,
+    !                       const void *src,
+    !                       const occaUDim_t bytes,
+    !                       const occaUDim_t offset,
+    !                       occaProperties props);
+    subroutine occaCopyPtrToMem(dest, src, bytes, offset, props) &
+               bind(C, name="occaCopyPtrToMem")
+      import occaMemory, C_void_ptr, occaUDim_t, occaProperties
+      implicit none
+      type(occaMemory), value :: dest
+      type(C_void_ptr), value, intent(in) :: src
+      integer(occaUDim_t), value, intent(in) :: bytes, offset
+      type(occaProperties), value :: props
+    end subroutine
+
+    ! void occaCopyMemToPtr(void *dest,
+    !                       occaMemory src,
+    !                       const occaUDim_t bytes,
+    !                       const occaUDim_t offset,
+    !                       occaProperties props);
+    subroutine occaCopyMemToPtr(dest, src, bytes, offset, props) &
+               bind(C, name="occaCopyMemToPtr")
+      import C_void_ptr, occaMemory, occaUDim_t, occaProperties
+      implicit none
+      type(C_void_ptr), value :: dest
+      type(occaMemory), value :: src
+      integer(occaUDim_t), value, intent(in) :: bytes, offset
+      type(occaProperties), value :: props
+    end subroutine
+
+
+    ! occaMemory occaMemoryClone(occaMemory memory);
+    type(occaMemory) function occaMemoryClone(memory) &
+                              bind(C, name="occaMemoryClone")
+      import occaMemory
+      implicit none
+      type(occaMemory), value :: memory
+    end function
+
+    ! void occaMemoryDetach(occaMemory memory);
+    subroutine occaMemoryDetach(memory) bind(C, name="occaMemoryDetach")
+      import occaMemory
+      implicit none
+      type(occaMemory), value :: memory
+    end subroutine
+
+    ! occaMemory occaWrapCpuMemory(occaDevice device,
+    !                              void *ptr,
+    !                              occaUDim_t bytes,
+    !                              occaProperties props);
+    type(occaMemory) function occaWrapCpuMemory(device, ptr, bytes, props) &
+                              bind(C, name="occaWrapCpuMemory")
+      import occaMemory, occaDevice, C_void_ptr, occaUDim_t, occaProperties
+      implicit none
+      type(occaDevice), value :: device
+      type(C_void_ptr), value :: ptr
+      integer(occaUDim_t), value, intent(in) :: bytes
+      type(occaProperties), value :: props
+    end function
+  end interface
+
+end module occa_memory_m

--- a/src/fortran/occa_properties_m.f90
+++ b/src/fortran/occa_properties_m.f90
@@ -1,0 +1,58 @@
+module occa_properties_m
+  ! occa/c/properties.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! occaProperties occaCreateProperties();
+    type(occaProperties) function occaCreateProperties() &
+                                  bind(C, name="occaCreateProperties")
+      import occaProperties
+      implicit none
+    end function
+
+    ! occaProperties occaCreatePropertiesFromString(const char *c);
+    type(occaProperties) function occaCreatePropertiesFromString(c) &
+                                  bind(C, name="occaCreatePropertiesFromString")
+      import C_char, occaProperties
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: c
+    end function
+
+    ! occaType occaPropertiesGet(occaProperties props,
+    !                            const char *key,
+    !                            occaType defaultValue);
+    type(occaType) function occaPropertiesGet(props, key, defaultValue) &
+                            bind(C, name="occaPropertiesGet")
+      import C_char, occaProperties, occaType
+      implicit none
+      type(occaProperties), value :: props
+      character(len=1,kind=C_char), dimension(*), intent(in) :: key
+      type(occaType), value, intent(in) :: defaultValue
+    end function
+
+    ! void occaPropertiesSet(occaProperties props,
+    !                        const char *key,
+    !                        occaType value);
+    subroutine occaPropertiesSet(props, key, value) &
+               bind(C, name="occaPropertiesSet")
+      import C_char, occaProperties, occaType
+      implicit none
+      type(occaProperties), value :: props
+      character(len=1,kind=C_char), dimension(*), intent(in) :: key
+      type(occaType), value :: value
+    end subroutine
+
+    ! bool occaPropertiesHas(occaProperties props, const char *key);
+    logical(kind=C_bool) function occaPropertiesHas(props, key) &
+                                  bind(C, name="occaPropertiesHas")
+      import C_bool, C_char, occaProperties
+      implicit none
+      type(occaProperties), value, intent(in) :: props
+      character(len=1,kind=C_char), dimension(*), intent(in) :: key
+    end function
+  end interface
+
+end module occa_properties_m

--- a/src/fortran/occa_scope_m.f90
+++ b/src/fortran/occa_scope_m.f90
@@ -1,0 +1,37 @@
+module occa_scope_m
+  ! occa/c/scope.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! occaScope occaCreateScope(occaProperties props);
+    type(occaScope) function occaCreateScope(props) &
+                             bind(C, name="occaCreateScope")
+      import occaScope, occaProperties
+      implicit none
+      type(occaProperties), value :: props
+    end function
+
+    ! void occaScopeAdd(occaScope scope, const char *name, occaType value);
+    subroutine occaScopeAdd(scope, name, value) bind(C, name="occaScopeAdd")
+      import C_char, occaScope, occaType
+      implicit none
+      type(occaScope), value :: scope
+      character(len=1,kind=C_char), dimension(*), intent(in) :: name
+      type(occaType), value :: value
+    end subroutine
+
+    ! void occaScopeAddConst(occaScope scope, const char *name, occaType value);
+    subroutine occaScopeAddConst(scope, name, value) &
+               bind(C, name="occaScopeAddConst")
+      import C_char, occaScope, occaType
+      implicit none
+      type(occaScope), value :: scope
+      character(len=1,kind=C_char), dimension(*), intent(in) :: name
+      type(occaType), value :: value
+    end subroutine
+  end interface
+
+end module occa_scope_m

--- a/src/fortran/occa_typedefs_m.f90
+++ b/src/fortran/occa_typedefs_m.f90
@@ -1,0 +1,41 @@
+module occa_typedefs_m
+
+  use, intrinsic :: iso_c_binding, &
+  ! C type aliases for pointer derived types:
+      C_ptr => C_ptr, &
+      C_char_ptr => C_ptr, &
+      C_void_ptr => C_ptr, &
+      C_int64_t => C_int64_t, &
+      occaDim_t => C_int64_t, &
+      occaUDim_t => C_int64_t
+
+  implicit none
+
+  !-----------------------------------------------------------------------------
+  ! Type definitions mapping the `struct` in the C layer to a defined type in
+  ! Fortran. For a basic example see:
+  !   https://gcc.gnu.org/onlinedocs/gfortran/Derived-Types-and-struct.html
+  !-----------------------------------------------------------------------------
+  type, bind(C) :: occaDim
+    integer(occaUDim_t) :: x, y, z
+  end type occaDim
+
+  type, private, bind(C) :: occaUnion
+    private
+    ! Use the largest data member in the C `union`.
+    integer(C_int64_t) :: data
+  end type occaUnion
+
+  type, bind(C) :: occaType
+    integer(C_int) :: magicHeader
+    integer(C_int) :: type
+    integer(C_int64_t) :: bytes
+    logical(kind=C_bool) needsFree
+
+    ! In the C layer, this is a `union`, which does not have a Fortran
+    ! counterpart. Thus use a defined type, corresponding to a `struct` in C,
+    ! with the largest data member in the C `union`.
+    type(occaUnion) :: value
+  end type occaType
+
+end module occa_typedefs_m

--- a/src/fortran/occa_typedefs_m.f90
+++ b/src/fortran/occa_typedefs_m.f90
@@ -20,7 +20,7 @@ module occa_typedefs_m
     integer(occaUDim_t) :: x, y, z
   end type occaDim
 
-  type, private, bind(C) :: occaUnion
+  type, bind(C) :: occaUnion
     private
     ! Use the largest data member in the C `union`.
     integer(C_int64_t) :: data

--- a/src/fortran/occa_types_m.f90
+++ b/src/fortran/occa_types_m.f90
@@ -1,0 +1,279 @@
+module occa_types_m
+  ! occa/c/types.h
+
+  use occa_typedefs_m, &
+    ! OCCA aliases for derived types:
+    occaType => occaType, &
+
+    occaDevice => occaType, &
+    occaKernel => occaType, &
+    occaKernelBuilder => occaType, &
+    occaMemory => occaType, &
+    occaStream => occaType, &
+    occaStreamTag => occaType, &
+
+    occaDtype => occaType, &
+    occaScope => occaType, &
+    occaJson => occaType, &
+    occaProperties => occaType
+
+  implicit none
+
+  interface
+    ! -----[ Known Types ]------------------
+    ! bool occaIsUndefined(occaType value);
+    logical(kind=C_bool) function occaIsUndefined(value) &
+                                  bind(C, name="occaIsUndefined")
+      import C_bool, occaType
+      implicit none
+      type(occaType), value :: value
+    end function
+
+    ! bool occaIsDefault(occaType value);
+    logical(kind=C_bool) function occaIsDefault(value) &
+                                  bind(C, name="occaIsDefault")
+      import C_bool, occaType
+      implicit none
+      type(occaType), value :: value
+    end function
+
+    ! occaType occaPtr(void *value);
+    type(occaType) function occaPtr(value) bind(C, name="occaPtr")
+      import occaType, C_ptr
+      implicit none
+      type(C_ptr), value :: value
+    end function
+
+    ! occaType occaBool(bool value);
+    ! NOTE: This function is not meant to be used directly. Use `occaBool`
+    !       instead.
+    type(occaType) function occaBool_C(value) bind(C, name="occaBool")
+      import occaType, C_bool
+      implicit none
+      logical(kind=C_bool), value :: value
+    end function
+    ! ======================================
+  end interface
+
+  interface occaInt
+    ! -----[ Integer Types ]----------------
+    ! NOTE: This provides a consistent interface for integer types in Fortran,
+    !       but slight deviates from the C interface
+    ! occaType occaInt8(int8_t value);
+    ! occaType occaUInt8(uint8_t value);
+    type(occaType) function occaInt8(value) bind(C, name="occaInt8")
+      import occaType, C_int8_t
+      implicit none
+      integer(C_int8_t), value :: value
+    end function
+
+    ! occaType occaInt16(int16_t value);
+    ! occaType occaUInt16(uint16_t value);
+    type(occaType) function occaInt16(value) bind(C, name="occaInt16")
+      import occaType, C_int16_t
+      implicit none
+      integer(C_int16_t), value :: value
+    end function
+
+    ! occaType occaInt32(int32_t value);
+    ! occaType occaUInt32(uint32_t value);
+    type(occaType) function occaInt32(value) bind(C, name="occaInt32")
+      import occaType, C_int32_t
+      implicit none
+      integer(C_int32_t), value :: value
+    end function
+
+    ! occaType occaInt64(int64_t value);
+    ! occaType occaUInt64(uint64_t value);
+    type(occaType) function occaInt64(value) bind(C, name="occaInt64")
+      import occaType, C_int64_t
+      implicit none
+      integer(C_int64_t), value :: value
+    end function
+
+    ! NOTE: C_signed_char == C_int8_t
+    ! ! occaType occaChar(char value);
+    ! ! occaType occaUChar(unsigned char value);
+    ! type(occaType) function occaChar(value) bind(C, name="occaChar")
+    !   import occaType, C_signed_char
+    !   implicit none
+    !   integer(C_signed_char), value :: value
+    ! end function
+
+    ! NOTE: C_short == C_int16_t
+    ! ! occaType occaShort(short value);
+    ! ! occaType occaUShort(unsigned short value);
+    ! type(occaType) function occaShort(value) bind(C, name="occaShort")
+    !   import occaType, C_short
+    !   implicit none
+    !   integer(C_short), value :: value
+    ! end function
+
+    ! NOTE: C_int == C_int32_t
+    ! ! occaType occaInt(int value);
+    ! ! occaType occaUInt(unsigned int value);
+    ! type(occaType) function occaInt(value) bind(C, name="occaInt")
+    !   import occaType, C_int
+    !   implicit none
+    !   integer(C_int), value :: value
+    ! end function
+
+    ! NOTE: C_long == C_int64_t
+    ! ! occaType occaLong(long value);
+    ! ! occaType occaULong(unsigned long value);
+    ! type(occaType) function occaLong(value) bind(C, name="occaLong")
+    !   import occaType, C_long
+    !   implicit none
+    !   integer(C_long), value :: value
+    ! end function
+    ! ======================================
+  end interface
+
+  interface occaReal
+    ! -----[ Real Types ]-------------------
+    ! occaType occaFloat(float value);
+    type(occaType) function occaFloat(value) bind(C, name="occaFloat")
+      import occaType, C_float
+      implicit none
+      real(C_float), value :: value
+    end function
+
+    ! occaType occaDouble(double value);
+    type(occaType) function occaDouble(value) bind(C, name="occaDouble")
+      import occaType, C_double
+      implicit none
+      real(C_double), value :: value
+    end function
+  end interface
+
+  interface
+    ! -----[ Ambiguous Types ]--------------
+    ! occaType occaStruct(const void *value, occaUDim_t bytes);
+    type(occaType) function occaStruct(value, bytes) bind(C, name="occaStruct")
+      import occaType, C_void_ptr, occaUDim_t
+      implicit none
+      type(C_void_ptr), value, intent(in) :: value
+      integer(occaUDim_t), value :: bytes
+    end function
+
+    ! occaType occaString(const char *str);
+    type(occaType) function occaString(str) bind(C, name="occaString")
+      import occaType, C_char
+      implicit none
+      character(len=1,kind=C_char), dimension(*), intent(in) :: str
+    end function
+    ! ======================================
+
+    ! void occaFree(occaType *value)
+    subroutine occaFree(value) bind(C, name="occaFree")
+      import occaType
+      implicit none
+      type(occaType) :: value
+    end subroutine
+  end interface
+
+  interface occaBool
+    module procedure occaBool1
+    module procedure occaBool4
+    module procedure occaBool8
+    !module procedure occaBoolInt1
+    !module procedure occaBoolInt4
+    !module procedure occaBoolInt8
+  end interface
+
+  ! ---[ Type Flags ]---------------------
+  integer(C_int), bind(C, name="OCCA_UNDEFINED")     :: OCCA_C_UNDEFINED
+  integer(C_int), bind(C, name="OCCA_DEFAULT")       :: OCCA_C_DEFAULT
+  integer(C_int), bind(C, name="OCCA_NULL")          :: OCCA_C_NULL
+
+  integer(C_int), bind(C, name="OCCA_PTR")           :: OCCA_C_PTR
+
+  integer(C_int), bind(C, name="OCCA_BOOL")          :: OCCA_C_BOOL
+  integer(C_int), bind(C, name="OCCA_INT8")          :: OCCA_C_INT8
+  integer(C_int), bind(C, name="OCCA_UINT8")         :: OCCA_C_UINT8
+  integer(C_int), bind(C, name="OCCA_INT16")         :: OCCA_C_INT16
+  integer(C_int), bind(C, name="OCCA_UINT16")        :: OCCA_C_UINT16
+  integer(C_int), bind(C, name="OCCA_INT32")         :: OCCA_C_INT32
+  integer(C_int), bind(C, name="OCCA_UINT32")        :: OCCA_C_UINT32
+  integer(C_int), bind(C, name="OCCA_INT64")         :: OCCA_C_INT64
+  integer(C_int), bind(C, name="OCCA_UINT64")        :: OCCA_C_UINT64
+  integer(C_int), bind(C, name="OCCA_FLOAT")         :: OCCA_C_FLOAT
+  integer(C_int), bind(C, name="OCCA_DOUBLE")        :: OCCA_C_DOUBLE
+
+  integer(C_int), bind(C, name="OCCA_STRUCT")        :: OCCA_C_STRUCT
+  integer(C_int), bind(C, name="OCCA_STRING")        :: OCCA_C_STRING
+
+  integer(C_int), bind(C, name="OCCA_DEVICE")        :: OCCA_C_DEVICE
+  integer(C_int), bind(C, name="OCCA_KERNEL")        :: OCCA_C_KERNEL
+  integer(C_int), bind(C, name="OCCA_KERNELBUILDER") :: OCCA_C_KERNELBUILDER
+  integer(C_int), bind(C, name="OCCA_MEMORY")        :: OCCA_C_MEMORY
+  integer(C_int), bind(C, name="OCCA_STREAM")        :: OCCA_C_STREAM
+  integer(C_int), bind(C, name="OCCA_STREAMTAG")     :: OCCA_C_STREAMTAG
+
+  integer(C_int), bind(C, name="OCCA_DTYPE")         :: OCCA_C_DTYPE
+  integer(C_int), bind(C, name="OCCA_SCOPE")         :: OCCA_C_SCOPE
+  integer(C_int), bind(C, name="OCCA_JSON")          :: OCCA_C_JSON
+  integer(C_int), bind(C, name="OCCA_PROPERTIES")    :: OCCA_C_PROPERTIES
+  ! ======================================
+
+  ! ---[ Globals & Flags ]----------------
+  type(occaType), bind(C, name="occaNull")          :: occaNull
+  type(occaType), bind(C, name="occaDefault")       :: occaDefault
+  type(occaType), bind(C, name="occaUndefined")     :: occaUndefined
+  type(occaType), bind(C, name="occaTrue")          :: occaTrue
+  type(occaType), bind(C, name="occaFalse")         :: occaFalse
+  integer(occaUDim_t), bind(C, name="occaAllBytes") :: occaAllBytes
+  ! ======================================
+
+  private :: occaBool1, occaBool4, occaBool8
+  !private :: occaBool1, occaBool4, occaBool8, &
+  !           occaBoolInt1, occaBoolInt4, occaBoolInt8
+
+contains
+
+  type(occaType) function occaBool1(val) result(res)
+    implicit none
+    logical(kind=1), intent(in) :: val
+    res = occaBool_C(logical(val, kind=C_bool))
+  end function
+
+  type(occaType) function occaBool4(val) result(res)
+    implicit none
+    logical(kind=4), intent(in) :: val
+    res = occaBool_C(logical(val, kind=C_bool))
+  end function
+
+  type(occaType) function occaBool8(val) result(res)
+    implicit none
+    logical(kind=8), intent(in) :: val
+    res = occaBool_C(logical(val, kind=C_bool))
+  end function
+
+  ! NOTE: Some compiler support an implict conversion between integer and
+  !       logical. This is however a non-standard extension, see e.g.:
+  !       https://gcc.gnu.org/onlinedocs/gfortran/Implicitly-convert-LOGICAL-and-INTEGER-values.html
+  !type(occaType) function occaBoolInt1(val) result(res)
+  !  implicit none
+  !  integer(kind=1), intent(in) :: val
+  !  logical(kind=C_bool) :: l
+  !  l = val
+  !  res = occaBool_C(l)
+  !end function
+  !
+  !type(occaType) function occaBoolInt4(val) result(res)
+  !  implicit none
+  !  integer(kind=4), intent(in) :: val
+  !  logical(kind=C_bool) :: l
+  !  l = val
+  !  res = occaBool_C(l)
+  !end function
+  !
+  !type(occaType) function occaBoolInt8(val) result(res)
+  !  implicit none
+  !  integer(kind=8), intent(in) :: val
+  !  logical(kind=C_bool) :: l
+  !  l = val
+  !  res = occaBool_C(l)
+  !end function
+
+end module occa_types_m

--- a/src/fortran/occa_uva_m.f90
+++ b/src/fortran/occa_uva_m.f90
@@ -1,0 +1,72 @@
+module occa_uva_m
+  ! occa/c/uva.h
+
+  use occa_types_m
+
+  implicit none
+
+  interface
+    ! bool occaIsManaged(void *ptr);
+    logical(kind=C_bool) function occaIsManaged(ptr) &
+                                  bind(C, name="occaIsManaged")
+      import C_void_ptr, C_bool
+      implicit none
+      type(C_void_ptr), value :: ptr
+    end function
+    ! void occaStartManaging(void *ptr);
+    subroutine occaStartManaging(ptr) bind(C, name="occaStartManaging")
+      import C_void_ptr
+      implicit none
+      type(C_void_ptr), value :: ptr
+    end subroutine
+    ! void occaStopManaging(void *ptr);
+    subroutine occaStopManaging(ptr) bind(C, name="occaStopManaging")
+      import C_void_ptr
+      implicit none
+      type(C_void_ptr), value :: ptr
+    end subroutine
+
+    ! void occaSyncToDevice(void *ptr, const occaUDim_t bytes);
+    subroutine occaSyncToDevice(ptr, bytes) bind(C, name="occaSyncToDevice")
+      import C_void_ptr, occaUDim_t
+      implicit none
+      type(C_void_ptr), value :: ptr
+      integer(occaUDim_t), value :: bytes
+    end subroutine
+    ! void occaSyncToHost(void *ptr, const occaUDim_t bytes);
+    subroutine occaSyncToHost(ptr, bytes) bind(C, name="occaSyncToHost")
+      import C_void_ptr, occaUDim_t
+      implicit none
+      type(C_void_ptr), value :: ptr
+      integer(occaUDim_t), value :: bytes
+    end subroutine
+
+    ! bool occaNeedsSync(void *ptr);
+    logical(kind=C_bool) function occaNeedsSync(ptr) &
+                                  bind(C, name="occaNeedsSync")
+      import C_void_ptr, C_bool
+      implicit none
+      type(C_void_ptr), value :: ptr
+    end function
+    ! void occaSync(void *ptr);
+    subroutine occaSync(ptr) bind(C, name="occaSync")
+      import C_void_ptr
+      implicit none
+      type(C_void_ptr), value :: ptr
+    end subroutine
+    ! void occaDontSync(void *ptr);
+    subroutine occaDontSync(ptr) bind(C, name="occaDontSync")
+      import C_void_ptr
+      implicit none
+      type(C_void_ptr), value :: ptr
+    end subroutine
+
+    ! void occaFreeUvaPtr(void *ptr);
+    subroutine occaFreeUvaPtr(ptr) bind(C, name="occaFreeUvaPtr")
+      import C_void_ptr
+      implicit none
+      type(C_void_ptr), value :: ptr
+    end subroutine
+  end interface
+
+end module occa_uva_m

--- a/tests/run_examples
+++ b/tests/run_examples
@@ -12,23 +12,44 @@ HEADER_CHARS=80
 export LD_LIBRARY_PATH="${OCCA_DIR}/lib:${LD_LIBRARY_PATH}"
 export DYLD_LIBRARY_PATH="${OCCA_DIR}/lib:${DYLD_LIBRARY_PATH}"
 
-declare -a examples=(
-  cpp/01_add_vectors
-  cpp/02_background_device
-  cpp/03_inline_okl
-  cpp/04_reduction
-  cpp/05_building_kernels
-  cpp/06_unified_memory
-  cpp/07_dtypes
-  cpp/08_arrays
-  cpp/09_streams
-  cpp/11_native_cpp_kernels
-  cpp/12_native_c_kernels
-  c/01_add_vectors
-  c/02_background_device
-  c/03_inline_okl
-  c/04_reduction
-)
+# Set default to running the C++ and C examples only
+CPP_EXAMPLES=${CPP_EXAMPLES:-1}
+C_EXAMPLES=${C_EXAMPLES:-1}
+FORTRAN_EXAMPLES=${FORTRAN_EXAMPLES:-0}
+
+declare -a examples=()
+if [[ $CPP_EXAMPLES -eq 1 ]]; then
+  examples+=(
+    cpp/01_add_vectors
+    cpp/02_background_device
+    cpp/03_inline_okl
+    cpp/04_reduction
+    cpp/05_building_kernels
+    cpp/06_unified_memory
+    cpp/07_dtypes
+    cpp/08_arrays
+    cpp/09_streams
+    cpp/11_native_cpp_kernels
+    cpp/12_native_c_kernels
+    )
+fi
+if [[ $C_EXAMPLES -eq 1 ]]; then
+  examples+=(
+    c/01_add_vectors
+    c/02_background_device
+    c/03_inline_okl
+    c/04_reduction
+  )
+fi
+if [[ $FORTRAN_EXAMPLES -eq 1 ]]; then
+  examples+=(
+    fortran/01_add_vectors
+    fortran/02_background_device
+    fortran/03_static_compilation
+    fortran/04_reduction
+    fortran/09_streams
+  )
+fi
 
 failed_examples=""
 for mode in $("${OCCA_DIR}/bin/occa" modes); do
@@ -37,7 +58,7 @@ for mode in $("${OCCA_DIR}/bin/occa" modes); do
         OpenMP) device="mode: 'OpenMP'";;
         CUDA)   device="mode: 'CUDA', device_id: 0";;
         OpenCL) device="mode: 'OpenCL', platform_id: 0, device_id: 0";;
-        Metal) device="mode: 'Metal', device_id: 0";;
+        Metal)  device="mode: 'Metal', device_id: 0";;
     esac
 
     for example_dir in "${examples[@]}"; do
@@ -71,13 +92,19 @@ for mode in $("${OCCA_DIR}/bin/occa" modes); do
                 fi
                 flags=(--verbose)
                 ;;
+            fortran/09_streams)
+                if [[ "${mode}" != Serial ]]; then
+                    continue
+                fi
+                flags=(--verbose)
+                ;;
         esac
 
         banner="(${mode}) ${example_dir}"
         chars=$(echo "${banner}" | wc -c)
         linechars=$((${HEADER_CHARS} - ${chars} - 6))
-	      line=$(printf '%*s' ${linechars} | tr ' ' '-')
-	      echo -e "\n---[ ${banner} ]${line}"
+        line=$(printf '%*s' ${linechars} | tr ' ' '-')
+        echo -e "\n---[ ${banner} ]${line}"
 
         cd "${EXAMPLE_DIR}/${example_dir}"
         make clean; make
@@ -90,7 +117,7 @@ for mode in $("${OCCA_DIR}/bin/occa" modes); do
         fi
 
         # Test output footer
-	      printf '%*s\n' ${HEADER_CHARS} | tr ' ' '='
+        printf '%*s\n' ${HEADER_CHARS} | tr ' ' '='
     done
 done
 

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 TEST_DIR=$(dirname "$0")
-TEST_SRC_DIR=$(dirname "$0")/src
-TEST_BIN_DIR=$(dirname "$0")/bin
+TEST_BIN_DIR=${TEST_DIR}/bin
 
 export ASAN_OPTIONS
 ASAN_OPTIONS+=':protect_shadow_gap=0'
@@ -10,19 +9,16 @@ ASAN_OPTIONS+=':detect_container_overflow=0'
 
 HEADER_CHARS=80
 
-tests_cpp=$(find "${TEST_SRC_DIR}" -type f -name '*.cpp')
+tests=$(find "${TEST_BIN_DIR}" -type f -executable)
 failed_tests=""
 
-for test_cpp in ${tests_cpp}; do
-    test="${test_cpp/${TEST_SRC_DIR}/${TEST_BIN_DIR}}"
-    test="${test/\.cpp/}"
-
+for test in ${tests[@]}; do
     # Test output header
-    test_name="${test_cpp/${TEST_SRC_DIR}\//}"
+    test_name="${test/${TEST_BIN_DIR}\//}"
     chars=$(echo "${test_name}" | wc -c)
     linechars=$((${HEADER_CHARS} - ${chars} - 6))
-	  line=$(printf '%*s' ${linechars} | tr ' ' '-')
-	  echo -e "\n---[ ${test_name} ]${line}"
+    line=$(printf '%*s' ${linechars} | tr ' ' '-')
+    echo -e "\n---[ ${test_name} ]${line}"
 
     "${test}"
 
@@ -38,7 +34,7 @@ for test_cpp in ${tests_cpp}; do
     fi
 
     # Test output footer
-	  printf '%*s\n' ${HEADER_CHARS} | tr ' ' '='
+    printf '%*s\n' ${HEADER_CHARS} | tr ' ' '='
 done
 
 if [[ "${failed_tests}" != "" ]]; then

--- a/tests/src/fortran/typedefs.f90
+++ b/tests/src/fortran/typedefs.f90
@@ -1,0 +1,75 @@
+program main
+  use occa
+
+  implicit none
+
+  call occaPrintModeInfo()
+  call testOccaTypedef(verbose=1)
+
+  stop 0
+
+contains
+
+  subroutine testOccaTypedef(verbose)
+    implicit none
+
+    interface
+      ! typedefs_helper.cpp
+      logical(kind=C_bool) pure function occaTypeHasCorrectSize(s, &
+                                                                magicHeader_s, &
+                                                                type_s, &
+                                                                bytes_s, &
+                                                                needsFree_s, &
+                                                                value_s, &
+                                                                verbose)  &
+                                         bind(C, name="occaTypeHasCorrectSize")
+        use, intrinsic :: iso_c_binding, only: C_size_t, C_bool
+        implicit none
+        integer(C_size_t), value, intent(in) :: s, magicHeader_s, type_s, &
+                                                bytes_s, needsFree_s, value_s
+        logical(kind=C_bool), value, intent(in) :: verbose
+      end function
+
+      pure subroutine printOccaType(value, verbose) &
+                      bind(C, name="printOccaType")
+        use, intrinsic :: iso_c_binding, only: C_bool
+        use occa, only: occaType
+        implicit none
+        type(occaType), intent(in) :: value
+        logical(kind=C_bool), value, intent(in) :: verbose
+      end subroutine
+    end interface
+
+    integer, intent(in), optional :: verbose
+    logical(kind=C_bool) :: ok, vrb
+    type(occaType) :: t
+
+    vrb = .false.
+    if (present(verbose)) then
+      if (verbose > 0) vrb = .true.
+    end if
+
+    ! Check occaType size (useful to verify the F <-> C type mapping)
+    ok = .false.
+    ok = occaTypeHasCorrectSize(C_sizeof(t), &
+                                C_sizeof(t%magicHeader), &
+                                C_sizeof(t%type), &
+                                C_sizeof(t%bytes), &
+                                C_sizeof(t%needsFree), &
+                                C_sizeof(t%value), &
+                                vrb)
+    if (.not. ok) then
+      stop "*** ERROR ***: `occaType` C and Fortran implementations are &
+           &inconsistent!"
+    end if
+
+    ! Dump occaDefault data (useful for debugging F <-> C mapping)
+    t = occaDefault
+    ok = .false.
+    ok = occaIsDefault(t)
+    call printOccaType(t, verbose=vrb)
+    if (.not. ok) then
+      stop "*** ERROR ***: Incorrect `occaDefault` type!"
+    end if
+  end subroutine
+end program

--- a/tests/src/fortran/typedefs_helper.cpp
+++ b/tests/src/fortran/typedefs_helper.cpp
@@ -1,0 +1,103 @@
+#include <stdio.h>
+#include <occa/c/types.h>
+
+OCCA_START_EXTERN_C
+
+//---[ occaType size ]------------------
+static size_t occaTypeGetSize() {
+    return sizeof(occaType);
+}
+
+static size_t occaTypeMagicHeaderGetSize() {
+    return sizeof(((occaType*)0)->magicHeader);
+}
+
+static size_t occaTypeTypeGetSize() {
+    return sizeof(((occaType*)0)->type);
+}
+
+static size_t occaTypeBytesGetSize() {
+    return sizeof(((occaType*)0)->bytes);
+}
+
+static size_t occaTypeNeedsFreeGetSize() {
+    return sizeof(((occaType*)0)->needsFree);
+}
+
+static size_t occaTypeValueGetSize() {
+    return sizeof(((occaType*)0)->value);
+}
+
+bool occaTypeHasCorrectSize(const size_t s,
+                            const size_t magicHeader_s,
+                            const size_t type_s,
+                            const size_t bytes_s,
+                            const size_t needsFree_s,
+                            const size_t value_s,
+                            const bool verbose) {
+    const bool ok = (   s             == occaTypeGetSize()
+                     && magicHeader_s == occaTypeMagicHeaderGetSize()
+                     && type_s        == occaTypeTypeGetSize()
+                     && bytes_s       == occaTypeBytesGetSize()
+                     && needsFree_s   == occaTypeNeedsFreeGetSize()
+                     && value_s       == occaTypeValueGetSize());
+
+    if (verbose || (!ok)) {
+        printf("\n");
+        printf("    ===============================================\n");
+        printf("    OCCA C-Fortran interface type size info:\n");
+        printf("    -------------------------------+-----+---------\n");
+        printf("                                   | C   | Fortran\n");
+        printf("    -------------------------------+-----+---------\n");
+        printf("      sizeof(occaType)             | %3ld | %3ld\n", occaTypeGetSize(), s);
+        printf("      sizeof(occaType.magicHeader) | %3ld | %3ld\n", occaTypeMagicHeaderGetSize(), magicHeader_s);
+        printf("      sizeof(occaType.type)        | %3ld | %3ld\n", occaTypeTypeGetSize(), type_s);
+        printf("      sizeof(occaType.bytes)       | %3ld | %3ld\n", occaTypeBytesGetSize(), bytes_s);
+        printf("      sizeof(occaType.needsFree)   | %3ld | %3ld\n", occaTypeNeedsFreeGetSize(), needsFree_s);
+        printf("      sizeof(occaType.value)       | %3ld | %3ld\n", occaTypeValueGetSize(), value_s);
+        printf("    ===============================================\n");
+        printf("\n");
+    }
+
+    return ok;
+}
+//======================================
+
+//---[ occaType print ]-----------------
+void printOccaType(const occaType *value, const bool verbose) {
+    printf("\n");
+    printf("    ===============================================\n");
+    printf("    Dump OCCA type data:\n");
+    printf("    -----------------------------------------------\n");
+    printf("      Memory address: %p\n", value);
+    printf("\n");
+    printf("      magicHeader:    %d\n", value->magicHeader);
+    printf("      type:           %d\n", value->type);
+    printf("      bytes:          %ld\n", value->bytes);
+    printf("      needsFree:      %d (%s)\n", value->needsFree,
+                                              value->needsFree ? "true" : "false");
+    printf("      value (C `union`):\n");
+    if (verbose) {
+        // Print all types of the C union
+        printf("      value.uint8_:   %d\n", value->value.uint8_);
+        printf("      value.uint16_:  %d\n", value->value.uint16_);
+        printf("      value.uint32_:  %d\n", value->value.uint32_);
+        printf("      value.uint64_:  %ld\n", value->value.uint64_);
+        printf("      value.int8_:    %d\n", value->value.int8_);
+        printf("      value.int16_:   %d\n", value->value.int16_);
+        printf("      value.int32_:   %d\n", value->value.int32_);
+        printf("      value.int64_:   %ld\n", value->value.int64_);
+        printf("      value.float_:   %f\n", value->value.float_);
+        printf("      value.double_:  %f\n", value->value.double_);
+        printf("      value.ptr:      %p\n", value->value.ptr);
+    } else {
+        // In the Fortran module we store the data as int64
+        printf("      value.int64_:   %ld\n", value->value.int64_);
+        printf("      value.ptr:      %p\n", value->value.ptr);
+    }
+    printf("    ===============================================\n");
+    printf("\n");
+}
+//======================================
+
+OCCA_END_EXTERN_C

--- a/tests/src/fortran/types.f90
+++ b/tests/src/fortran/types.f90
@@ -1,0 +1,70 @@
+program main
+  use occa
+
+  implicit none
+
+  call testOccaType()
+
+  stop 0
+
+contains
+
+  subroutine testOccaType()
+    implicit none
+
+    type(occaType) :: t
+
+    ! ---[ Known Types ]--------------------
+    t = occaUndefined
+    if (.not. occaIsUndefined(t)) stop "*** ERROR ***: types - occaUndefined"
+    if (      occaIsDefault(t))   stop "*** ERROR ***: types - occaUndefined"
+
+    t = occaDefault
+    if (.not. occaIsDefault(t))   stop "*** ERROR ***: types - occaDefault"
+    if (      occaIsUndefined(t)) stop "*** ERROR ***: types - occaDefault"
+
+    t = occaNull
+    if (      occaIsDefault(t))   stop "*** ERROR ***: types - occaNull"
+    if (      occaIsUndefined(t)) stop "*** ERROR ***: types - occaNull"
+
+    t = occaPtr(C_NULL_ptr)
+    if (t%type .ne. OCCA_C_PTR)   stop "*** ERROR ***: types - occaPtr"
+
+    t = occaBool(.true._C_bool)
+    if (t%type .ne. OCCA_C_BOOL)  stop "*** ERROR ***: types - occaBool"
+    ! ======================================
+
+
+    ! ---[ Integer Types ]------------------
+    t = occaInt(123_C_int8_t)
+    if (t%type .ne. OCCA_C_INT8)  stop "*** ERROR ***: types - occaInt8"
+
+    t = occaInt(123_C_int16_t)
+    if (t%type .ne. OCCA_C_INT16) stop "*** ERROR ***: types - occaInt16"
+
+    t = occaInt(123_C_int32_t)
+    if (t%type .ne. OCCA_C_INT32) stop "*** ERROR ***: types - occaInt32"
+
+    t = occaInt(123_C_int64_t)
+    if (t%type .ne. OCCA_C_INT64) stop "*** ERROR ***: types - occaInt64"
+    ! ======================================
+
+
+    ! ---[ Real Types ]---------------------
+    t = occaReal(123.45_C_float)
+    if (t%type .ne. OCCA_C_FLOAT)  stop "*** ERROR ***: types - occaFloat"
+
+    t = occaReal(123.45_C_double)
+    if (t%type .ne. OCCA_C_DOUBLE) stop "*** ERROR ***: types - occaDouble"
+    ! ======================================
+
+
+    ! ---[ Ambiguous Types ]----------------
+    t = occaStruct(C_NULL_ptr, 123_occaUDim_t)
+    if (t%type .ne. OCCA_C_STRUCT) stop "*** ERROR ***: types - occaStruct"
+
+    t = occaString("123")
+    if (t%type .ne. OCCA_C_STRING) stop "*** ERROR ***: types - occaString"
+    ! ======================================
+  end subroutine
+end program

--- a/tests/src/io/utils.cpp
+++ b/tests/src/io/utils.cpp
@@ -136,7 +136,7 @@ void testDirMethods() {
             0);
   dirs = occa::io::directories(testDir);
   ASSERT_EQ((int) dirs.size(),
-            6);
+            7);
 
   ASSERT_IN(testDir + "c/", dirs);
   ASSERT_IN(testDir + "io/", dirs);


### PR DESCRIPTION
## Description

This add a Fortran interface for OCCA and respective tests and examples. 

The implementation utilises the Fortran 2003 `ISO_C_BINDING` module. Thus a [Fortran 2003 compliant compiler](http://fortranwiki.org/fortran/show/Fortran+2003+status) is required. The interface relies on OCCA's C interface and is sthus limited to the functionality exposed via the C interface. The Fortran implementation is in most cases a simple `interface` to the C functions, thus simply providing a standardised way for the compiler to call the C functions from a  Fortran program.

The Fortran interface is compiled into a shared library `libocca_fortran.so`, which can be simply linked to an application intending to use OCCA. Alternatively, the Fortran modules can be directly included in a statically compiled program, as demonstrated in `examples/fortran/03_static_compilation`.

This resolves issue #104.


### Future work
While this initial implementation is fully functional, a subsequent revision could include additional wrapper/convenience functions to make the interface more "Fortran-like". 
The following lists a few examples in this regard:
1. The Fortran-to-C string conversion could be hidden by implementing a small shim layer around the `interface` in order to hide the `F_C_str` function in:
``` Fortran
device = occaCreateDeviceFromString(F_C_str(info))
```
2. Another example would be the Fortran pointer assignment for UVA memory, which could be wrapped in a single function call. Currently this requires the following:
``` Fortran
  type(C_void_ptr)       :: a 
  real(C_float), pointer :: a_ptr(:)

  a  = occaTypedUMalloc(entries, occaDtypeFloat, C_NULL_ptr, occaDefault)

  if (C_associated(a)) then
    call C_F_pointer(a,a_ptr,[entries])
  end if
```
3. The call to `C_loc` in 
``` Fortran
call occaCopyPtrToMem(o_b, C_loc(b), occaAllBytes   , 0_occaUDim_t, occaDefault)
```
could be hidden in a convenience function/wrapper analog to the proposed shim layer in 1.
