### PR TITLE
OpenMP - add base compiler flag for OpenMP on PPC with GCC

### DIFF
--- a/src/modes/openmp/utils.cpp
+++ b/src/modes/openmp/utils.cpp
@@ -10,6 +10,7 @@ namespace occa {
 
     std::string baseCompilerFlag(const int vendor_) {
       if (vendor_ & (sys::vendor::GNU |
+                     sys::vendor::PPC |
                      sys::vendor::LLVM)) {
         return "-fopenmp";
       } else if (vendor_ & sys::vendor::Intel) {


### PR DESCRIPTION
## Description

This should be the second half of #395. Now we pass with the new OCCA backend on Travis PowerPC:

https://travis-ci.com/github/CEED/libCEED/jobs/372904963



<!-- Thank you for contributing! -->
