### PR TITLE
[CUDA] Removes certain errors on destructors due to CUDA Deinit

### DIFF
--- a/include/occa/defines/errors.hpp
+++ b/include/occa/defines/errors.hpp
@@ -49,6 +49,10 @@
 #define OCCA_CUDA_ERROR2(expr, filename, function, line, message) OCCA_CUDA_ERROR3(expr, filename, function, line, message)
 #define OCCA_CUDA_ERROR(message, expr) OCCA_CUDA_ERROR2(expr, __FILE__, __PRETTY_FUNCTION__, __LINE__, message)
 
+#define OCCA_CUDA_DESTRUCTOR_ERROR3(expr, filename, function, line, message) OCCA_CUDA_TEMPLATE_CHECK(occa::cuda::destructorError, expr, filename, function, line, message)
+#define OCCA_CUDA_DESTRUCTOR_ERROR2(expr, filename, function, line, message) OCCA_CUDA_DESTRUCTOR_ERROR3(expr, filename, function, line, message)
+#define OCCA_CUDA_DESTRUCTOR_ERROR(message, expr) OCCA_CUDA_DESTRUCTOR_ERROR2(expr, __FILE__, __PRETTY_FUNCTION__, __LINE__, message)
+
 #define OCCA_CUDA_WARNING3(expr, filename, function, line, message) OCCA_CUDA_TEMPLATE_CHECK(occa::cuda::warn, expr, filename, function, line, message)
 #define OCCA_CUDA_WARNING2(expr, filename, function, line, message) OCCA_CUDA_WARNING3(expr, filename, function, line, message)
 #define OCCA_CUDA_WARNING(message, expr) OCCA_CUDA_WARNING2(expr, __FILE__, __PRETTY_FUNCTION__, __LINE__, message)

--- a/include/occa/modes/cuda/utils.hpp
+++ b/include/occa/modes/cuda/utils.hpp
@@ -95,6 +95,12 @@ namespace occa {
                const int line,
                const std::string &message);
 
+    void destructorError(CUresult errorCode,
+                         const std::string &filename,
+                         const std::string &function,
+                         const int line,
+                         const std::string &message);
+
     std::string getErrorMessage(const CUresult errorCode);
   }
 }

--- a/src/modes/cuda/device.cpp
+++ b/src/modes/cuda/device.cpp
@@ -79,8 +79,10 @@ namespace occa {
 
     device::~device() {
       if (cuContext) {
-        OCCA_CUDA_ERROR("Device: Freeing Context",
-                        cuCtxDestroy(cuContext) );
+        OCCA_CUDA_DESTRUCTOR_ERROR(
+          "Device: Freeing Context",
+          cuCtxDestroy(cuContext)
+        );
         cuContext = NULL;
       }
     }

--- a/src/modes/cuda/kernel.cpp
+++ b/src/modes/cuda/kernel.cpp
@@ -27,8 +27,10 @@ namespace occa {
 
     kernel::~kernel() {
       if (cuModule) {
-        OCCA_CUDA_ERROR("Kernel (" + name + ") : Unloading Module",
-                        cuModuleUnload(cuModule));
+        OCCA_CUDA_DESTRUCTOR_ERROR(
+          "Kernel (" + name + ") : Unloading Module",
+          cuModuleUnload(cuModule)
+        );
         cuModule = NULL;
       }
     }

--- a/src/modes/cuda/memory.cpp
+++ b/src/modes/cuda/memory.cpp
@@ -15,8 +15,10 @@ namespace occa {
     memory::~memory() {
       if (isOrigin) {
         if (mappedPtr) {
-          OCCA_CUDA_ERROR("Device: mappedFree()",
-                          cuMemFreeHost(mappedPtr));
+          OCCA_CUDA_DESTRUCTOR_ERROR(
+            "Device: mappedFree()",
+            cuMemFreeHost(mappedPtr)
+          );
         } else if (cuPtr) {
           cuMemFree(cuPtr);
         }

--- a/src/modes/cuda/stream.cpp
+++ b/src/modes/cuda/stream.cpp
@@ -10,8 +10,10 @@ namespace occa {
       cuStream(cuStream_) {}
 
     stream::~stream() {
-      OCCA_CUDA_ERROR("Device: freeStream",
-                      cuStreamDestroy(cuStream));
+      OCCA_CUDA_DESTRUCTOR_ERROR(
+        "Device: freeStream",
+        cuStreamDestroy(cuStream)
+      );
     }
   }
 }

--- a/src/modes/cuda/streamTag.cpp
+++ b/src/modes/cuda/streamTag.cpp
@@ -9,8 +9,10 @@ namespace occa {
       cuEvent(cuEvent_) {}
 
     streamTag::~streamTag() {
-      OCCA_CUDA_ERROR("streamTag: Freeing CUevent",
-                      cuEventDestroy(cuEvent));
+      OCCA_CUDA_DESTRUCTOR_ERROR(
+        "streamTag: Freeing CUevent",
+        cuEventDestroy(cuEvent)
+      );
     }
   }
 }

--- a/src/modes/cuda/utils.cpp
+++ b/src/modes/cuda/utils.cpp
@@ -20,6 +20,8 @@ namespace occa {
     }
 
     int getDeviceCount() {
+      init();
+
       int deviceCount = 0;
       OCCA_CUDA_ERROR("Finding Number of Devices",
                       cuDeviceGetCount(&deviceCount));
@@ -27,6 +29,8 @@ namespace occa {
     }
 
     CUdevice getDevice(const int id) {
+      init();
+
       CUdevice device = -1;
       OCCA_CUDA_ERROR("Getting CUdevice",
                       cuDeviceGet(&device, id));
@@ -87,7 +91,6 @@ namespace occa {
                           CUdeviceptr srcMemory,
                           const udim_t bytes,
                           CUstream usingStream) {
-
       peerToPeerMemcpy(destDevice, destContext, destMemory,
                        srcDevice , srcContext , srcMemory ,
                        bytes,
@@ -103,7 +106,6 @@ namespace occa {
                                CUdeviceptr srcMemory,
                                const udim_t bytes,
                                CUstream usingStream) {
-
       peerToPeerMemcpy(destDevice, destContext, destMemory,
                        srcDevice , srcContext , srcMemory ,
                        bytes,
@@ -119,7 +121,6 @@ namespace occa {
                           const udim_t bytes,
                           CUstream usingStream,
                           const bool isAsync) {
-
 #if CUDA_VERSION >= 4000
       if (!isAsync) {
         OCCA_CUDA_ERROR("Peer-to-Peer Memory Copy",
@@ -154,6 +155,7 @@ namespace occa {
       CUdevice cuDevice = ((device.mode() == "CUDA")
                            ? ((cuda::device*) device.getModeDevice())->cuDevice
                            : CU_DEVICE_CPU);
+
       OCCA_CUDA_ERROR("Advising about unified memory",
                       cuMemAdvise(((cuda::memory*) mem.getModeMemory())->cuPtr,
                                   (size_t) bytes_,
@@ -177,6 +179,7 @@ namespace occa {
     void prefetch(occa::memory mem, const dim_t bytes, occa::device device) {
       OCCA_ERROR("Memory allocated with mode [" << mem.mode() << "], not [CUDA]",
                  mem.mode() == "CUDA");
+
 #if CUDA_VERSION >= 8000
       udim_t bytes_ = ((bytes == -1) ? mem.size() : bytes);
       CUdevice cuDevice = ((device.mode() == "CUDA")
@@ -202,11 +205,10 @@ namespace occa {
     occa::device wrapDevice(CUdevice device,
                             CUcontext context,
                             const occa::properties &props) {
-
       occa::properties allProps;
-      allProps["mode"]     = "CUDA";
+      allProps["mode"]      = "CUDA";
       allProps["device_id"] = -1;
-      allProps["wrapped"]  = true;
+      allProps["wrapped"]   = true;
       allProps += props;
 
       cuda::device &dev = *(new cuda::device(allProps));
@@ -258,6 +260,22 @@ namespace occa {
                const int line,
                const std::string &message) {
       if (!errorCode) {
+        return;
+      }
+      std::stringstream ss;
+      ss << message << '\n'
+         << "CUDA Error [ " << errorCode << " ]: "
+         << occa::cuda::getErrorMessage(errorCode);
+      occa::error(filename, function, line, ss.str());
+    }
+
+    // On destructors, ignore the case when CUDA becomes uninitialized
+    void destructorError(CUresult errorCode,
+                         const std::string &filename,
+                         const std::string &function,
+                         const int line,
+                         const std::string &message) {
+      if (!errorCode || errorCode == CUDA_ERROR_DEINITIALIZED) {
         return;
       }
       std::stringstream ss;


### PR DESCRIPTION
## Description

CUDA uninitializes before some static objects are destroyed, raising some `CUDA_ERROR_DEINITIALIZED`. Since this is most likely going to show up on destructors at the end of a program, we add a special case to avoid erroring out.

<!-- Thank you for contributing! -->
