### PR TITLE
[Lang] Add barriers only after last inner block in each kernel, skipping last inner block

### DIFF
--- a/include/occa/lang/modes/withLauncher.hpp
+++ b/include/occa/lang/modes/withLauncher.hpp
@@ -44,6 +44,8 @@ namespace occa {
 
         bool isLastInnerLoop(forStatement &forSmnt);
 
+        bool isInsideLoop(forStatement &forSmnt);
+
         void setKernelLaunch(functionDeclStatement &kernelSmnt,
                              forStatement &forSmnt,
                              const int kernelIndex);

--- a/include/occa/lang/modes/withLauncher.hpp
+++ b/include/occa/lang/modes/withLauncher.hpp
@@ -42,6 +42,8 @@ namespace occa {
         bool isOuterMostOklLoop(forStatement &forSmnt,
                                 const std::string &attr);
 
+        bool isLastInnerLoop(forStatement &forSmnt);
+
         void setKernelLaunch(functionDeclStatement &kernelSmnt,
                              forStatement &forSmnt,
                              const int kernelIndex);

--- a/src/lang/modes/withLauncher.cpp
+++ b/src/lang/modes/withLauncher.cpp
@@ -446,20 +446,24 @@ namespace occa {
                 replaceOccaFor(outerSmnt);
               });
 
-        const bool applyBarriers = usesBarriers();
+        if (usesBarriers()) {
+          statementArray::from(kernelSmnt)
+              .flatFilterByAttribute("inner")
+              .filterByStatementType(statementType::for_)
+              .forEach([&](statement_t *smnt) {
+                  forStatement &innerSmnt = (forStatement&) *smnt;
+
+                  // TODO 1.1: Only apply barriers when needed in the last inner-loop
+                  if (isOuterMostInnerLoop(innerSmnt) )
+                    addBarriersAfterInnerLoop(innerSmnt);
+                });
+        }
 
         statementArray::from(kernelSmnt)
             .flatFilterByAttribute("inner")
             .filterByStatementType(statementType::for_)
             .forEach([&](statement_t *smnt) {
                 forStatement &innerSmnt = (forStatement&) *smnt;
-
-                // TODO 1.1: Only apply barriers when needed in the last inner-loop
-                if (applyBarriers &&
-                    isOuterMostInnerLoop(innerSmnt)) {
-                  addBarriersAfterInnerLoop(innerSmnt);
-                }
-
                 replaceOccaFor(innerSmnt);
               });
       }

--- a/src/lang/modes/withLauncher.cpp
+++ b/src/lang/modes/withLauncher.cpp
@@ -150,6 +150,17 @@ namespace occa {
         return true;
       }
 
+      bool withLauncher::isLastInnerLoop(forStatement &forSmnt) {
+        blockStatement &parent = *(forSmnt.up);
+        for(int smntIndex = forSmnt.childIndex()+1; smntIndex<parent.size(); smntIndex++) {
+          if ((parent[smntIndex]->type() & statementType::for_)
+              && parent[smntIndex]->hasAttribute("inner")) {
+            return false;
+          }
+        }
+        return true;
+      }
+
       void withLauncher::setKernelLaunch(functionDeclStatement &kernelSmnt,
                                          forStatement &forSmnt,
                                          const int kernelIndex) {
@@ -453,8 +464,8 @@ namespace occa {
               .forEach([&](statement_t *smnt) {
                   forStatement &innerSmnt = (forStatement&) *smnt;
 
-                  // TODO 1.1: Only apply barriers when needed in the last inner-loop
-                  if (isOuterMostInnerLoop(innerSmnt) )
+                  //Only apply barriers when needed in the last inner-loop
+                  if (isOuterMostInnerLoop(innerSmnt) && !isLastInnerLoop(innerSmnt))
                     addBarriersAfterInnerLoop(innerSmnt);
                 });
         }


### PR DESCRIPTION
## Description

Fixes a bug where inner for loops were being replaced while checking if they were the outermost inner loop. Also adds one additional check for whether the inner block is the last in a kernel and skips adding a barrier if so.

Fixes #205


<!-- Thank you for contributing! -->
