### PR TITLE
[HIP] Avoid checking the error code from hipGetDeviceCount

### DIFF
--- a/src/modes/hip/utils.cpp
+++ b/src/modes/hip/utils.cpp
@@ -19,8 +19,7 @@ namespace occa {
 
     int getDeviceCount() {
       int deviceCount;
-      OCCA_HIP_ERROR("Finding Number of Devices",
-                     hipGetDeviceCount(&deviceCount));
+      hipGetDeviceCount(&deviceCount);
       return deviceCount;
     }
 

--- a/src/modes/hip/utils.cpp
+++ b/src/modes/hip/utils.cpp
@@ -18,7 +18,7 @@ namespace occa {
     }
 
     int getDeviceCount() {
-      int deviceCount;
+      int deviceCount=0;
       hipGetDeviceCount(&deviceCount);
       return deviceCount;
     }


### PR DESCRIPTION
Since hipGetDeviceCount will throw a hipErrorNoDevice error when no devices are present, it's better to not check the error code so that `occa info` does not fail on GPU-less headnodes.

## Description




<!-- Thank you for contributing! -->
