### PR TITLE
[Preprocessor] Allows including standard headers (prints warnings)

### DIFF
--- a/include/occa/io/utils.hpp
+++ b/include/occa/io/utils.hpp
@@ -35,6 +35,7 @@ namespace occa {
     std::string slashToSnake(const std::string &str);
 
     bool isAbsolutePath(const std::string &filename);
+    std::string getRelativePath(const std::string &filename);
 
     std::string expandEnvVariables(const std::string &filename);
 

--- a/include/occa/lang/preprocessor.hpp
+++ b/include/occa/lang/preprocessor.hpp
@@ -16,6 +16,8 @@ namespace occa {
   namespace lang {
     class tokenizer_t;
 
+    typedef std::map<std::string, bool> stringSet;
+
     typedef std::vector<token_t*> tokenVector;
     typedef std::stack<token_t*>  tokenStack;
     typedef std::list<token_t*>   tokenList;
@@ -57,6 +59,7 @@ namespace occa {
 
       macroMap compilerMacros;
       macroMap sourceMacros;
+      stringSet standardHeaders;
       //================================
 
       //---[ Metadata ]-----------------
@@ -82,6 +85,7 @@ namespace occa {
       preprocessor_t& operator = (const preprocessor_t &pp);
 
       void initDirectives();
+      void initStandardHeaders();
 
       void warningOn(token_t *token,
                      const std::string &message);
@@ -173,6 +177,7 @@ namespace occa {
       void processWarning(identifierToken &directive);
 
       void processInclude(identifierToken &directive);
+      bool isStandardHeader(const std::string &header);
       void processPragma(identifierToken &directive);
       void processOccaPragma(identifierToken &directive,
                              tokenVector &lineTokens);

--- a/src/io/utils.cpp
+++ b/src/io/utils.cpp
@@ -69,9 +69,13 @@ namespace occa {
     std::string currentWorkingDirectory() {
       char cwdBuff[FILENAME_MAX];
 #if (OCCA_OS == OCCA_WINDOWS_OS)
-      ignoreResult(_getcwd(cwdBuff, sizeof(cwdBuff)));
+      ignoreResult(
+        _getcwd(cwdBuff, sizeof(cwdBuff))
+      );
 #else
-      ignoreResult(getcwd(cwdBuff, sizeof(cwdBuff)));
+      ignoreResult(
+        getcwd(cwdBuff, sizeof(cwdBuff))
+      );
 #endif
       return endWithSlash(std::string(cwdBuff));
     }
@@ -151,6 +155,13 @@ namespace occa {
 #endif
     }
 
+    std::string getRelativePath(const std::string &filename) {
+      if (startsWith(filename, "./")) {
+        return filename.substr(2);
+      }
+      return filename;
+    }
+
     std::string expandEnvVariables(const std::string &filename) {
       const int chars = (int) filename.size();
       if (!chars) {
@@ -178,7 +189,7 @@ namespace occa {
       expFilename = fo.expand(expFilename);
 
       if (makeAbsolute && !isAbsolutePath(expFilename)) {
-        expFilename = env::CWD + expFilename;
+        return env::CWD + getRelativePath(expFilename);
       }
       return expFilename;
     }

--- a/src/io/utils.cpp
+++ b/src/io/utils.cpp
@@ -21,6 +21,7 @@
 #include <occa/io/utils.hpp>
 #include <occa/tools/env.hpp>
 #include <occa/tools/lex.hpp>
+#include <occa/tools/misc.hpp>
 
 namespace occa {
   // Kernel Caching
@@ -68,9 +69,9 @@ namespace occa {
     std::string currentWorkingDirectory() {
       char cwdBuff[FILENAME_MAX];
 #if (OCCA_OS == OCCA_WINDOWS_OS)
-      _getcwd(cwdBuff, sizeof(cwdBuff));
+      ignoreResult(_getcwd(cwdBuff, sizeof(cwdBuff)));
 #else
-      getcwd(cwdBuff, sizeof(cwdBuff));
+      ignoreResult(getcwd(cwdBuff, sizeof(cwdBuff)));
 #endif
       return endWithSlash(std::string(cwdBuff));
     }

--- a/src/lang/preprocessor.cpp
+++ b/src/lang/preprocessor.cpp
@@ -27,6 +27,7 @@ namespace occa {
     preprocessor_t::preprocessor_t(const occa::properties &settings_) {
       init();
       initDirectives();
+      initStandardHeaders();
 
       includePaths = env::OCCA_INCLUDE_PATH;
 
@@ -203,6 +204,128 @@ namespace occa {
       directives["include"] = &preprocessor_t::processInclude;
       directives["pragma"]  = &preprocessor_t::processPragma;
       directives["line"]    = &preprocessor_t::processLine;
+    }
+
+    void preprocessor_t::initStandardHeaders() {
+      standardHeaders["algorithm"] = true;
+      standardHeaders["any"] = true;
+      standardHeaders["array"] = true;
+      standardHeaders["assert.h"] = true;
+      standardHeaders["atomic"] = true;
+      standardHeaders["bitset"] = true;
+      standardHeaders["cassert"] = true;
+      standardHeaders["ccomplex"] = true;
+      standardHeaders["cctype"] = true;
+      standardHeaders["cerrno"] = true;
+      standardHeaders["cfenv"] = true;
+      standardHeaders["cfloat"] = true;
+      standardHeaders["charconv"] = true;
+      standardHeaders["chrono"] = true;
+      standardHeaders["cinttypes"] = true;
+      standardHeaders["ciso646"] = true;
+      standardHeaders["climits"] = true;
+      standardHeaders["clocale"] = true;
+      standardHeaders["cmath"] = true;
+      standardHeaders["codecvt"] = true;
+      standardHeaders["compare"] = true;
+      standardHeaders["complex.h"] = true;
+      standardHeaders["complex"] = true;
+      standardHeaders["condition_variable"] = true;
+      standardHeaders["csetjmp"] = true;
+      standardHeaders["csignal"] = true;
+      standardHeaders["cstdalign"] = true;
+      standardHeaders["cstdarg"] = true;
+      standardHeaders["cstdbool"] = true;
+      standardHeaders["cstddef"] = true;
+      standardHeaders["cstdint"] = true;
+      standardHeaders["cstdio"] = true;
+      standardHeaders["cstdlib"] = true;
+      standardHeaders["cstring"] = true;
+      standardHeaders["ctgmath"] = true;
+      standardHeaders["ctime"] = true;
+      standardHeaders["ctype.h"] = true;
+      standardHeaders["cuchar"] = true;
+      standardHeaders["cwchar"] = true;
+      standardHeaders["cwctype"] = true;
+      standardHeaders["deque"] = true;
+      standardHeaders["errno.h"] = true;
+      standardHeaders["exception"] = true;
+      standardHeaders["execution"] = true;
+      standardHeaders["fenv.h"] = true;
+      standardHeaders["filesystem"] = true;
+      standardHeaders["float.h"] = true;
+      standardHeaders["forward_list"] = true;
+      standardHeaders["fstream"] = true;
+      standardHeaders["functional"] = true;
+      standardHeaders["future"] = true;
+      standardHeaders["initializer_list"] = true;
+      standardHeaders["inttypes.h"] = true;
+      standardHeaders["iomanip"] = true;
+      standardHeaders["ios"] = true;
+      standardHeaders["iosfwd"] = true;
+      standardHeaders["iostream"] = true;
+      standardHeaders["iso646.h"] = true;
+      standardHeaders["istream"] = true;
+      standardHeaders["iterator"] = true;
+      standardHeaders["limits.h"] = true;
+      standardHeaders["limits"] = true;
+      standardHeaders["list"] = true;
+      standardHeaders["locale.h"] = true;
+      standardHeaders["locale"] = true;
+      standardHeaders["map"] = true;
+      standardHeaders["math.h"] = true;
+      standardHeaders["memory"] = true;
+      standardHeaders["memory_resource"] = true;
+      standardHeaders["mutex"] = true;
+      standardHeaders["new"] = true;
+      standardHeaders["numeric"] = true;
+      standardHeaders["optional"] = true;
+      standardHeaders["ostream"] = true;
+      standardHeaders["queue"] = true;
+      standardHeaders["random"] = true;
+      standardHeaders["ratio"] = true;
+      standardHeaders["regex"] = true;
+      standardHeaders["scoped_allocator"] = true;
+      standardHeaders["set"] = true;
+      standardHeaders["setjmp.h"] = true;
+      standardHeaders["shared_mutex"] = true;
+      standardHeaders["signal.h"] = true;
+      standardHeaders["sstream"] = true;
+      standardHeaders["stack"] = true;
+      standardHeaders["stdalign.h"] = true;
+      standardHeaders["stdarg.h"] = true;
+      standardHeaders["stdatomic.h"] = true;
+      standardHeaders["stdbool.h"] = true;
+      standardHeaders["stddef.h"] = true;
+      standardHeaders["stdexcept"] = true;
+      standardHeaders["stdint.h"] = true;
+      standardHeaders["stdio.h"] = true;
+      standardHeaders["stdlib.h"] = true;
+      standardHeaders["stdnoreturn.h"] = true;
+      standardHeaders["streambuf"] = true;
+      standardHeaders["string.h"] = true;
+      standardHeaders["string"] = true;
+      standardHeaders["string_view"] = true;
+      standardHeaders["strstream"] = true;
+      standardHeaders["syncstream"] = true;
+      standardHeaders["system_error"] = true;
+      standardHeaders["tgmath.h"] = true;
+      standardHeaders["thread"] = true;
+      standardHeaders["threads.h"] = true;
+      standardHeaders["time.h"] = true;
+      standardHeaders["tuple"] = true;
+      standardHeaders["type_traits"] = true;
+      standardHeaders["typeindex"] = true;
+      standardHeaders["typeinfo"] = true;
+      standardHeaders["uchar.h"] = true;
+      standardHeaders["unordered_map"] = true;
+      standardHeaders["unordered_set"] = true;
+      standardHeaders["utility"] = true;
+      standardHeaders["valarray"] = true;
+      standardHeaders["variant"] = true;
+      standardHeaders["vector"] = true;
+      standardHeaders["wchar.h"] = true;
+      standardHeaders["wctype.h"] = true;
     }
 
     void preprocessor_t::warningOn(token_t *token,
@@ -1174,7 +1297,17 @@ namespace occa {
           }
         }
       }
+
       if (!io::exists(header)) {
+        // Default to standard headers if they exist
+        if (standardHeaders.find(header) != standardHeaders.end()) {
+          warningOn(&directive,
+                    "Including standard headers may not be portable for all modes");
+          pushOutput(new directiveToken(directive.origin,
+                                        "include <" + header + ">"));
+          return;
+        }
+
         errorOn(&directive,
                 "File does not exist");
         skipToNewline();

--- a/src/tools/sys.cpp
+++ b/src/tools/sys.cpp
@@ -277,7 +277,12 @@ namespace occa {
       for (int i = 0; i < pathSize; ++i) {
         const std::string &dir = path[i];
 
-        foundOcca |= dir == "occa" || dir == ".occa";
+        foundOcca |= (
+          dir == "occa"
+          || dir == ".occa"
+          || startsWith(dir, "occa_")
+          || startsWith(dir, ".occa_")
+        );
 
         if (!dir.size() ||
             (dir == ".")) {

--- a/tests/src/fortran/typedefs_helper.cpp
+++ b/tests/src/fortran/typedefs_helper.cpp
@@ -69,7 +69,7 @@ void printOccaType(const occaType *value, const bool verbose) {
     printf("    ===============================================\n");
     printf("    Dump OCCA type data:\n");
     printf("    -----------------------------------------------\n");
-    printf("      Memory address: %p\n", value);
+    printf("      Memory address: %p\n", (void*) value);
     printf("\n");
     printf("      magicHeader:    %d\n", value->magicHeader);
     printf("      type:           %d\n", value->type);

--- a/tests/src/io/fileOpener.cpp
+++ b/tests/src/io/fileOpener.cpp
@@ -42,23 +42,23 @@ void testOccaFileOpener() {
   ASSERT_EQ(occaOpener.expand("occa://foo.okl"),
             "");
 
-  ASSERT_EQ(occaOpener.expand("occa://a/"),
+  ASSERT_EQ(occaOpener.expand("occa://my_library/"),
             "");
-  ASSERT_EQ(occaOpener.expand("occa://a/foo.okl"),
+  ASSERT_EQ(occaOpener.expand("occa://my_library/foo.okl"),
             "");
 
-  occa::io::addLibraryPath("a", "foo");
+  occa::io::addLibraryPath("my_library", "foo");
 
-  ASSERT_EQ(occaOpener.expand("occa://a/"),
+  ASSERT_EQ(occaOpener.expand("occa://my_library/"),
             "foo/");
-  ASSERT_EQ(occaOpener.expand("occa://a/foo.okl"),
+  ASSERT_EQ(occaOpener.expand("occa://my_library/foo.okl"),
             "foo/foo.okl");
 
-  occa::io::addLibraryPath("a", "foo/");
+  occa::io::addLibraryPath("my_library", "foo/");
 
-  ASSERT_EQ(occaOpener.expand("occa://a/"),
+  ASSERT_EQ(occaOpener.expand("occa://my_library/"),
             "foo/");
-  ASSERT_EQ(occaOpener.expand("occa://a/foo.okl"),
+  ASSERT_EQ(occaOpener.expand("occa://my_library/foo.okl"),
             "foo/foo.okl");
 
   ASSERT_THROW(

--- a/tests/src/io/utils.cpp
+++ b/tests/src/io/utils.cpp
@@ -59,6 +59,15 @@ void testPathMethods() {
   ASSERT_EQ(occa::io::convertSlashes("/a/b"),
             "/a/b");
 
+  ASSERT_EQ(occa::io::getRelativePath("./a"),
+            "a");
+  ASSERT_EQ(occa::io::getRelativePath("./a/b"),
+            "a/b");
+  ASSERT_EQ(occa::io::getRelativePath(".a/b"),
+            ".a/b");
+  ASSERT_EQ(occa::io::getRelativePath("../a/b"),
+            "../a/b");
+
   ASSERT_EQ(occa::io::expandEnvVariables("~"),
             occa::env::HOME);
   ASSERT_EQ(occa::io::expandEnvVariables("~/a"),

--- a/tests/src/lang/preprocessor.cpp
+++ b/tests/src/lang/preprocessor.cpp
@@ -15,6 +15,7 @@ void testIfWithUndefines();
 void testErrorDefines();
 void testSpecialMacros();
 void testInclude();
+void testIncludeStandardHeader();
 void testPragma();
 void testOccaPragma();
 void testOccaDirective();
@@ -82,6 +83,7 @@ int main(const int argc, const char **argv) {
   testErrorDefines();
   testSpecialMacros();
   testInclude();
+  testIncludeStandardHeader();
   testPragma();
   testOccaPragma();
   testOccaDirective();
@@ -598,6 +600,35 @@ void testInclude() {
   preprocessor_t &pp = *((preprocessor_t*) tokenStream.getInput("preprocessor_t"));
   ASSERT_EQ(1,
             (int) pp.dependencies.size());
+}
+
+void testIncludeStandardHeader() {
+#define checkInclude(header)                    \
+  getToken();                                   \
+  ASSERT_EQ_BINARY(tokenType::directive,        \
+                   token->type());              \
+  ASSERT_EQ("include <" header ">",             \
+            token->to<directiveToken>().value)
+
+  setStream(
+     "#include \"math.h\"\n"
+      "#include <math.h>\n"
+      "#include \"cmath\"\n"
+      "#include <cmath>\n"
+      "#include \"iostream\"\n"
+      "#include <iostream>\n"
+  );
+
+  preprocessor_t *pp = (preprocessor_t*) tokenStream.getInput("preprocessor_t");
+
+  checkInclude("math.h");
+  checkInclude("math.h");
+  checkInclude("cmath");
+  checkInclude("cmath");
+  checkInclude("iostream");
+  checkInclude("iostream");
+
+  ASSERT_EQ(6, pp->warnings);
 }
 
 void testPragma() {

--- a/tests/src/tools/sys.cpp
+++ b/tests/src/tools/sys.cpp
@@ -17,11 +17,17 @@ int main(const int argc, const char **argv) {
 }
 
 void testRmrf() {
+  // Need to make sure "occa" is in the filepath
+  occa::io::addLibraryPath("my_library", "/path/to/my_library/occa");
+
   ASSERT_TRUE(occa::sys::isSafeToRmrf("/a/occa/b"));
   ASSERT_TRUE(occa::sys::isSafeToRmrf("/a/b/../b/.occa"));
+  ASSERT_TRUE(occa::sys::isSafeToRmrf("/a/occa_dir/b"));
+  ASSERT_TRUE(occa::sys::isSafeToRmrf("/a/b/../b/.occa_dir"));
   ASSERT_TRUE(occa::sys::isSafeToRmrf("/../../../../../occa/a/b"));
   ASSERT_TRUE(occa::sys::isSafeToRmrf("~/c/.cache/occa"));
-  ASSERT_TRUE(occa::sys::isSafeToRmrf("occa://lib"));
+  ASSERT_TRUE(occa::sys::isSafeToRmrf("occa://my_library/"));
+  ASSERT_TRUE(occa::sys::isSafeToRmrf("occa://my_library/file"));
 
   ASSERT_FALSE(occa::sys::isSafeToRmrf("/occa/a/.."));
   ASSERT_FALSE(occa::sys::isSafeToRmrf("/a/b/c/.."));
@@ -29,12 +35,13 @@ void testRmrf() {
   ASSERT_FALSE(occa::sys::isSafeToRmrf("/../../../../../a/b"));
   ASSERT_FALSE(occa::sys::isSafeToRmrf("~/c/.."));
 
+  // Needs to have occa in the name
   const std::string dummyDir = "occa_foo_bar_test";
 
   occa::sys::rmrf(dummyDir);
   ASSERT_FALSE(occa::io::isDir(dummyDir));
 
-  occa::sys::mkdir(dummyDir);
+  occa::sys::mkpath(dummyDir);
   ASSERT_TRUE(occa::io::isDir(dummyDir));
 
   occa::sys::rmrf(dummyDir);


### PR DESCRIPTION
## Description

Allows including standard headers such as 

```cpp
#include <math.h>
```

but prints warnings since it might not be portable

For cleanup, adds `occa_` and `.occa_` prefixed files to the list of "safe to delete" directories

<!-- Thank you for contributing! -->
