### PR TITLE
[CUDA] Sets the CUDA context in more methods

### DIFF
--- a/include/occa/modes/cuda/device.hpp
+++ b/include/occa/modes/cuda/device.hpp
@@ -42,6 +42,8 @@ namespace occa {
 
       void* getNullPtr();
 
+      void setCudaContext();
+
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::properties &props);
 

--- a/src/modes/cuda/device.cpp
+++ b/src/modes/cuda/device.cpp
@@ -126,12 +126,17 @@ namespace occa {
       return (void*) &(nullPtr->cuPtr);
     }
 
+    void device::setCudaContext() {
+      OCCA_CUDA_ERROR("Device: Setting Context",
+                      cuCtxSetCurrent(cuContext));
+    }
+
     //---[ Stream ]---------------------
     modeStream_t* device::createStream(const occa::properties &props) {
       CUstream cuStream = NULL;
 
-      OCCA_CUDA_ERROR("Device: Setting Context",
-                      cuCtxSetCurrent(cuContext));
+      setCudaContext();
+
       OCCA_CUDA_ERROR("Device: createStream",
                       cuStreamCreate(&cuStream, CU_STREAM_DEFAULT));
 
@@ -141,8 +146,8 @@ namespace occa {
     occa::streamTag device::tagStream() {
       CUevent cuEvent = NULL;
 
-      OCCA_CUDA_ERROR("Device: Setting Context",
-                      cuCtxSetCurrent(cuContext));
+      setCudaContext();
+
       OCCA_CUDA_ERROR("Device: Tagging Stream (Creating Tag)",
                       cuEventCreate(&cuEvent,
                                     CU_EVENT_DEFAULT));
@@ -218,6 +223,8 @@ namespace occa {
       CUmodule cuModule;
       CUfunction cuFunction;
       CUresult error;
+
+      setCudaContext();
 
       error = cuModuleLoad(&cuModule, binaryFilename.c_str());
       if (error) {
@@ -353,6 +360,8 @@ namespace occa {
       CUmodule cuModule;
       CUresult error;
 
+      setCudaContext();
+
       error = cuModuleLoad(&cuModule, binaryFilename.c_str());
       if (error) {
         lock.release();
@@ -410,6 +419,8 @@ namespace occa {
       CUmodule cuModule = NULL;
       CUfunction cuFunction = NULL;
 
+      setCudaContext();
+
       OCCA_CUDA_ERROR("Kernel [" + kernelName + "]: Loading Module",
                       cuModuleLoad(&cuModule, filename.c_str()));
 
@@ -438,8 +449,7 @@ namespace occa {
 
       cuda::memory &mem = *(new cuda::memory(this, bytes, props));
 
-      OCCA_CUDA_ERROR("Device: Setting Context",
-                      cuCtxSetCurrent(cuContext));
+      setCudaContext();
 
       OCCA_CUDA_ERROR("Device: malloc",
                       cuMemAlloc(&(mem.cuPtr), bytes));
@@ -456,8 +466,8 @@ namespace occa {
 
       cuda::memory &mem = *(new cuda::memory(this, bytes, props));
 
-      OCCA_CUDA_ERROR("Device: Setting Context",
-                      cuCtxSetCurrent(cuContext));
+      setCudaContext();
+
       OCCA_CUDA_ERROR("Device: malloc host",
                       cuMemAllocHost((void**) &(mem.mappedPtr), bytes));
       OCCA_CUDA_ERROR("Device: get device pointer from host",
@@ -481,8 +491,8 @@ namespace occa {
       const unsigned int flags = (props.get("attached_host", false) ?
                                   CU_MEM_ATTACH_HOST : CU_MEM_ATTACH_GLOBAL);
 
-      OCCA_CUDA_ERROR("Device: Setting Context",
-                      cuCtxSetCurrent(cuContext));
+      setCudaContext();
+
       OCCA_CUDA_ERROR("Device: Unified alloc",
                       cuMemAllocManaged(&(mem.cuPtr),
                                         bytes,

--- a/src/modes/cuda/kernel.cpp
+++ b/src/modes/cuda/kernel.cpp
@@ -62,6 +62,8 @@ namespace occa {
     }
 
     void kernel::deviceRun() const {
+      device *devicePtr = (device*) modeDevice;
+
       const int args = (int) arguments.size();
       if (!args) {
         vArgs.resize(1);
@@ -74,9 +76,11 @@ namespace occa {
         vArgs[i] = arguments[i].ptr();
         // Set a proper NULL pointer
         if (!vArgs[i]) {
-          vArgs[i] = ((device*) modeDevice)->getNullPtr();
+          vArgs[i] = devicePtr->getNullPtr();
         }
       }
+
+      devicePtr->setCudaContext();
 
       OCCA_CUDA_ERROR("Launching Kernel",
                       cuLaunchKernel(cuFunction,


### PR DESCRIPTION
## Description

If multiple devices are created in the same process, the wrong context gets kept in a few places.

<!-- Thank you for contributing! -->
