### PR TITLE
[#396] Avoids kernel calls on noop dim sizes

### DIFF
--- a/include/occa/core/kernel.hpp
+++ b/include/occa/core/kernel.hpp
@@ -70,6 +70,8 @@ namespace occa {
 
     void setupRun();
 
+    bool isNoop() const;
+
     //---[ Virtual Methods ]------------
     virtual ~modeKernel_t() = 0;
 

--- a/include/occa/types/dim.hpp
+++ b/include/occa/types/dim.hpp
@@ -23,7 +23,8 @@ namespace occa {
     dim operator * (const dim &d) const;
     dim operator / (const dim &d) const;
 
-    bool hasNegativeEntries();
+    bool isZero() const;
+    bool hasNegativeEntries() const;
 
     udim_t& operator [] (int i);
     udim_t  operator [] (int i) const;

--- a/src/core/kernel.cpp
+++ b/src/core/kernel.cpp
@@ -142,6 +142,12 @@ namespace occa {
       }
     }
   }
+
+  bool modeKernel_t::isNoop() const {
+    return (
+      outerDims.isZero() && innerDims.isZero()
+    );
+  }
   //====================================
 
   //---[ kernel ]-----------------------
@@ -304,6 +310,10 @@ namespace occa {
 
   void kernel::run() const {
     assertInitialized();
+
+    if (modeKernel->isNoop()) {
+      return;
+    }
 
     modeKernel->setupRun();
     modeKernel->run();

--- a/src/types/dim.cpp
+++ b/src/types/dim.cpp
@@ -66,7 +66,11 @@ namespace occa {
                z / d.z);
   }
 
-  bool dim::hasNegativeEntries() {
+  bool dim::isZero() const {
+    return !(x && y && z);
+  }
+
+  bool dim::hasNegativeEntries() const {
     return ((x & (1 << (sizeof(udim_t) - 1))) ||
             (y & (1 << (sizeof(udim_t) - 1))) ||
             (z & (1 << (sizeof(udim_t) - 1))));


### PR DESCRIPTION
## Description

If the outer and inner dims are all set to `0`, avoid launching the kernel


<!-- Thank you for contributing! -->
