### PR TITLE
[Core] Adding hostMalloc API

### DIFF
--- a/include/occa/c/memory.h
+++ b/include/occa/c/memory.h
@@ -8,8 +8,7 @@ OCCA_START_EXTERN_C
 
 bool occaMemoryIsInitialized(occaMemory memory);
 
-void* occaMemoryPtr(occaMemory memory,
-                    occaJson props);
+void* occaMemoryPtr(occaMemory memory);
 
 occaDevice occaMemoryGetDevice(occaMemory memory);
 

--- a/include/occa/core/memory.hpp
+++ b/include/occa/core/memory.hpp
@@ -55,12 +55,6 @@ namespace occa {
     template <class TM = void>
     const TM* ptr() const;
 
-    template <class TM = void>
-    TM* ptr(const occa::json &props);
-
-    template <class TM = void>
-    const TM* ptr(const occa::json &props) const;
-
     modeMemory_t* getModeMemory() const;
     modeDevice_t* getModeDevice() const;
 
@@ -163,12 +157,6 @@ namespace occa {
 
   template <>
   const void* memory::ptr<void>() const;
-
-  template <>
-  void* memory::ptr<void>(const occa::json &props);
-
-  template <>
-  const void* memory::ptr<void>(const occa::json &props) const;
 }
 
 #include "memory.tpp"

--- a/include/occa/core/memory.tpp
+++ b/include/occa/core/memory.tpp
@@ -8,14 +8,4 @@ namespace occa {
   const TM* memory::ptr() const {
     return (const TM*) ptr<void>();
   }
-
-  template <class TM>
-  TM* memory::ptr(const occa::json &props) {
-    return (TM*) ptr<void>(props);
-  }
-
-  template <class TM>
-  const TM* memory::ptr(const occa::json &props) const {
-    return (const TM*) ptr<void>(props);
-  }
 }

--- a/src/c/memory.cpp
+++ b/src/c/memory.cpp
@@ -7,13 +7,9 @@ bool occaMemoryIsInitialized(occaMemory memory) {
   return occa::c::memory(memory).isInitialized();
 }
 
-void* occaMemoryPtr(occaMemory memory,
-                    occaJson props) {
+void* occaMemoryPtr(occaMemory memory) {
   occa::memory mem = occa::c::memory(memory);
-  if (occa::c::isDefault(props)) {
-    return mem.ptr();
-  }
-  return mem.ptr(occa::c::json(props));
+  return mem.ptr();
 }
 
 occaDevice occaMemoryGetDevice(occaMemory memory) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -85,28 +85,14 @@ namespace occa {
   template <>
   void* memory::ptr<void>() {
     return (modeMemory
-            ? modeMemory->ptr
+            ? modeMemory->getPtr()
             : NULL);
   }
 
   template <>
   const void* memory::ptr<void>() const {
     return (modeMemory
-            ? modeMemory->ptr
-            : NULL);
-  }
-
-  template <>
-  void* memory::ptr<void>(const occa::json &props) {
-    return (modeMemory
-            ? modeMemory->getPtr(props)
-            : NULL);
-  }
-
-  template <>
-  const void* memory::ptr<void>(const occa::json &props) const {
-    return (modeMemory
-            ? modeMemory->getPtr(props)
+            ? modeMemory->getPtr()
             : NULL);
   }
 

--- a/src/occa/internal/core/memory.cpp
+++ b/src/occa/internal/core/memory.cpp
@@ -30,7 +30,7 @@ namespace occa {
     }
   }
 
-  void* modeMemory_t::getPtr(const occa::json &props) {
+  void* modeMemory_t::getPtr() {
     return ptr;
   }
 

--- a/src/occa/internal/core/memory.hpp
+++ b/src/occa/internal/core/memory.hpp
@@ -44,7 +44,7 @@ namespace occa {
 
     virtual modeMemory_t* addOffset(const dim_t offset) = 0;
 
-    virtual void* getPtr(const occa::json &props);
+    virtual void* getPtr();
 
     virtual void copyTo(void *dest,
                         const udim_t bytes,

--- a/src/occa/internal/modes/cuda/device.hpp
+++ b/src/occa/internal/modes/cuda/device.hpp
@@ -93,9 +93,9 @@ namespace occa {
                                    const void *src,
                                    const occa::json &props);
 
-      virtual modeMemory_t* mappedAlloc(const udim_t bytes,
-                                        const void *src,
-                                        const occa::json &props);
+      virtual modeMemory_t* hostAlloc(const udim_t bytes,
+                                      const void *src,
+                                      const occa::json &props);
 
       modeMemory_t* unifiedAlloc(const udim_t bytes,
                                  const void *src,

--- a/src/occa/internal/modes/cuda/memory.cpp
+++ b/src/occa/internal/modes/cuda/memory.cpp
@@ -9,23 +9,24 @@ namespace occa {
                    const occa::json &properties_) :
         occa::modeMemory_t(modeDevice_, size_, properties_),
         cuPtr(reinterpret_cast<CUdeviceptr&>(ptr)),
-        mappedPtr(NULL),
-        isUnified(false) {}
+        isUnified(false),
+        useHostPtr(false) {}
 
     memory::~memory() {
       if (isOrigin) {
-        if (mappedPtr) {
+        if (useHostPtr) {
           OCCA_CUDA_DESTRUCTOR_ERROR(
-            "Device: mappedFree()",
-            cuMemFreeHost(mappedPtr)
+            "Device: hostFree()",
+            cuMemFreeHost(ptr)
           );
         } else if (cuPtr) {
           cuMemFree(cuPtr);
         }
       }
+      ptr = nullptr;
       cuPtr = 0;
-      mappedPtr = NULL;
       size = 0;
+      useHostPtr=false;
     }
 
     CUstream& memory::getCuStream() const {
@@ -41,18 +42,20 @@ namespace occa {
                              size - offset,
                              properties);
       m->cuPtr = cuPtr + offset;
-      if (mappedPtr) {
-        m->mappedPtr = mappedPtr + offset;
+      if (useHostPtr) {
+        m->ptr = ptr + offset;
       }
       m->isUnified = isUnified;
+      m->useHostPtr = useHostPtr;
       return m;
     }
 
-    void* memory::getPtr(const occa::json &props) {
-      if (props.get("mapped", false)) {
-        return mappedPtr;
+    void* memory::getPtr() {
+      if (useHostPtr) {
+        return ptr;
+      } else {
+        return (void*)cuPtr;
       }
-      return ptr;
     }
 
     void memory::copyFrom(const void *src,
@@ -61,17 +64,21 @@ namespace occa {
                           const occa::json &props) {
       const bool async = props.get("async", false);
 
-      if (!async) {
-        OCCA_CUDA_ERROR("Memory: Copy From",
-                        cuMemcpyHtoD(cuPtr + offset,
-                                     src,
-                                     bytes));
+      if (useHostPtr) {
+        ::memcpy(ptr+offset, src, bytes);
       } else {
-        OCCA_CUDA_ERROR("Memory: Async Copy From",
-                        cuMemcpyHtoDAsync(cuPtr + offset,
-                                          src,
-                                          bytes,
-                                          getCuStream()));
+        if (!async) {
+          OCCA_CUDA_ERROR("Memory: Copy From",
+                          cuMemcpyHtoD(cuPtr + offset,
+                                       src,
+                                       bytes));
+        } else {
+          OCCA_CUDA_ERROR("Memory: Async Copy From",
+                          cuMemcpyHtoDAsync(cuPtr + offset,
+                                            src,
+                                            bytes,
+                                            getCuStream()));
+        }
       }
     }
 
@@ -82,17 +89,47 @@ namespace occa {
                           const occa::json &props) {
       const bool async = props.get("async", false);
 
-      if (!async) {
-        OCCA_CUDA_ERROR("Memory: Copy From",
-                        cuMemcpyDtoD(cuPtr + destOffset,
-                                     ((memory*) src)->cuPtr + srcOffset,
-                                     bytes));
+      if (useHostPtr && ((memory*) src)->useHostPtr) {
+        ::memcpy(ptr + destOffset, src->ptr + srcOffset, bytes);
+      } else if (((memory*) src)->useHostPtr) {
+        if (!async) {
+          OCCA_CUDA_ERROR("Memory: Copy From",
+                          cuMemcpyHtoD(cuPtr + destOffset,
+                                       src->ptr + srcOffset,
+                                       bytes));
+        } else {
+          OCCA_CUDA_ERROR("Memory: Async Copy From",
+                          cuMemcpyHtoDAsync(cuPtr + destOffset,
+                                            src->ptr + srcOffset,
+                                            bytes,
+                                            getCuStream()));
+        }
+      } else if (useHostPtr) {
+        if (!async) {
+          OCCA_CUDA_ERROR("Memory: Copy From",
+                          cuMemcpyDtoH(ptr + destOffset,
+                                       ((memory*) src)->cuPtr + srcOffset,
+                                       bytes));
+        } else {
+          OCCA_CUDA_ERROR("Memory: Async Copy From",
+                          cuMemcpyDtoHAsync(ptr + destOffset,
+                                            ((memory*) src)->cuPtr + srcOffset,
+                                            bytes,
+                                            getCuStream()));
+        }
       } else {
-        OCCA_CUDA_ERROR("Memory: Async Copy From",
-                        cuMemcpyDtoDAsync(cuPtr + destOffset,
-                                          ((memory*) src)->cuPtr + srcOffset,
-                                          bytes,
-                                          getCuStream()));
+        if (!async) {
+          OCCA_CUDA_ERROR("Memory: Copy From",
+                          cuMemcpyDtoD(cuPtr + destOffset,
+                                       ((memory*) src)->cuPtr + srcOffset,
+                                       bytes));
+        } else {
+          OCCA_CUDA_ERROR("Memory: Async Copy From",
+                          cuMemcpyDtoDAsync(cuPtr + destOffset,
+                                            ((memory*) src)->cuPtr + srcOffset,
+                                            bytes,
+                                            getCuStream()));
+        }
       }
     }
 
@@ -102,23 +139,29 @@ namespace occa {
                         const occa::json &props) const {
       const bool async = props.get("async", false);
 
-      if (!async) {
-        OCCA_CUDA_ERROR("Memory: Copy From",
-                        cuMemcpyDtoH(dest,
-                                     cuPtr + offset,
-                                     bytes));
+      if (useHostPtr) {
+        ::memcpy(dest, ptr+offset, bytes);
       } else {
-        OCCA_CUDA_ERROR("Memory: Async Copy From",
-                        cuMemcpyDtoHAsync(dest,
-                                          cuPtr + offset,
-                                          bytes,
-                                          getCuStream()));
+        if (!async) {
+          OCCA_CUDA_ERROR("Memory: Copy From",
+                          cuMemcpyDtoH(dest,
+                                       cuPtr + offset,
+                                       bytes));
+        } else {
+          OCCA_CUDA_ERROR("Memory: Async Copy From",
+                          cuMemcpyDtoHAsync(dest,
+                                            cuPtr + offset,
+                                            bytes,
+                                            getCuStream()));
+        }
       }
     }
 
     void memory::detach() {
+      ptr = nullptr;
       cuPtr = 0;
       size = 0;
+      useHostPtr=false;
     }
   }
 }

--- a/src/occa/internal/modes/cuda/memory.cpp
+++ b/src/occa/internal/modes/cuda/memory.cpp
@@ -26,7 +26,7 @@ namespace occa {
       ptr = nullptr;
       cuPtr = 0;
       size = 0;
-      useHostPtr=false;
+      useHostPtr = false;
     }
 
     CUstream& memory::getCuStream() const {
@@ -54,7 +54,7 @@ namespace occa {
       if (useHostPtr) {
         return ptr;
       } else {
-        return (void*)cuPtr;
+        return (void*) cuPtr;
       }
     }
 
@@ -90,8 +90,10 @@ namespace occa {
       const bool async = props.get("async", false);
 
       if (useHostPtr && ((memory*) src)->useHostPtr) {
+        // src: host, dest: host
         ::memcpy(ptr + destOffset, src->ptr + srcOffset, bytes);
       } else if (((memory*) src)->useHostPtr) {
+        // src: host, dest: device
         if (!async) {
           OCCA_CUDA_ERROR("Memory: Copy From",
                           cuMemcpyHtoD(cuPtr + destOffset,
@@ -105,6 +107,7 @@ namespace occa {
                                             getCuStream()));
         }
       } else if (useHostPtr) {
+        // src: device, dest: host
         if (!async) {
           OCCA_CUDA_ERROR("Memory: Copy From",
                           cuMemcpyDtoH(ptr + destOffset,
@@ -118,6 +121,7 @@ namespace occa {
                                             getCuStream()));
         }
       } else {
+        // src: device, dest: device
         if (!async) {
           OCCA_CUDA_ERROR("Memory: Copy From",
                           cuMemcpyDtoD(cuPtr + destOffset,
@@ -161,7 +165,7 @@ namespace occa {
       ptr = nullptr;
       cuPtr = 0;
       size = 0;
-      useHostPtr=false;
+      useHostPtr = false;
     }
   }
 }

--- a/src/occa/internal/modes/cuda/memory.hpp
+++ b/src/occa/internal/modes/cuda/memory.hpp
@@ -18,12 +18,10 @@ namespace occa {
                                      const udim_t bytes,
                                      const occa::json &props);
 
-      friend void* getMappedPtr(occa::memory mem);
-
     public:
       CUdeviceptr &cuPtr;
-      char *mappedPtr;
       bool isUnified;
+      bool useHostPtr;
 
       memory(modeDevice_t *modeDevice_,
              udim_t size_,
@@ -36,7 +34,7 @@ namespace occa {
 
       modeMemory_t* addOffset(const dim_t offset);
 
-      void* getPtr(const occa::json &props);
+      void* getPtr();
 
       void copyTo(void *dest,
                   const udim_t bytes,

--- a/src/occa/internal/modes/hip/device.hpp
+++ b/src/occa/internal/modes/hip/device.hpp
@@ -83,9 +83,9 @@ namespace occa {
                                    const void *src,
                                    const occa::json &props);
 
-      virtual modeMemory_t* mappedAlloc(const udim_t bytes,
-                                        const void *src,
-                                        const occa::json &props);
+      virtual modeMemory_t* hostAlloc(const udim_t bytes,
+                                      const void *src,
+                                      const occa::json &props);
 
       modeMemory_t* wrapMemory(const void *ptr,
                                const udim_t bytes,

--- a/src/occa/internal/modes/hip/memory.cpp
+++ b/src/occa/internal/modes/hip/memory.cpp
@@ -27,7 +27,7 @@ namespace occa {
       ptr = nullptr;
       hipPtr = 0;
       size = 0;
-      useHostPtr=false;
+      useHostPtr = false;
     }
 
     hipStream_t& memory::getHipStream() const {
@@ -90,8 +90,10 @@ namespace occa {
       const bool async = props.get("async", false);
 
       if (useHostPtr && ((memory*) src)->useHostPtr) {
+        // src: host, dest: host
         ::memcpy(ptr + destOffset, src->ptr + srcOffset, bytes);
       } else if (((memory*) src)->useHostPtr) {
+        // src: host, dest: device
         if (!async) {
           OCCA_HIP_ERROR("Memory: Copy From",
                          hipMemcpyHtoD(addHipPtrOffset(hipPtr, destOffset),
@@ -105,6 +107,7 @@ namespace occa {
                                             getHipStream()));
         }
       } else if (useHostPtr) {
+        // src: device, dest: host
         if (!async) {
           OCCA_HIP_ERROR("Memory: Copy From",
                          hipMemcpyDtoH(ptr + destOffset,
@@ -118,6 +121,7 @@ namespace occa {
                                             getHipStream()));
         }
       } else {
+        // src: device, dest: device
         if (!async) {
           OCCA_HIP_ERROR("Memory: Copy From",
                          hipMemcpyDtoD(addHipPtrOffset(hipPtr, destOffset),
@@ -161,7 +165,7 @@ namespace occa {
       ptr = 0;
       hipPtr = 0;
       size = 0;
-      useHostPtr=false;
+      useHostPtr = false;
     }
   }
 }

--- a/src/occa/internal/modes/hip/memory.cpp
+++ b/src/occa/internal/modes/hip/memory.cpp
@@ -13,20 +13,21 @@ namespace occa {
                    const occa::json &properties_) :
       occa::modeMemory_t(modeDevice_, size_, properties_),
       hipPtr(reinterpret_cast<hipDeviceptr_t&>(ptr)),
-      mappedPtr(NULL) {}
+      useHostPtr(false) {}
 
     memory::~memory() {
       if (isOrigin) {
-        if (mappedPtr) {
-          OCCA_HIP_ERROR("Device: mappedFree()",
-                         hipHostFree(mappedPtr));
+        if (useHostPtr) {
+          OCCA_HIP_ERROR("Device: hostFree()",
+                         hipHostFree(ptr));
         } else if (hipPtr) {
           hipFree((void*) hipPtr);
         }
       }
+      ptr = nullptr;
       hipPtr = 0;
-      mappedPtr = NULL;
       size = 0;
+      useHostPtr=false;
     }
 
     hipStream_t& memory::getHipStream() const {
@@ -42,17 +43,19 @@ namespace occa {
                              size - offset,
                              properties);
       m->hipPtr = addHipPtrOffset(hipPtr, offset);
-      if (mappedPtr) {
-        m->mappedPtr = mappedPtr + offset;
+      if (useHostPtr) {
+        m->ptr = ptr + offset;
       }
+      m->useHostPtr = useHostPtr;
       return m;
     }
 
-    void* memory::getPtr(const occa::json &props) {
-      if (props.get("mapped", false)) {
-        return mappedPtr;
+    void* memory::getPtr() {
+      if (useHostPtr) {
+        return ptr;
+      } else {
+        return static_cast<void*>(hipPtr);
       }
-      return ptr;
     }
 
     void memory::copyFrom(const void *src,
@@ -61,17 +64,21 @@ namespace occa {
                           const occa::json &props) {
       const bool async = props.get("async", false);
 
-      if (!async) {
-        OCCA_HIP_ERROR("Memory: Copy From",
-                       hipMemcpyHtoD(addHipPtrOffset(hipPtr, offset),
-                                     const_cast<void*>(src),
-                                     bytes) );
+      if (useHostPtr) {
+        ::memcpy(ptr+offset, src, bytes);
       } else {
-        OCCA_HIP_ERROR("Memory: Async Copy From",
-                       hipMemcpyHtoDAsync(addHipPtrOffset(hipPtr, offset),
-                                          const_cast<void*>(src),
-                                          bytes,
-                                          getHipStream()) );
+        if (!async) {
+          OCCA_HIP_ERROR("Memory: Copy From",
+                         hipMemcpyHtoD(addHipPtrOffset(hipPtr, offset),
+                                       const_cast<void*>(src),
+                                       bytes) );
+        } else {
+          OCCA_HIP_ERROR("Memory: Async Copy From",
+                         hipMemcpyHtoDAsync(addHipPtrOffset(hipPtr, offset),
+                                            const_cast<void*>(src),
+                                            bytes,
+                                            getHipStream()) );
+        }
       }
     }
 
@@ -82,17 +89,47 @@ namespace occa {
                           const occa::json &props) {
       const bool async = props.get("async", false);
 
-      if (!async) {
-        OCCA_HIP_ERROR("Memory: Copy From",
-                       hipMemcpyDtoD(addHipPtrOffset(hipPtr, destOffset),
-                                     addHipPtrOffset(((memory*) src)->hipPtr, srcOffset),
-                                     bytes) );
+      if (useHostPtr && ((memory*) src)->useHostPtr) {
+        ::memcpy(ptr + destOffset, src->ptr + srcOffset, bytes);
+      } else if (((memory*) src)->useHostPtr) {
+        if (!async) {
+          OCCA_HIP_ERROR("Memory: Copy From",
+                         hipMemcpyHtoD(addHipPtrOffset(hipPtr, destOffset),
+                                       src->ptr + srcOffset,
+                                       bytes));
+        } else {
+          OCCA_HIP_ERROR("Memory: Async Copy From",
+                         hipMemcpyHtoDAsync(addHipPtrOffset(hipPtr, destOffset),
+                                            src->ptr + srcOffset,
+                                            bytes,
+                                            getHipStream()));
+        }
+      } else if (useHostPtr) {
+        if (!async) {
+          OCCA_HIP_ERROR("Memory: Copy From",
+                         hipMemcpyDtoH(ptr + destOffset,
+                                       addHipPtrOffset(((memory*) src)->hipPtr, srcOffset),
+                                       bytes));
+        } else {
+          OCCA_HIP_ERROR("Memory: Async Copy From",
+                         hipMemcpyDtoHAsync(ptr + destOffset,
+                                            addHipPtrOffset(((memory*) src)->hipPtr, srcOffset),
+                                            bytes,
+                                            getHipStream()));
+        }
       } else {
-        OCCA_HIP_ERROR("Memory: Async Copy From",
-                       hipMemcpyDtoDAsync(addHipPtrOffset(hipPtr, destOffset),
-                                          addHipPtrOffset(((memory*) src)->hipPtr, srcOffset),
-                                          bytes,
-                                          getHipStream()) );
+        if (!async) {
+          OCCA_HIP_ERROR("Memory: Copy From",
+                         hipMemcpyDtoD(addHipPtrOffset(hipPtr, destOffset),
+                                       addHipPtrOffset(((memory*) src)->hipPtr, srcOffset),
+                                       bytes) );
+        } else {
+          OCCA_HIP_ERROR("Memory: Async Copy From",
+                         hipMemcpyDtoDAsync(addHipPtrOffset(hipPtr, destOffset),
+                                            addHipPtrOffset(((memory*) src)->hipPtr, srcOffset),
+                                            bytes,
+                                            getHipStream()) );
+        }
       }
     }
 
@@ -102,23 +139,29 @@ namespace occa {
                         const occa::json &props) const {
       const bool async = props.get("async", false);
 
-      if (!async) {
-        OCCA_HIP_ERROR("Memory: Copy From",
-                       hipMemcpyDtoH(dest,
-                                     addHipPtrOffset(hipPtr, offset),
-                                     bytes) );
+      if (useHostPtr) {
+        ::memcpy(dest, ptr+offset, bytes);
       } else {
-        OCCA_HIP_ERROR("Memory: Async Copy From",
-                       hipMemcpyDtoHAsync(dest,
-                                          addHipPtrOffset(hipPtr, offset),
-                                          bytes,
-                                          getHipStream()) );
+        if (!async) {
+          OCCA_HIP_ERROR("Memory: Copy From",
+                         hipMemcpyDtoH(dest,
+                                       addHipPtrOffset(hipPtr, offset),
+                                       bytes) );
+        } else {
+          OCCA_HIP_ERROR("Memory: Async Copy From",
+                         hipMemcpyDtoHAsync(dest,
+                                            addHipPtrOffset(hipPtr, offset),
+                                            bytes,
+                                            getHipStream()) );
+        }
       }
     }
 
     void memory::detach() {
+      ptr = 0;
       hipPtr = 0;
       size = 0;
+      useHostPtr=false;
     }
   }
 }

--- a/src/occa/internal/modes/hip/memory.hpp
+++ b/src/occa/internal/modes/hip/memory.hpp
@@ -16,11 +16,9 @@ namespace occa {
                                      const udim_t bytes,
                                      const occa::json &props);
 
-      friend void* getMappedPtr(occa::memory mem);
-
     public:
       hipDeviceptr_t &hipPtr;
-      char *mappedPtr;
+      bool useHostPtr;
 
       memory(modeDevice_t *modeDevice_,
              udim_t size_,
@@ -33,7 +31,7 @@ namespace occa {
 
       modeMemory_t* addOffset(const dim_t offset);
 
-      void* getPtr(const occa::json &props);
+      void* getPtr();
 
       void copyTo(void *dest,
                   const udim_t bytes,

--- a/src/occa/internal/modes/metal/memory.cpp
+++ b/src/occa/internal/modes/metal/memory.cpp
@@ -34,7 +34,7 @@ namespace occa {
       return metalBuffer;
     }
 
-    void* memory::getPtr(const occa::json &props) {
+    void* memory::getPtr() {
       if (!ptr) {
         ptr = (char*) metalBuffer.getPtr();
       }

--- a/src/occa/internal/modes/metal/memory.hpp
+++ b/src/occa/internal/modes/metal/memory.hpp
@@ -27,7 +27,7 @@ namespace occa {
 
       const api::metal::buffer_t& getMetalBuffer();
 
-      void* getPtr(const occa::json &props);
+      void* getPtr();
 
       udim_t getOffset() const;
 

--- a/src/occa/internal/modes/opencl/device.cpp
+++ b/src/occa/internal/modes/opencl/device.cpp
@@ -359,7 +359,7 @@ namespace occa {
                                   NULL, &error);
       mem->rootClMem = &mem->clMem;
 
-      mem->useHostPtr=true;
+      mem->useHostPtr = true;
 
       OCCA_OPENCL_ERROR("Device: clCreateBuffer", error);
 

--- a/src/occa/internal/modes/opencl/device.cpp
+++ b/src/occa/internal/modes/opencl/device.cpp
@@ -317,8 +317,8 @@ namespace occa {
                                  const void *src,
                                  const occa::json &props) {
 
-      if (props.get("mapped", false)) {
-        return mappedAlloc(bytes, src, props);
+      if (props.get("host", false)) {
+        return hostAlloc(bytes, src, props);
       }
 
       cl_int error;
@@ -344,9 +344,9 @@ namespace occa {
       return mem;
     }
 
-    modeMemory_t* device::mappedAlloc(const udim_t bytes,
-                                      const void *src,
-                                      const occa::json &props) {
+    modeMemory_t* device::hostAlloc(const udim_t bytes,
+                                    const void *src,
+                                    const occa::json &props) {
 
       cl_int error;
 
@@ -359,6 +359,8 @@ namespace occa {
                                   NULL, &error);
       mem->rootClMem = &mem->clMem;
 
+      mem->useHostPtr=true;
+
       OCCA_OPENCL_ERROR("Device: clCreateBuffer", error);
 
       if (src != NULL){
@@ -366,13 +368,13 @@ namespace occa {
       }
 
       // Map memory to read/write
-      mem->mappedPtr = clEnqueueMapBuffer(getCommandQueue(),
-                                          mem->clMem,
-                                          CL_TRUE,
-                                          CL_MAP_READ | CL_MAP_WRITE,
-                                          0, bytes,
-                                          0, NULL, NULL,
-                                          &error);
+      mem->ptr = (char*) clEnqueueMapBuffer(getCommandQueue(),
+                                            mem->clMem,
+                                            CL_TRUE,
+                                            CL_MAP_READ | CL_MAP_WRITE,
+                                            0, bytes,
+                                            0, NULL, NULL,
+                                            &error);
 
       OCCA_OPENCL_ERROR("Device: clEnqueueMapBuffer", error);
 

--- a/src/occa/internal/modes/opencl/device.hpp
+++ b/src/occa/internal/modes/opencl/device.hpp
@@ -84,9 +84,9 @@ namespace occa {
                                    const void *src,
                                    const occa::json &props);
 
-      virtual modeMemory_t* mappedAlloc(const udim_t bytes,
-                                        const void *src,
-                                        const occa::json &props);
+      virtual modeMemory_t* hostAlloc(const udim_t bytes,
+                                      const void *src,
+                                      const occa::json &props);
 
       modeMemory_t* wrapMemory(const void *ptr,
                                const udim_t bytes,

--- a/src/occa/internal/modes/opencl/memory.cpp
+++ b/src/occa/internal/modes/opencl/memory.cpp
@@ -37,7 +37,7 @@ namespace occa {
       ptr = nullptr;
       clMem = NULL;
       size = 0;
-      useHostPtr=false;
+      useHostPtr = false;
     }
 
     cl_command_queue& memory::getCommandQueue() const {
@@ -79,7 +79,7 @@ namespace occa {
       if (useHostPtr) {
         return ptr;
       } else {
-        return static_cast<void*>(clMem); //dubious
+        return static_cast<void*>(clMem); // Dubious...
       }
     }
 
@@ -129,9 +129,9 @@ namespace occa {
     }
 
     void memory::detach() {
-      ptr=nullptr;
+      ptr = nullptr;
       size = 0;
-      useHostPtr=false;
+      useHostPtr = false;
     }
   }
 }

--- a/src/occa/internal/modes/opencl/memory.cpp
+++ b/src/occa/internal/modes/opencl/memory.cpp
@@ -11,7 +11,7 @@ namespace occa {
         occa::modeMemory_t(modeDevice_, size_, properties_),
         rootClMem(&clMem),
         rootOffset(0),
-        useHostPtr(NULL) {}
+        useHostPtr(false) {}
 
     memory::~memory() {
       if (isOrigin) {

--- a/src/occa/internal/modes/opencl/memory.hpp
+++ b/src/occa/internal/modes/opencl/memory.hpp
@@ -13,8 +13,6 @@ namespace occa {
 
       friend cl_mem getCLMemory(occa::memory memory);
 
-      friend void* getMappedPtr(occa::memory memory);
-
       friend occa::memory wrapMemory(occa::device device,
                                      cl_mem clMem,
                                      const udim_t bytes,
@@ -25,7 +23,7 @@ namespace occa {
       dim_t rootOffset;
 
       cl_mem clMem;
-      void *mappedPtr;
+      bool useHostPtr;
 
     public:
       memory(modeDevice_t *modeDevice_,
@@ -39,7 +37,7 @@ namespace occa {
 
       modeMemory_t* addOffset(const dim_t offset);
 
-      void* getPtr(const occa::json &props);
+      void* getPtr();
 
       void copyTo(void *dest,
                   const udim_t bytes,

--- a/tests/src/c/device.cpp
+++ b/tests/src/c/device.cpp
@@ -287,7 +287,7 @@ void testWrapMemory() {
   ASSERT_NEQ(occa::c::memory(mem1),
              occa::c::memory(mem2));
 
-  int *ptr = (int*) occaMemoryPtr(mem2, occaDefault);
+  int *ptr = (int*) occaMemoryPtr(mem2);
   occaMemoryDetach(mem2);
 
   for (int i = 0; i < entries; ++i) {

--- a/tests/src/c/memory.cpp
+++ b/tests/src/c/memory.cpp
@@ -40,12 +40,12 @@ void testInit() {
             OCCA_MEMORY);
   ASSERT_TRUE(occaMemoryIsInitialized(mem));
 
-  int *ptr = (int*) occaMemoryPtr(mem, occaDefault);
+  int *ptr = (int*) occaMemoryPtr(mem);
   ASSERT_EQ(ptr[0], 0);
   ASSERT_EQ(ptr[1], 1);
   ASSERT_EQ(ptr[2], 2);
 
-  int *ptr2 = (int*) occaMemoryPtr(mem, props);
+  int *ptr2 = (int*) occaMemoryPtr(mem);
   ASSERT_EQ(ptr, ptr2);
 
   ASSERT_EQ(occa::c::device(occaMemoryGetDevice(mem)),
@@ -66,7 +66,7 @@ void testInit() {
   ASSERT_EQ((size_t) occaMemorySize(subMem),
             bytes - (1 * sizeof(int)));
 
-  ptr = (int*) occaMemoryPtr(subMem, occaDefault);
+  ptr = (int*) occaMemoryPtr(subMem);
   ASSERT_EQ(ptr[0], 1);
   ASSERT_EQ(ptr[1], 2);
 
@@ -138,8 +138,8 @@ void testCopyMethods() {
     occaJsonParse("{foo: 'bar'}")
   );
 
-  int *ptr2 = (int*) occaMemoryPtr(mem2, occaDefault);
-  int *ptr4 = (int*) occaMemoryPtr(mem4, occaDefault);
+  int *ptr2 = (int*) occaMemoryPtr(mem2);
+  int *ptr4 = (int*) occaMemoryPtr(mem4);
 
   // Mem -> Mem
   // Copy over [2, 3]


### PR DESCRIPTION
## Description

~~This PR implements a new API, `hostMalloc` which lets users malloc `occa::memory` regions in pinned host memory, if the backend device supports this, i.e. in CUDA, HIP, and somewhat OpenCL.~~

**Edit:** After consideration, we don't need to introduce a separate device::hostMalloc API for a functionality that is only present on some backends. We'll instead trigger the hostMalloc behavior by passing a `"{'host': true}"` prop in the device::malloc.

This PR also somewhat changes how the device/pinned host pointers are managed in backends in order to let users obtain the correct underlying pointer via the `memory::ptr()` method automatically, rather than having to pass a particular `occa::properties` setting. Users can also directly pass these hostMalloc'd buffers into kernels since GPU devices can directly read & write pinned host memory regions*. Finally, the correct copyTo/copyFrom behaviors are determined automatically based on the location of the underlying pointers. 

Some examples of the resulting API change in user applications can be seen in this draft PR: https://github.com/paranumal/libparanumal/pull/28

*The OpenCL spec unfortunately does not explicitly guarantee that GPU kernels will directly access pinned host memory. For now, users will continue to have to explicitly copy back the contents of hostMalloc'd buffers in order to guarantee coherency. Potentially, OCCA could also expose some kind of sync wherein a pinned host buffer would be re-mapped. 

P.S. I have no idea if there is a similar functionality in Metal. If someone wants to take a look at the corresponding tweaks in the Metal backend, that would be greatly appreciated. 

<!-- Thank you for contributing! -->
