### PR TITLE
Use arch name property to determine gpu arch

### DIFF
--- a/src/occa/internal/modes/hip/polyfill.hpp
+++ b/src/occa/internal/modes/hip/polyfill.hpp
@@ -37,6 +37,7 @@ namespace occa {
     size_t totalGlobalMem;
     int maxThreadsPerBlock;
     int gcnArch;
+    char gcnArchName[256];
     int major;
     int minor;
 

--- a/src/occa/internal/modes/hip/utils.cpp
+++ b/src/occa/internal/modes/hip/utils.cpp
@@ -58,7 +58,7 @@ namespace occa {
                      hipGetDeviceProperties(&hipProps, deviceId));
 
       if (hipProps.gcnArch) {
-        return "gfx" + toString(hipProps.gcnArch);
+        return hipProps.gcnArchName;
       }
       std::string sm = "sm_";
       sm += toString(

--- a/src/occa/internal/modes/hip/utils.cpp
+++ b/src/occa/internal/modes/hip/utils.cpp
@@ -57,9 +57,14 @@ namespace occa {
       OCCA_HIP_ERROR("Getting HIP device properties",
                      hipGetDeviceProperties(&hipProps, deviceId));
 
-      if (hipProps.gcnArch) {
+      if (hipProps.gcnArch) { // AMD or NVIDIA
+#if HIP_VERSION >= 306
         return hipProps.gcnArchName;
+#else
+        return "gfx" + toString(hipProps.gcnArch);
+#endif
       }
+
       std::string sm = "sm_";
       sm += toString(
         majorVersion >= 0


### PR DESCRIPTION
HIP added a gcnArchName member to the hipDeviceProps_t struct.  This is
a char array and is more suitable for determining the name of the
architecture to target.  The older gcnArch is an integer and is a little
more brittle.

## Description




<!-- Thank you for contributing! -->
