### PR TITLE
[QOL] Adds occa::env::setOccaCacheDir

### DIFF
--- a/include/occa/tools/env.hpp
+++ b/include/occa/tools/env.hpp
@@ -34,6 +34,8 @@ namespace occa {
       return fromString<TM>(value);
     }
 
+    void setOccaCacheDir(const std::string &path);
+
     class envInitializer_t {
     public:
       envInitializer_t();
@@ -42,15 +44,17 @@ namespace occa {
     private:
       bool isInitialized;
 
-      void initSettings();
-      void initEnvironment();
-      void loadConfig();
+      static void initSettings();
+      static void initEnvironment();
+      static void loadConfig();
 
-      void setupCachePath();
-      void setupIncludePath();
-      void registerFileOpeners();
+      static void setupCachePath();
+      static void setupIncludePath();
+      static void registerFileOpeners();
 
-      void cleanFileOpeners();
+      static void cleanFileOpeners();
+
+      friend void setOccaCacheDir(const std::string &path);
     };
 
     extern envInitializer_t envInitializer;

--- a/src/tools/env.cpp
+++ b/src/tools/env.cpp
@@ -41,6 +41,11 @@ namespace occa {
       return "";
     }
 
+    void setOccaCacheDir(const std::string &path) {
+      OCCA_CACHE_DIR = path;
+      envInitializer_t::setupCachePath();
+    }
+
     envInitializer_t::envInitializer_t() :
       isInitialized(false) {
       if (isInitialized) {
@@ -139,6 +144,7 @@ namespace occa {
     }
 
     void envInitializer_t::setupCachePath() {
+      // Set defaults if needed
       if (env::OCCA_CACHE_DIR.size() == 0) {
         std::stringstream ss;
 
@@ -155,6 +161,7 @@ namespace occa {
 #endif
         env::OCCA_CACHE_DIR = ss.str();
       }
+
       env::OCCA_CACHE_DIR = io::filename(env::OCCA_CACHE_DIR);
       io::endWithSlash(env::OCCA_CACHE_DIR);
 


### PR DESCRIPTION
## Description

Adds a programmatic way of setting the `OCCA_CACHE_DIR`

```cpp
occa::env::setOccaCacheDir(<path>)
```

Solves #252

<!-- Thank you for contributing! -->
