### PR TITLE
[Preprocessor] Adds OCCA defines when compiling kernels

### DIFF
--- a/src/lang/preprocessor.cpp
+++ b/src/lang/preprocessor.cpp
@@ -78,6 +78,15 @@ namespace occa {
         compilerMacros[specialMacros[i]->name()] = specialMacros[i];
       }
 
+      // OCCA-specific macros
+      addCompilerDefine("OCCA_MAJOR_VERSION", toString(OCCA_MAJOR_VERSION));
+      addCompilerDefine("OCCA_MINOR_VERSION", toString(OCCA_MINOR_VERSION));
+      addCompilerDefine("OCCA_PATCH_VERSION", toString(OCCA_PATCH_VERSION));
+      addCompilerDefine("OCCA_VERSION", toString(OCCA_VERSION));
+      addCompilerDefine("OKL_VERSION" , toString(OKL_VERSION));
+      addCompilerDefine("__OKL__" , "1");
+      addCompilerDefine("__OCCA__" , "1");
+
       // Alternative representations
       addCompilerDefine("and"   , "&&");
       addCompilerDefine("and_eq", "&=");

--- a/tests/src/lang/preprocessor.cpp
+++ b/tests/src/lang/preprocessor.cpp
@@ -13,6 +13,7 @@ void testIfElse();
 void testIfElseDefines();
 void testIfWithUndefines();
 void testErrorDefines();
+void testOccaMacros();
 void testSpecialMacros();
 void testInclude();
 void testPragma();
@@ -80,6 +81,7 @@ int main(const int argc, const char **argv) {
   testIfElseDefines();
   testIfWithUndefines();
   testErrorDefines();
+  testOccaMacros();
   testSpecialMacros();
   testInclude();
   testPragma();
@@ -508,6 +510,35 @@ void testErrorDefines() {
   while (!tokenStream.isEmpty()) {
     getToken();
   }
+}
+
+void testOccaMacros() {
+  setStream(
+    "OCCA_MAJOR_VERSION\n"
+    "OCCA_MINOR_VERSION\n"
+    "OCCA_PATCH_VERSION\n"
+    "OCCA_VERSION\n"
+    "OKL_VERSION\n"
+    "__OKL__\n"
+    "__OCCA__\n"
+  );
+
+  ASSERT_EQ(OCCA_MAJOR_VERSION,
+            (int) nextTokenPrimitiveValue());
+  ASSERT_EQ(OCCA_MINOR_VERSION,
+            (int) nextTokenPrimitiveValue());
+  ASSERT_EQ(OCCA_PATCH_VERSION,
+            (int) nextTokenPrimitiveValue());
+  ASSERT_EQ(OCCA_VERSION,
+            (int) nextTokenPrimitiveValue());
+  ASSERT_EQ(OKL_VERSION,
+            (int) nextTokenPrimitiveValue());
+  // __OKL__
+  ASSERT_EQ(1,
+            (int) nextTokenPrimitiveValue());
+  // __OCCA__
+  ASSERT_EQ(1,
+            (int) nextTokenPrimitiveValue());
 }
 
 void testSpecialMacros() {


### PR DESCRIPTION
## Description

Adds the following defines when compiling OKL kernels:

- `OCCA_MAJOR_VERSION`
- `OCCA_MINOR_VERSION`
- `OCCA_PATCH_VERSION`
- `OCCA_VERSION`
- `OKL_VERSION`
- `__OKL__`
- `__OCCA__`

All of these defines can be found in `include/occa/defines/occa.hpp` except for the following which are defined as a plain `1` to be truthy:
- `__OKL__`
- `__OCCA__`


<!-- Thank you for contributing! -->
