### PR TITLE
[Lang] Adds support for U/L/LL suffix on hex/binary primitives

### DIFF
--- a/include/occa/lang/primitive.hpp
+++ b/include/occa/lang/primitive.hpp
@@ -53,6 +53,7 @@ namespace occa {
   class primitive {
   public:
     int type;
+    std::string source;
 
     union {
       bool bool_;
@@ -79,12 +80,14 @@ namespace occa {
     }
 
     inline primitive(const primitive &p) :
-      type(p.type) {
+        type(p.type),
+        source(p.source) {
       value.ptr = p.value.ptr;
     }
 
     inline primitive& operator = (const primitive &p) {
       type = p.type;
+      source = p.source;
       value.ptr = p.value.ptr;
       return *this;
     }
@@ -327,6 +330,8 @@ namespace occa {
     }
 
     std::string toString() const;
+    std::string toBinaryString() const;
+    std::string toHexString() const;
 
     friend io::output& operator << (io::output &out,
                                     const primitive &p);

--- a/tests/src/lang/primitive.cpp
+++ b/tests/src/lang/primitive.cpp
@@ -110,6 +110,14 @@ void testLoad() {
             (double) occa::primitive("150.1E-1"));
   ASSERT_EQ(-15.01,
             (double) occa::primitive("-150.1E-1"));
+
+  ASSERT_TRUE(!!(occa::primitive("0x7f800000U").type & occa::primitiveType::isUnsigned));
+
+  ASSERT_TRUE(!!(occa::primitive("0x7f800000L").type & occa::primitiveType::int64_));
+  ASSERT_TRUE(!!(occa::primitive("0x7f800000LL").type & occa::primitiveType::int64_));
+
+  ASSERT_TRUE(!!(occa::primitive("0x7f800000UL").type & occa::primitiveType::uint64_));
+  ASSERT_TRUE(!!(occa::primitive("0x7f800000LLU").type & occa::primitiveType::uint64_));
 }
 
 void testBadParsing() {
@@ -145,8 +153,17 @@ void testBadParsing() {
 }
 
 void testToString() {
-  ASSERT_EQ("68719476735L",
+  ASSERT_EQ("0xFFFFFFFFF",
             occa::primitive("0xFFFFFFFFF").toString());
+
+  ASSERT_EQ("0x7f800000U",
+            occa::primitive("0x7f800000U").toString());
+
+  ASSERT_EQ("0x7f800000L",
+            occa::primitive("0x7f800000L").toString());
+
+  ASSERT_EQ("0x7f800000LL",
+            occa::primitive("0x7f800000LL").toString());
 
   ASSERT_EQ("NaN",
             occa::primitive("").toString());


### PR DESCRIPTION
## Description

Examples of cases covered now:
```
0x7f800000U
0x7f800000L
0x7f800000LL
0x7f800000UL
0x7f800000LLU
```

This also outputs primitives based on their source rather than parsed values for better accuracy
