### PR TITLE
[Lang] Pretty-prints long function calls and tuples

### DIFF
--- a/include/occa/lang/expr/exprNode.hpp
+++ b/include/occa/lang/expr/exprNode.hpp
@@ -21,6 +21,10 @@ namespace occa {
     typedef std::stack<exprNode*>   exprNodeStack;
     typedef std::vector<token_t*>   tokenVector;
 
+    // Variables to help make output prettier
+    static const int PRETTIER_MAX_VAR_WIDTH  = 30;
+    static const int PRETTIER_MAX_LINE_WIDTH = 80;
+
     namespace exprNodeType {
       extern const udim_t empty;
       extern const udim_t primitive;

--- a/include/occa/lang/printer.hpp
+++ b/include/occa/lang/printer.hpp
@@ -9,8 +9,6 @@
 
 namespace occa {
   namespace lang {
-    int charsFromNewline(const std::string &s);
-
     class printer {
     private:
       std::stringstream ss;
@@ -38,6 +36,7 @@ namespace occa {
       void pushInlined(const bool inlined);
       void popInlined();
 
+      int indentationSize();
       void addIndentation();
       void removeIndentation();
 
@@ -45,6 +44,7 @@ namespace occa {
       bool lastCharNeedsWhitespace();
       void forceNextInlined();
 
+      int cursorPosition();
       std::string indentFromNewline();
 
       void printIndentation();

--- a/src/lang/expr/callNode.cpp
+++ b/src/lang/expr/callNode.cpp
@@ -52,15 +52,53 @@ namespace occa {
     }
 
     void callNode::print(printer &pout) const {
-      pout << *value
-           << '(';
+      bool useNewlineDelimiters = false;
+      std::string functionName = value->toString();
+      int lineWidth = (
+        pout.cursorPosition()
+        + (int) functionName.size()
+      );
+
       const int argCount = (int) args.size();
       for (int i = 0; i < argCount; ++i) {
+        const std::string argStr = args[i]->toString();
+        const int argSize = (int) argStr.size();
+        lineWidth += argSize;
+
+        useNewlineDelimiters |= (
+          argSize > PRETTIER_MAX_VAR_WIDTH
+          || lineWidth > PRETTIER_MAX_LINE_WIDTH
+        );
+      }
+
+      pout << functionName
+           << '(';
+
+      if (useNewlineDelimiters) {
+        pout.addIndentation();
+        pout.printNewline();
+        pout.printIndentation();
+      }
+
+      for (int i = 0; i < argCount; ++i) {
         if (i) {
-          pout << ", ";
+          if (useNewlineDelimiters) {
+            pout << ',';
+            pout.printNewline();
+            pout.printIndentation();
+          } else {
+            pout << ", ";
+          }
         }
         pout << *(args[i]);
       }
+
+      if (useNewlineDelimiters) {
+        pout.removeIndentation();
+        pout.printNewline();
+        pout.printIndentation();
+      }
+
       pout << ')';
     }
 

--- a/src/lang/expr/expression.cpp
+++ b/src/lang/expr/expression.cpp
@@ -411,7 +411,7 @@ namespace occa {
         // Only consider () as a function call if preceeded by:
         //   - identifier
         //   - pairEnd
-        const int prevTokenType = state.beforePairToken->type();
+        const int prevTokenType = token_t::safeType(state.beforePairToken);
         if (!(prevTokenType & (outputTokenType |
                                tokenType::op))) {
           transformLastPair(opToken, state);

--- a/src/lang/expr/tupleNode.cpp
+++ b/src/lang/expr/tupleNode.cpp
@@ -48,14 +48,50 @@ namespace occa {
     }
 
     void tupleNode::print(printer &pout) const {
-      pout << '{';
+      bool useNewlineDelimiters = false;
+      strVector printedArgs;
+      // For the initial {
+      int lineWidth = pout.cursorPosition() + 1;
+
       const int argCount = (int) args.size();
       for (int i = 0; i < argCount; ++i) {
+        const std::string argStr = args[i]->toString();
+        const int argSize = (int) argStr.size();
+        lineWidth += argSize;
+
+        useNewlineDelimiters |= (
+          argSize > PRETTIER_MAX_VAR_WIDTH
+          || lineWidth > PRETTIER_MAX_LINE_WIDTH
+        );
+      }
+
+      pout << '{';
+
+      if (useNewlineDelimiters) {
+        pout.addIndentation();
+        pout.printNewline();
+        pout.printIndentation();
+      }
+
+      for (int i = 0; i < argCount; ++i) {
         if (i) {
-          pout << ", ";
+          if (useNewlineDelimiters) {
+            pout << ',';
+            pout.printNewline();
+            pout.printIndentation();
+          } else {
+            pout << ", ";
+          }
         }
         pout << *(args[i]);
       }
+
+      if (useNewlineDelimiters) {
+        pout.removeIndentation();
+        pout.printNewline();
+        pout.printIndentation();
+      }
+
       pout << '}';
     }
 

--- a/src/lang/printer.cpp
+++ b/src/lang/printer.cpp
@@ -2,17 +2,6 @@
 
 namespace occa {
   namespace lang {
-    int charsFromNewline(const std::string &s) {
-      const char *c = s.c_str();
-      const int chars = (int) s.size();
-      for (int pos = (chars - 1); pos >= 0; --pos) {
-        if (*c == '\n') {
-          return (chars - pos - 1);
-        }
-      }
-      return chars;
-    }
-
     printer::printer() :
       ss(),
       out(NULL) {
@@ -67,6 +56,10 @@ namespace occa {
       }
     }
 
+    int printer::indentationSize() {
+      (int) indent.size();
+    }
+
     void printer::addIndentation() {
       indent += "  ";
     }
@@ -95,6 +88,10 @@ namespace occa {
 
     void printer::forceNextInlined() {
       lastChar = '\0';
+    }
+
+    int printer::cursorPosition() {
+      return charsFromNewline;
     }
 
     std::string printer::indentFromNewline() {


### PR DESCRIPTION
## Description

Pretty prints long function calls and tuples

#### Function

```cpp
tensor_2d_gradElementTranspose_Q6_P5(o0_B, o0_Bx, (double *) quadOutput0[component][0], (double *) quadOutput0[component][1], &dofOutput0[0 + (5 * (0 + (5 * (component + (1 * element)))))]); 
```
⟶
```cpp
tensor_2d_gradElementTranspose_Q6_P5(
  o0_B,
  o0_Bx,
  (double *) quadOutput0[component][0],
  (double *) quadOutput0[component][1],
  &dofOutput0[0 + (5 * (0 + (5 * (component + (1 * element)))))]
);
```

#### Tuple

```cpp
const double dXdxdXdxT[2][2] = {{qdata[i + 0 * Q], qdata[i + 2 * Q]}, {qdata[i + 2 * Q], qdata[i + 1 * Q]}};
```
⟶
```cpp
const double dXdxdXdxT[2][2] = {
  {qdata[i + 0 * Q], qdata[i + 2 * Q]},
  {qdata[i + 2 * Q], qdata[i + 1 * Q]}
};
```