### PR TITLE
Add OCCA_KERNEL_PATH

### DIFF
--- a/bin/occa.cpp
+++ b/bin/occa.cpp
@@ -269,6 +269,7 @@ bool runEnv(const json &args) {
             << "    - OCCA_COMPILER_SHARED_FLAGS : " << envEcho("OCCA_COMPILER_SHARED_FLAGS") << "\n"
             << "    - OCCA_INCLUDE_PATH          : " << envEcho("OCCA_INCLUDE_PATH") << "\n"
             << "    - OCCA_LIBRARY_PATH          : " << envEcho("OCCA_LIBRARY_PATH") << "\n"
+            << "    - OCCA_KERNEL_PATH           : " << envEcho("OCCA_KERNEL_PATH") << "\n"
             << "    - OCCA_OPENCL_COMPILER_FLAGS : " << envEcho("OCCA_OPENCL_COMPILER_FLAGS") << "\n"
             << "    - OCCA_CUDA_COMPILER         : " << envEcho("OCCA_CUDA_COMPILER") << "\n"
             << "    - OCCA_CUDA_COMPILER_FLAGS   : " << envEcho("OCCA_CUDA_COMPILER_FLAGS") << "\n"

--- a/include/occa/io/utils.hpp
+++ b/include/occa/io/utils.hpp
@@ -53,6 +53,8 @@ namespace occa {
 
     std::string shortname(const std::string &filename);
 
+    std::string findInPaths(const std::string &filename, const strVector &paths);
+
     bool isDir(const std::string &filename);
     bool isFile(const std::string &filename);
 

--- a/include/occa/tools/env.hpp
+++ b/include/occa/tools/env.hpp
@@ -17,6 +17,7 @@ namespace occa {
     extern size_t      OCCA_MEM_BYTE_ALIGN;
     extern strVector   OCCA_INCLUDE_PATH;
     extern strVector   OCCA_LIBRARY_PATH;
+    extern strVector   OCCA_KERNEL_PATH;
     extern bool        OCCA_VERBOSE;
     extern bool        OCCA_COLOR_ENABLED;
 

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -433,7 +433,8 @@ namespace occa {
                              const occa::properties &props) const {
     occa::properties allProps;
     hash_t kernelHash;
-    setupKernelInfo(props, hashFile(filename),
+    const std::string realFilename = io::findInPaths(filename, env::OCCA_KERNEL_PATH);
+    setupKernelInfo(props, hashFile(realFilename),
                     allProps, kernelHash);
 
     // TODO: [#185] Fix kernel cache frees
@@ -444,7 +445,6 @@ namespace occa {
     //   return cachedKernel;
     // }
 
-    const std::string realFilename = io::filename(filename);
     const std::string hashDir = io::hashDir(realFilename, kernelHash);
     allProps["hash"] = kernelHash.getFullString();
 

--- a/src/io/utils.cpp
+++ b/src/io/utils.cpp
@@ -263,6 +263,28 @@ namespace occa {
       return expFilename.substr(cPath.size());
     }
 
+    std::string findInPaths(const std::string &filename, const strVector &paths) {
+      if (io::isAbsolutePath(filename)) {
+        return filename;
+      }
+
+      // Test paths until one exists
+      // Default to a relative path if none are found
+      std::string absFilename = env::CWD + filename;
+      for (size_t i = 0; i < paths.size(); ++i) {
+        const std::string path = paths[i];
+        if (io::exists(io::endWithSlash(path) + filename)) {
+          absFilename = io::endWithSlash(path) + filename;
+          break;
+        }
+      }
+
+      if (io::exists(absFilename)) {
+        return absFilename;
+      }
+      return filename;
+    }
+
     bool isFile(const std::string &filename) {
       const std::string expFilename = io::filename(filename);
       struct stat statInfo;

--- a/src/lang/preprocessor.cpp
+++ b/src/lang/preprocessor.cpp
@@ -1304,21 +1304,7 @@ namespace occa {
       }
 
       // Expand non-absolute path
-      std::string header = io::filename(tokenizer->getHeader(), false);
-      // Test includePaths until one exists
-      // Default to a relative path if none are found
-      if (!io::isAbsolutePath(header)) {
-        const int pathCount = (int) includePaths.size();
-        for (int i = 0; i < pathCount; ++i) {
-          const std::string path = includePaths[i];
-          if (io::exists(path + header)) {
-            header = path + header;
-            break;
-          } else if (i == (pathCount - 1)) {
-            header = env::CWD + header;
-          }
-        }
-      }
+      std::string header = io::findInPaths(io::filename(tokenizer->getHeader(), false), includePaths);
 
       if (!io::exists(header)) {
         // Default to standard headers if they exist

--- a/src/tools/env.cpp
+++ b/src/tools/env.cpp
@@ -24,6 +24,7 @@ namespace occa {
     size_t      OCCA_MEM_BYTE_ALIGN;
     strVector   OCCA_INCLUDE_PATH;
     strVector   OCCA_LIBRARY_PATH;
+    strVector   OCCA_KERNEL_PATH;
     bool        OCCA_VERBOSE;
     bool        OCCA_COLOR_ENABLED;
 
@@ -82,6 +83,7 @@ namespace occa {
 
       OCCA_INCLUDE_PATH = split(env::var("OCCA_INCLUDE_PATH"), ':', '\\');
       OCCA_LIBRARY_PATH = split(env::var("OCCA_LIBRARY_PATH"), ':', '\\');
+      OCCA_KERNEL_PATH  = split(env::var("OCCA_KERNEL_PATH"), ':', '\\');
 
       io::endWithSlash(HOME);
       io::endWithSlash(CWD);


### PR DESCRIPTION
## Description

It would be quite useful to us to be able to specify paths where occa can look for kernels that are specified with a relative path.
It should work in the expected way: if a path is absolute, that path is taken regardless of anything else, if it is relative, all the paths in OCCA_KERNEL_PATH (colon-separated) will be checked and if it's still not found the cwd is used.

Similar code already existed in the preprocessor, and I've lifted this into a function.