### PR TITLE
Fix compilation on PowerPC

### DIFF
--- a/include/occa/scripts/shellTools.sh
+++ b/include/occa/scripts/shellTools.sh
@@ -224,6 +224,7 @@ function compilerVendor {
     local b_HP=6
     local b_VisualStudio=7
     local b_Cray=8
+    local b_PPC=9
 
     local testFilename="${SCRIPTS_DIR}/tests/compiler.cpp"
     local binaryFilename="${SCRIPTS_DIR}/tests/compiler"
@@ -243,6 +244,7 @@ function compilerVendor {
         "${b_HP}")           echo HP           ;;
         "${b_Cray}")         echo CRAY         ;;
         "${b_VisualStudio}") echo VISUALSTUDIO ;;
+        "${b_PPC}")          echo POWERPC      ;;
         *)                   echo N/A          ;;
     esac
 }
@@ -251,7 +253,7 @@ function compilerCpp11Flags {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM|INTEL|PGI)
+        GCC|LLVM|INTEL|PGI|POWERPC)
             echo "-std=c++11";;
         CRAY)      echo "-hstd=c++11"          ;;
         IBM)       echo "-qlanglvl=extended0x" ;;
@@ -268,6 +270,7 @@ function compilerReleaseFlags {
 
     case "$vendor" in
         GCC|LLVM)   echo " -O3 -march=native -D __extern_always_inline=inline" ;;
+        POWERPC)    echo " -O3 -mcpu=native -mtune=native -D __extern_always_inline=inline" ;;
         INTEL)      echo " -O3 -xHost"                                         ;;
         CRAY)       echo " -O3 -h intrinsics -fast"                            ;;
         IBM)        echo " -O3 -qhot=simd"                                     ;;
@@ -291,7 +294,7 @@ function compilerPicFlag {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM|INTEL|PATHSCALE|CRAY|PGI)
+        GCC|LLVM|INTEL|PATHSCALE|CRAY|PGI|POWERPC)
             echo "-fPIC";;
         IBM) echo "-qpic";;
         HP)  echo "+z";;
@@ -303,7 +306,7 @@ function compilerSharedFlag {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM|INTEL|PATHSCALE|CRAY|PGI)
+        GCC|LLVM|INTEL|PATHSCALE|CRAY|PGI|POWERPC)
             echo "-shared";;
         IBM) echo "-qmkshrobj";;
         HP)  echo "-b";;
@@ -319,13 +322,13 @@ function compilerOpenMPFlag {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM)        echo "-fopenmp" ;;
-        INTEL|PATHSCALE) echo "-openmp"  ;;
-        CRAY)            echo ""         ;;
-        IBM)             echo "-qsmp"    ;;
-        PGI)             echo "-mp"      ;;
-        HP)              echo "+Oopenmp" ;;
-        *)               echo ""         ;;
+        GCC|LLVM|POWERPC) echo "-fopenmp" ;;
+        INTEL|PATHSCALE)  echo "-openmp"  ;;
+        CRAY)             echo ""         ;;
+        IBM)              echo "-qsmp"    ;;
+        PGI)              echo "-mp"      ;;
+        HP)               echo "+Oopenmp" ;;
+        *)                echo ""         ;;
     esac
 }
 

--- a/include/occa/scripts/tests/compiler.cpp
+++ b/include/occa/scripts/tests/compiler.cpp
@@ -7,7 +7,8 @@
 #define OCCA_HP_VENDOR           6
 #define OCCA_VISUALSTUDIO_VENDOR 7
 #define OCCA_CRAY_VENDOR         8
-#define OCCA_NOT_FOUND           9
+#define OCCA_PPC_VENDOR          9
+#define OCCA_NOT_FOUND           10
 
 int main(int argc, char **argv) {
 
@@ -36,6 +37,9 @@ int main(int argc, char **argv) {
 
 #elif defined(__clang__)
   return OCCA_LLVM_VENDOR;
+
+#elif defined(__powerpc__)
+  return OCCA_PPC_VENDOR;
 
 // Clang also defines __GNUC__, so check for it after __clang__
 #elif defined(__GNUC__) || defined(__GNUG__)


### PR DESCRIPTION
## Description

On PowerPC (e.g. [Lassen](https://hpc.llnl.gov/hardware/platforms/lassen)) `-march` is not a valid flag of gcc and compilation fails right away. This adds a check for PowerPC (gcc defines `__powerpc__` there) and replaces `-march=native` with `-mcpu=native -mtune=native` in that case.

If this is not the right place to do this change please let me know!

<!-- Thank you for contributing! -->
