### PR TITLE
[Lang][Preprocessor] Adds okl/strict_headers option

### DIFF
--- a/include/occa/lang/preprocessor.hpp
+++ b/include/occa/lang/preprocessor.hpp
@@ -42,6 +42,10 @@ namespace occa {
       typedef void (preprocessor_t::*processDirective_t)(identifierToken &directive);
       typedef std::map<std::string, processDirective_t> directiveMap;
 
+      //---[ Settings ]-----------------
+      bool strictHeaders;
+      //================================
+
       //---[ Status ]-------------------
       std::vector<int> statusStack;
       int status;

--- a/include/occa/lang/tokenizer.hpp
+++ b/include/occa/lang/tokenizer.hpp
@@ -112,6 +112,8 @@ namespace occa {
       token_t* getCharToken(const int encoding);
 
       int peekForHeader();
+      bool loadingQuotedHeader();
+      bool loadingAngleBracketHeader();
       std::string getHeader();
 
       void setOrigin(const int line,

--- a/src/lang/tokenizer.cpp
+++ b/src/lang/tokenizer.cpp
@@ -815,35 +815,53 @@ namespace occa {
       return tokenType::none;
     }
 
-    std::string tokenizer_t::getHeader() {
+    bool tokenizer_t::loadingQuotedHeader() {
+      // Assumes we are loading a header
       int type = shallowPeek();
 
-      // Push after in case of whitespace
-      push();
-      if (type & tokenType::op) {
-        ++fp.start; // Skip <
-        push();
-        skipTo(">\n");
-        if (*fp.start == '\n') {
-          printError("Not able to find a closing >");
-          pop();
-          pop();
-          return NULL;
-        }
-        const std::string header = str();
-        pop();
-        ++fp.start; // Skip >
-        return header;
-      }
+      return (type & tokenType::string);
+    }
 
-      if (!(type & tokenType::string)) {
+    bool tokenizer_t::loadingAngleBracketHeader() {
+      // Assumes we are loading a header
+      int type = shallowPeek();
+
+      return (type & tokenType::op);
+    }
+
+    std::string tokenizer_t::getHeader() {
+      bool isQuoted = loadingQuotedHeader();
+      bool isAngleBracket = loadingAngleBracketHeader();
+
+      if (!isQuoted && !isAngleBracket) {
         printError("Not able to parse header");
         return NULL;
       }
 
-      std::string value;
-      getString(value);
-      return value;
+      // Push after in case of whitespace
+      push();
+
+      // (Quoted) #include "..."
+      if (isQuoted) {
+        std::string value;
+        getString(value);
+        return value;
+      }
+
+      // (Angle bracket) #include <...>
+      ++fp.start; // Skip <
+      push();
+      skipTo(">\n");
+      if (*fp.start == '\n') {
+        printError("Not able to find a closing >");
+        pop();
+        pop();
+        return NULL;
+      }
+      const std::string header = str();
+      pop();
+      ++fp.start; // Skip >
+      return header;
     }
 
     void tokenizer_t::setOrigin(const int line,

--- a/tests/src/lang/preprocessor.cpp
+++ b/tests/src/lang/preprocessor.cpp
@@ -658,28 +658,37 @@ void testIncludeStandardHeader() {
   getToken();                                   \
   ASSERT_EQ_BINARY(tokenType::directive,        \
                    token->type());              \
-  ASSERT_EQ("include <" header ">",             \
+  ASSERT_EQ("include " header,                  \
             token->to<directiveToken>().value)
 
-  setStream(
-     "#include \"math.h\"\n"
+  for (int i = 0; i < 2; ++i) {
+    const bool hasStrictHeaders = (bool) i;
+
+    setStream(
+      "#include \"math.h\"\n"
       "#include <math.h>\n"
       "#include \"cmath\"\n"
       "#include <cmath>\n"
       "#include \"iostream\"\n"
       "#include <iostream>\n"
-  );
+    );
 
-  preprocessor_t *pp = (preprocessor_t*) tokenStream.getInput("preprocessor_t");
+    preprocessor_t *pp = (preprocessor_t*) tokenStream.getInput("preprocessor_t");
+    pp->strictHeaders = hasStrictHeaders;
 
-  checkInclude("math.h");
-  checkInclude("math.h");
-  checkInclude("cmath");
-  checkInclude("cmath");
-  checkInclude("iostream");
-  checkInclude("iostream");
+    checkInclude("\"math.h\"");
+    checkInclude("<math.h>");
+    checkInclude("\"cmath\"");
+    checkInclude("<cmath>");
+    checkInclude("\"iostream\"");
+    checkInclude("<iostream>");
 
-  ASSERT_EQ(6, pp->warnings);
+    if (hasStrictHeaders) {
+      ASSERT_EQ(6, pp->warnings);
+    } else {
+      ASSERT_EQ(0, pp->warnings);
+    }
+  }
 }
 
 void testPragma() {

--- a/tests/src/lang/tokenizer/token.cpp
+++ b/tests/src/lang/tokenizer/token.cpp
@@ -108,6 +108,18 @@ void testPeekMethods() {
   testCharPeek("U'\\''" , encodingType::U);
   testCharPeek("L'\\''" , encodingType::L);
 
+  setStream("<foobar>");
+  ASSERT_TRUE(tokenizer.loadingAngleBracketHeader());
+  ASSERT_FALSE(tokenizer.loadingQuotedHeader());
+
+  setStream("\"foobar\"");
+  ASSERT_FALSE(tokenizer.loadingAngleBracketHeader());
+  ASSERT_TRUE(tokenizer.loadingQuotedHeader());
+
+  setStream("foobar");
+  ASSERT_FALSE(tokenizer.loadingAngleBracketHeader());
+  ASSERT_FALSE(tokenizer.loadingQuotedHeader());
+
   ASSERT_EQ("foobar",
             getHeader("<foobar>"));
   ASSERT_EQ("foobar",


### PR DESCRIPTION
## Description

Adds the option to include non-standard system headers

```sh
> occa translate addVectors.okl
addVectors.okl:1:2: Error: File does not exist
#include "foobar"
 ^
```
Adding 
```cpp
kernelProps["okl/strict_headers"] = false;
```
or passing it in the CLI ends up including headers even if OCCA can't find them:
```sh
> occa translate -k "okl: { strict_headers: false }" addVectors.okl
...
#include "foobar"
...
```