### PR TITLE
Make build system understand new hipconfig output

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -338,7 +338,7 @@ ifdef OCCA_HIP_ENABLED
     ifeq ($(hipPlatform),nvcc)
       linkerFlags += -lcuda
       linkerFlags += -lcudart
-    else ifeq ($(hipPlatform),hcc)
+    else ifeq ($(hipPlatform),$(filter $(hipPlatform),hcc amd))
       #set HIP_COMPILER if not supplied by user
       ifeq (,$(HIP_COMPILER))
         hipCompiler = $(shell $(HIP_PATH)/bin/hipconfig --compiler)
@@ -374,7 +374,7 @@ else
     ifeq ($(hipPlatform),nvcc)
       hipLibFlags  = $(call libraryFlagsFor,cuda)
       hipLibFlags += $(call libraryFlagsFor,cudart)
-    else ifeq ($(hipPlatform),hcc)
+    else ifeq ($(hipPlatform),$(filter $(hipPlatform),hcc amd))
       #set HIP_COMPILER if not supplied by user
       ifeq (,$(HIP_COMPILER))
         hipCompiler = $(shell $(HIP_PATH)/bin/hipconfig --compiler)


### PR DESCRIPTION
From ROCm 4.0, hipconfig --platform will output 'amd' instead of 'hcc'.
This change simply proactively mitigates a potential surprise where OCCA
thinks it couldn't find ROCm.

## Description




<!-- Thank you for contributing! -->
