### PR TITLE
[Parser] Properly stores struct definitions

### DIFF
--- a/include/occa/lang/file.hpp
+++ b/include/occa/lang/file.hpp
@@ -99,6 +99,8 @@ namespace occa {
 
       dim_t distanceTo(const fileOrigin &origin);
 
+      bool operator == (const fileOrigin &origin);
+
       void preprint(io::output &out) const;
       void postprint(io::output &out) const;
 

--- a/src/lang/file.cpp
+++ b/src/lang/file.cpp
@@ -254,6 +254,16 @@ namespace occa {
       return (origin.position.start - position.end);
     }
 
+    bool fileOrigin::operator == (const fileOrigin &origin) {
+      if (file != origin.file) {
+        return false;
+      }
+      return (
+        position.start == origin.position.start
+        && position.end == origin.position.end
+      );
+    }
+
     void fileOrigin::preprint(io::output &out) const {
       print(out, true);
     }

--- a/src/lang/statement/declarationStatement.cpp
+++ b/src/lang/statement/declarationStatement.cpp
@@ -121,7 +121,7 @@ namespace occa {
         if (!success) {
           delete type;
         }
-      } else if (var.vartype.has(struct_)) {
+      } else if (var.vartype.definesStruct()) {
         // Struct
         declaredType = true;
 

--- a/src/lang/statement/functionDeclStatement.cpp
+++ b/src/lang/statement/functionDeclStatement.cpp
@@ -47,12 +47,16 @@ namespace occa {
     }
 
     void functionDeclStatement::print(printer &pout) const {
+      // Double newlines to make it look cleaner
+      pout.printNewlines(2);
+
       pout.printStartIndentation();
       function.printDeclaration(pout);
       pout << ' ';
       blockStatement::print(pout);
+
       // Double newlines to make it look cleaner
-      pout << '\n';
+      pout.printNewlines(2);
     }
   }
 }

--- a/src/lang/type/vartype.cpp
+++ b/src/lang/type/vartype.cpp
@@ -310,8 +310,14 @@ namespace occa {
 
     vartype_t vartype_t::declarationType() const {
       vartype_t other;
-      other.type = type;
+
+      if (typeToken && type) {
+        other.setType(*typeToken, *type);
+      } else if (type) {
+        other.setType(*type);
+      }
       other.qualifiers = qualifiers;
+
       return other;
     }
 
@@ -341,8 +347,8 @@ namespace occa {
     }
 
     bool vartype_t::definesStruct() const {
-      if (has(struct_)) {
-        return true;
+      if (typeToken && type && (type->type() & typeType::struct_)) {
+        return (typeToken->origin == type->source->origin);
       }
       if (!has(typedef_)) {
         return false;


### PR DESCRIPTION
## Description

New struct loader wasn't handling when `struct` was used as a qualifier


<!-- Thank you for contributing! -->
