### PR TITLE
[Parser] Bug not loading child statements properly

### DIFF
--- a/src/lang/parser.cpp
+++ b/src/lang/parser.cpp
@@ -663,7 +663,7 @@ namespace occa {
       // We need to create a block statement to hold these statements
       blockStatement *blockSmnt = new blockStatement(smnt->up,
                                                      smnt->source);
-      statementPtrVector &statements = smntContext.up->children;
+      statementPtrVector &statements = blockSmnt->children;
 
       smntContext.pushUp(*blockSmnt);
 
@@ -676,6 +676,11 @@ namespace occa {
         if (!smnt || smnt->type() != statementType::comment) {
           break;
         }
+      }
+
+      // Add the last non-comment statement
+      if (smnt) {
+        statements.push_back(smnt);
       }
 
       smntContext.popUp();

--- a/tests/files/addVectors.okl
+++ b/tests/files/addVectors.okl
@@ -23,5 +23,12 @@
                         float *ab) {
   for (int i = 0; i < /*Comment 5.1*/ entries; ++i; /*Comment 5.2*/ @tile(16, @outer, @inner)) {
     ab[i] = a[i] + b[i];
+
+    double A[3][3];
+    for (int i = 0; i < 3; i++)
+      for (int j = 0; j < 3; j++)
+        // Comment 6.1
+        // Comment 6.2
+        A[i][k] = a[i] + b[j];
   }
 }


### PR DESCRIPTION
## Description

During the PR to add `commentStatement`, the logic for fetching the next non-`commentStatement` when it started with a `commentStatement` was wrong