### PR TITLE
[Preprocessor] Adds OKL_KERNEL_HASH define to help debug running kernels

### DIFF
--- a/include/occa/lang/preprocessor.hpp
+++ b/include/occa/lang/preprocessor.hpp
@@ -63,6 +63,8 @@ namespace occa {
       //================================
 
       //---[ Metadata ]-----------------
+      occa::properties settings;
+
       strToBoolMap dependencies;
       int warnings, errors;
       //================================
@@ -83,6 +85,8 @@ namespace occa {
       void clear_();
 
       preprocessor_t& operator = (const preprocessor_t &pp);
+
+      void setSettings(occa::properties settings_);
 
       void initDirectives();
       void initStandardHeaders();

--- a/src/lang/preprocessor.cpp
+++ b/src/lang/preprocessor.cpp
@@ -29,9 +29,11 @@ namespace occa {
       initDirectives();
       initStandardHeaders();
 
+      setSettings(settings_);
+
       includePaths = env::OCCA_INCLUDE_PATH;
 
-      json oklIncludePaths = settings_["okl/include_paths"];
+      json oklIncludePaths = settings["okl/include_paths"];
       if (oklIncludePaths.isArray()) {
         jsonArray pathArray = oklIncludePaths.array();
         const int pathCount = (int) pathArray.size();
@@ -87,6 +89,16 @@ namespace occa {
       addCompilerDefine("OKL_VERSION" , toString(OKL_VERSION));
       addCompilerDefine("__OKL__" , "1");
       addCompilerDefine("__OCCA__" , "1");
+
+      // Add kernel hash as a define
+      std::string hashValue = settings.get<std::string>("hash", "");
+      if (hashValue.size()) {
+        hash_t hash = hash_t::fromString(hashValue);
+        hashValue = hash.getString();
+      } else {
+        hashValue = "unknown";
+      }
+      addCompilerDefine("OKL_KERNEL_HASH", "\"" + hashValue + "\"");
 
       // Alternative representations
       addCompilerDefine("and"   , "&&");
@@ -194,6 +206,10 @@ namespace occa {
         ++it;
       }
       return *this;
+    }
+
+    void preprocessor_t::setSettings(occa::properties settings_) {
+      settings = settings_;
     }
 
     void preprocessor_t::initDirectives() {

--- a/tests/src/lang/preprocessor.cpp
+++ b/tests/src/lang/preprocessor.cpp
@@ -515,6 +515,13 @@ void testErrorDefines() {
 }
 
 void testOccaMacros() {
+  occa::hash_t hash = occa::hash_t::fromString("df15688e1bde01ebb5b3750031d017b2312d028acd9753b27dd4ba0aef0a4d41");
+
+  occa::properties preprocessorSettings;
+  preprocessorSettings["hash"] = hash.getFullString();
+
+  preprocessor.setSettings(preprocessorSettings);
+
   setStream(
     "OCCA_MAJOR_VERSION\n"
     "OCCA_MINOR_VERSION\n"
@@ -523,6 +530,7 @@ void testOccaMacros() {
     "OKL_VERSION\n"
     "__OKL__\n"
     "__OCCA__\n"
+    "OKL_KERNEL_HASH\n"
   );
 
   ASSERT_EQ(OCCA_MAJOR_VERSION,
@@ -541,6 +549,18 @@ void testOccaMacros() {
   // __OCCA__
   ASSERT_EQ(1,
             (int) nextTokenPrimitiveValue());
+  // OKL_KERNEL_HASH
+  ASSERT_EQ(hash.getString(),
+            nextTokenStringValue());
+
+  // Test default OKL_KERNEL_HASH
+  preprocessor.setSettings("");
+
+  setStream("OKL_KERNEL_HASH");
+
+  // OKL_KERNEL_HASH
+  ASSERT_EQ("unknown",
+            nextTokenStringValue());
 }
 
 void testSpecialMacros() {


### PR DESCRIPTION
## Description

Adds `OKL_KERNEL_HASH` string define to make it easy to debug which kernel is being run

**Tip**: You can use `printf()` or `std::cout` in Serial mode!


<!-- Thank you for contributing! -->
