### PR TITLE
[Tokenizer] Don't prematurely load primitives

### DIFF
--- a/tests/src/lang/tokenizer/token.cpp
+++ b/tests/src/lang/tokenizer/token.cpp
@@ -29,6 +29,11 @@ void testPeekMethods() {
     tokenType::identifier,
     tokenizer.peek()
   );
+  setStream("true_case");
+  ASSERT_EQ_BINARY(
+    tokenType::identifier,
+    tokenizer.peek()
+  );
 
   setStream("1");
   ASSERT_EQ_BINARY(
@@ -121,6 +126,11 @@ void testTokenMethods() {
     getTokenType()
   );
   setToken("_abcd020230");
+  ASSERT_EQ_BINARY(
+    tokenType::identifier,
+    getTokenType()
+  );
+  setToken("true_case");
   ASSERT_EQ_BINARY(
     tokenType::identifier,
     getTokenType()


### PR DESCRIPTION
## Description

Fixes corner-case when loading tokens and the identifier starts with `true` or `false`


<!-- Thank you for contributing! -->
