### PR TITLE
Add size_t and ptrdiff_t to builtin types

### DIFF
--- a/include/occa/lang/builtins/types.hpp
+++ b/include/occa/lang/builtins/types.hpp
@@ -48,6 +48,10 @@ namespace occa {
     extern const primitive_t void_;
     extern const primitive_t auto_;
 
+    // TODO: Auto-generate type aliases for common C types
+    extern const primitive_t size_t_;
+    extern const primitive_t ptrdiff_t_;
+
     // OKL Primitives
     extern const primitive_t uchar2;
     extern const primitive_t uchar3;

--- a/src/lang/builtins/types.cpp
+++ b/src/lang/builtins/types.cpp
@@ -45,6 +45,10 @@ namespace occa {
     const primitive_t void_         ("void");
     const primitive_t auto_         ("auto");
 
+    // TODO: Auto-generate type aliases for common C types
+    const primitive_t size_t_       ("size_t");
+    const primitive_t ptrdiff_t_    ("ptrdiff_t");
+
     // OKL Primitives
     const primitive_t uchar2        ("uchar2");
     const primitive_t uchar3        ("uchar3");

--- a/src/lang/keyword.cpp
+++ b/src/lang/keyword.cpp
@@ -318,6 +318,8 @@ namespace occa {
       keywords.add(*(new typeKeyword(const_cast<primitive_t&>(double_))));
       keywords.add(*(new typeKeyword(const_cast<primitive_t&>(void_))));
       keywords.add(*(new typeKeyword(const_cast<primitive_t&>(auto_))));
+      keywords.add(*(new typeKeyword(const_cast<primitive_t&>(size_t_))));
+      keywords.add(*(new typeKeyword(const_cast<primitive_t&>(ptrdiff_t_))));
 
       // OKL Types
       keywords.add(*(new typeKeyword(const_cast<primitive_t&>(uchar2))));

--- a/tests/src/lang/type.cpp
+++ b/tests/src/lang/type.cpp
@@ -129,16 +129,18 @@ void testCasting() {
 
 void testComparision() {
   // Test primitives
-  const primitive_t* types[9] = {
+  const int nTypes = 11;
+  const primitive_t* types[nTypes] = {
     &bool_,
     &char_, &char16_t_, &char32_t_, &wchar_t_,
     &short_,
     &int_,
-    &float_, &double_
+    &float_, &double_,
+    &size_t_, &ptrdiff_t_,
   };
-  for (int j = 0; j < 9; ++j) {
+  for (int j = 0; j < nTypes; ++j) {
     vartype_t jVar(*types[j]);
-    for (int i = 0; i < 9; ++i) {
+    for (int i = 0; i < nTypes; ++i) {
       vartype_t iVar(*types[i]);
       ASSERT_EQ(i == j,
                 iVar == jVar);


### PR DESCRIPTION
## Description

Currently the parser/preprocessor doesn't handle the `size_t` and `ptrdiff_t` types. I added them in the same places where `wchar_t` was handled to follow the example of another type that doesn't do much.

Should I add/extend a test for this, if this is a sensible addition at all?