### PR TITLE
Fix assignment of negative literal to unsigned type

### DIFF
--- a/src/modes/cuda/utils.cpp
+++ b/src/modes/cuda/utils.cpp
@@ -34,7 +34,7 @@ namespace occa {
     }
 
     udim_t getDeviceMemorySize(CUdevice device) {
-      size_t bytes = -1;
+      size_t bytes = 0;
       OCCA_CUDA_ERROR("Finding available memory on device",
                       cuDeviceTotalMem(&bytes, device));
       return bytes;


### PR DESCRIPTION
## Description

Another small thing: assigning a negative literal to size_t is causing compiler complains.
We had this discussion before about udim_t and we added `const occa::udim_t UDIM_DEFAULT = static_cast<occa::udim_t>(-1);` for that to avoid `static_cast` noise everywhere, but since `size_t` is a default type I'm not sure if we would want to go that way? Plus, it's not really a 'default'.

In this particular instance, an error should be thrown if anything is wrong, right? So initializing with 0 is as good as anything?