### PR TITLE
[Core] Allows for case-insensitive mode names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   run:

--- a/bin/occa.cpp
+++ b/bin/occa.cpp
@@ -136,7 +136,9 @@ bool runTranslate(const json &args) {
   const json &options = args["options"];
   const json &arguments = args["arguments"];
 
-  const std::string mode = options["mode"];
+  const std::string originalMode = options["mode"];
+  const std::string mode = lowercase(originalMode);
+
   const bool printLauncher = options["launcher"];
   const std::string filename = arguments[0];
 
@@ -151,22 +153,22 @@ bool runTranslate(const json &args) {
 
   lang::parser_t *parser = NULL;
   lang::parser_t *launcherParser = NULL;
-  if (mode == "" || mode == "Serial") {
+  if (mode == "" || mode == "serial") {
     parser = new lang::okl::serialParser(kernelProps);
-  } else if (mode == "OpenMP") {
+  } else if (mode == "openmp") {
     parser = new lang::okl::openmpParser(kernelProps);
-  } else if (mode == "CUDA") {
+  } else if (mode == "cuda") {
     parser = new lang::okl::cudaParser(kernelProps);
-  } else if (mode == "HIP") {
+  } else if (mode == "hip") {
     parser = new lang::okl::hipParser(kernelProps);
-  } else if (mode == "OpenCL") {
+  } else if (mode == "opencl") {
     parser = new lang::okl::openclParser(kernelProps);
-  } else if (mode == "Metal") {
+  } else if (mode == "metal") {
     parser = new lang::okl::metalParser(kernelProps);
   }
 
   if (!parser) {
-    printError("Unable to translate for mode [" + mode + "]");
+    printError("Unable to translate for mode [" + originalMode + "]");
     ::exit(1);
   }
 
@@ -197,10 +199,10 @@ bool runTranslate(const json &args) {
       << "*/\n";
   }
 
-  if (printLauncher && ((mode == "CUDA")
-                        || (mode == "HIP")
-                        || (mode == "OpenCL")
-                        || (mode == "Metal"))) {
+  if (printLauncher && ((mode == "cuda")
+                        || (mode == "hip")
+                        || (mode == "opencl")
+                        || (mode == "metal"))) {
     launcherParser = &(((occa::lang::okl::withLauncher*) parser)->launcherParser);
     std::cout << launcherParser->toString();
   } else {
@@ -284,7 +286,7 @@ bool runModes(const json &args) {
   strToModeMap &modeMap = getModeMap();
   strToModeMap::iterator it = modeMap.begin();
   while (it != modeMap.end()) {
-    std::cout << it->first << '\n';
+    std::cout << it->second->name() << '\n';
     ++it;
   }
   return true;

--- a/include/occa/modes.hpp
+++ b/include/occa/modes.hpp
@@ -43,7 +43,9 @@ namespace occa {
 
   bool modeIsEnabled(const std::string &mode);
 
-  mode_t* getMode(const occa::properties &props);
+  mode_t* getMode(const std::string &mode);
+
+  mode_t* getModeFromProps(const occa::properties &props);
 
   modeDevice_t* newModeDevice(const occa::properties &props);
 }

--- a/src/core/base.cpp
+++ b/src/core/base.cpp
@@ -252,7 +252,7 @@ namespace occa {
     int index = 0;
 
     for (; it != modeMap.end(); ++it) {
-      if (it->first == "Serial") {
+      if (it->second->name() == "Serial") {
         serialIndex = index;
       }
       table.add(it->second->getDescription());
@@ -260,9 +260,11 @@ namespace occa {
     }
 
     // Set so Serial mode is first to show up
-    styling::section serialSection = table.sections[serialIndex];
-    table.sections[serialIndex] = table.sections[0];
-    table.sections[0] = serialSection;
+    if (serialIndex != 0) {
+      styling::section serialSection = table.sections[serialIndex];
+      table.sections[serialIndex] = table.sections[0];
+      table.sections[0] = serialSection;
+    }
 
     io::stdout << table;
   }

--- a/tests/src/modes.cpp
+++ b/tests/src/modes.cpp
@@ -2,22 +2,42 @@
 
 #include <occa/modes.hpp>
 
-void testMode();
+void testModeByName();
+void testModeByProps();
 
 int main(const int argc, const char **argv) {
-  testMode();
+  testModeByName();
+  testModeByProps();
 
   return 0;
 }
 
-void testMode() {
-  occa::mode_t *serialMode = occa::getMode("mode: 'Serial'");
+void testModeByName() {
+  occa::mode_t *serialMode = occa::getMode("Serial");
   ASSERT_NEQ((void*) serialMode,
              (void*) NULL);
 
-  ASSERT_EQ(occa::getMode(""),
+  ASSERT_EQ((void*) serialMode,
+            (void*) occa::getMode("serial"));
+
+  ASSERT_EQ((void*) occa::getMode(""),
+            (void*) NULL);
+
+  ASSERT_EQ((void*) occa::getMode("Foo"),
+            (void*) NULL);
+}
+
+void testModeByProps() {
+  occa::mode_t *serialMode = occa::getModeFromProps("mode: 'Serial'");
+  ASSERT_NEQ((void*) serialMode,
+             (void*) NULL);
+
+  ASSERT_EQ((void*) serialMode,
+            (void*) occa::getModeFromProps("mode: 'serial'"));
+
+  ASSERT_EQ(occa::getModeFromProps(""),
             serialMode);
 
-  ASSERT_EQ(occa::getMode("mode: 'Foo'"),
+  ASSERT_EQ(occa::getModeFromProps("mode: 'Foo'"),
             serialMode);
 }


### PR DESCRIPTION
## Description

Made modes case-insensitive since it shouldn't matter for the user if they use `"CUDA"` or `"cuda"`


<!-- Thank you for contributing! -->
