### PR TITLE
[CMake] Place compiledDefines header in Cmake build directory, rather than source tree. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,8 @@ find_package(Threads REQUIRED)
 target_link_libraries(libocca PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 
 target_include_directories(libocca PUBLIC
-                          $<BUILD_INTERFACE:${OCCA_SOURCE_DIR}/include>)
+                          $<BUILD_INTERFACE:${OCCA_SOURCE_DIR}/include>
+                          $<BUILD_INTERFACE:${OCCA_BUILD_DIR}/include>)
 
 target_compile_definitions(libocca PRIVATE -DUSE_CMAKE)
 
@@ -221,7 +222,7 @@ if (ENABLE_MPI)
 endif(ENABLE_MPI)
 
 #Generate CompiledDefines from libraries we found
-configure_file(scripts/compiledDefinesTemplate.hpp.in ${OCCA_SOURCE_DIR}/include/occa/defines/compiledDefines.hpp)
+configure_file(scripts/compiledDefinesTemplate.hpp.in ${OCCA_BUILD_DIR}/include/occa/defines/compiledDefines.hpp)
 
 #Find source files
 file(GLOB_RECURSE OCCA_SRC RELATIVE ${OCCA_SOURCE_DIR} "src/*.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ set_target_properties(libocca PROPERTIES OUTPUT_NAME occa LIBRARY_OUTPUT_DIRECTO
 
 #Find needed and requested packages
 find_package(Threads REQUIRED)
-target_link_libraries(libocca PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(libocca PRIVATE ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 
 target_include_directories(libocca PUBLIC
                           $<BUILD_INTERFACE:${OCCA_SOURCE_DIR}/include>

--- a/src/modes/cuda/device.cpp
+++ b/src/modes/cuda/device.cpp
@@ -283,6 +283,7 @@ namespace occa {
               << " -D OCCA_OS=OCCA_WINDOWS_OS -D _MSC_VER=1800"
 #endif
               << " -I"        << env::OCCA_DIR << "include"
+              << " -I"        << env::OCCA_INSTALL_DIR << "include"
               << " -L"        << env::OCCA_INSTALL_DIR << "lib -locca"
               << " -x cu -c " << sourceFilename
               << " -o "       << ptxBinaryFilename;
@@ -311,6 +312,7 @@ namespace occa {
               << " -D OCCA_OS=OCCA_WINDOWS_OS -D _MSC_VER=1800"
 #endif
               << " -I"        << env::OCCA_DIR << "include"
+              << " -I"        << env::OCCA_INSTALL_DIR << "include"
               << " -L"        << env::OCCA_INSTALL_DIR << "lib -locca"
               << " -x cu " << sourceFilename
               << " -o "    << binaryFilename;

--- a/src/modes/hip/device.cpp
+++ b/src/modes/hip/device.cpp
@@ -284,6 +284,7 @@ namespace occa {
               << ' ' << hipccCompilerFlags
 #if defined(__HIP_PLATFORM_NVCC___) || defined(__HIP_ROCclr__)
               << " -I"        << env::OCCA_DIR << "include"
+              << " -I"        << env::OCCA_INSTALL_DIR << "include"
 #endif
               /* NC: hipcc doesn't seem to like linking a library in */
               //<< " -L"        << env::OCCA_INSTALL_DIR << "lib -locca"

--- a/src/modes/serial/device.cpp
+++ b/src/modes/serial/device.cpp
@@ -329,6 +329,7 @@ namespace occa {
               << ' '    << sourceFilename
               << " -o " << binaryFilename
               << " -I"  << env::OCCA_DIR << "include"
+              << " -I"  << env::OCCA_INSTALL_DIR << "include"
               << " -L"  << env::OCCA_INSTALL_DIR << "lib -locca"
               << ' '    << compilerLinkerFlags
               << std::endl;
@@ -340,6 +341,7 @@ namespace occa {
               << " /wd4244 /wd4800 /wd4804 /wd4018"
               << ' '       << compilerFlags
               << " /I"     << env::OCCA_DIR << "include"
+              << " /I"     << env::OCCA_INSTALL_DIR << "include"
               << ' '       << sourceFilename
               << " /link " << env::OCCA_INSTALL_DIR << "lib/libocca.lib",
               << ' '       << compilerLinkerFlags


### PR DESCRIPTION
## Description

This PR is to move the install location of the `compiledDefines.hpp` header to the cmake build folder, rather than placing it in the OCCA_DIR/include folder. This behavior makes the cmake build system align better with the usual cmake workflow. 


<!-- Thank you for contributing! -->
