### PR TITLE
[#399][Sys] Remove sysctl usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,39 +87,39 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Compiler info
-      run: make -j 16 info
       if: ${{ !matrix.useCMake }}
+      run: make -j 16 info
 
     - name: CMake build
+      if: ${{ matrix.useCMake }}
       run: |
         cmake -E make_directory ${{runner.workspace}}/occa/build
         cd ${{runner.workspace}}/occa/build
         cmake -DENABLE_TESTS=On -DENABLE_EXAMPLES=On ${{runner.workspace}}/occa
         make -j 16
-      if: ${{ matrix.useCMake }}
 
     - name: Compile library
-      run: make -j 16
       if: ${{ !matrix.useCMake }}
+      run: make -j 16
 
     - name: Compile tests
-      run: make -j 16 tests
       if: ${{ !matrix.useCMake }}
+      run: make -j 16 tests
 
     - name: Run unit tests
-      run: ./tests/run_tests
       if: ${{ !matrix.useCMake }}
+      run: ./tests/run_tests
 
     - name: Run examples
-      run: ./tests/run_examples
       if: ${{ !matrix.useCMake }}
+      run: ./tests/run_examples
 
     - name: Run CTests
+      if: ${{ matrix.useCMake }}
       run: |
         cd ${{runner.workspace}}/occa/build
-        make test
-      if: ${{ matrix.useCMake }}
+        CTEST_OUTPUT_ON_FAILURE=1 make test
 
     - name: Upload code coverage
-      run: bash <(curl --no-buffer -s https://codecov.io/bash) -x "${GCOV}"
       if: ${{ matrix.OCCA_COVERAGE }}
+      run: bash <(curl --no-buffer -s https://codecov.io/bash) -x "${GCOV}"

--- a/include/occa/io.hpp
+++ b/include/occa/io.hpp
@@ -2,6 +2,7 @@
 #define OCCA_IO_HEADER
 
 #include <occa/io/cache.hpp>
+#include <occa/io/enums.hpp>
 #include <occa/io/fileOpener.hpp>
 #include <occa/io/lock.hpp>
 #include <occa/io/utils.hpp>

--- a/include/occa/io/enums.hpp
+++ b/include/occa/io/enums.hpp
@@ -1,0 +1,14 @@
+#ifndef OCCA_IO_ENUMS_HEADER
+#define OCCA_IO_ENUMS_HEADER
+
+namespace occa {
+  namespace enums {
+    enum FileType {
+      FILE_TYPE_TEXT,
+      FILE_TYPE_BINARY,
+      FILE_TYPE_PSEUDO
+    };
+  }
+}
+
+#endif

--- a/include/occa/io/utils.hpp
+++ b/include/occa/io/utils.hpp
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include <occa/types.hpp>
+#include <occa/io/enums.hpp>
 
 namespace occa {
   // Kernel Caching
@@ -69,10 +70,10 @@ namespace occa {
 
     char* c_read(const std::string &filename,
                  size_t *chars = NULL,
-                 const bool readingBinary = false);
+                 const enums::FileType fileType = enums::FILE_TYPE_TEXT);
 
     std::string read(const std::string &filename,
-                     const bool readingBinary = false);
+                     const enums::FileType fileType = enums::FILE_TYPE_TEXT);
 
     void write(const std::string &filename,
                const std::string &content);

--- a/include/occa/lang/primitive.hpp
+++ b/include/occa/lang/primitive.hpp
@@ -10,8 +10,8 @@
 
 #include <occa/defines.hpp>
 #include <occa/io/output.hpp>
+#include <occa/tools/logging.hpp>
 #include <occa/tools/string.hpp>
-#include <occa/tools/sys.hpp>
 
 namespace occa {
   //---[ Primitive Type ]---------------

--- a/include/occa/tools.hpp
+++ b/include/occa/tools.hpp
@@ -6,6 +6,7 @@
 #include <occa/tools/exception.hpp>
 #include <occa/tools/gc.hpp>
 #include <occa/tools/hash.hpp>
+#include <occa/tools/enums.hpp>
 #include <occa/tools/json.hpp>
 #include <occa/tools/lex.hpp>
 #include <occa/tools/misc.hpp>

--- a/include/occa/tools/enums.hpp
+++ b/include/occa/tools/enums.hpp
@@ -1,0 +1,21 @@
+#ifndef OCCA_TOOLS_ENUMS_HEADER
+#define OCCA_TOOLS_ENUMS_HEADER
+
+namespace occa {
+  namespace sys {
+    namespace language {
+      static const int notFound = 0;
+      static const int CPP      = 1;
+      static const int C        = 2;
+    }
+
+    enum class CacheLevel {
+      L1D,
+      L1I,
+      L2,
+      L3
+    };
+  }
+}
+
+#endif

--- a/include/occa/tools/logging.hpp
+++ b/include/occa/tools/logging.hpp
@@ -1,0 +1,43 @@
+#ifndef OCCA_TOOLS_LOGGING_HEADER
+#define OCCA_TOOLS_LOGGING_HEADER
+
+#include <iostream>
+
+namespace occa {
+  namespace io {
+    class output;
+  }
+
+  void _message(const std::string &header,
+                const bool exitInFailure,
+                const std::string &filename,
+                const std::string &function,
+                const int line,
+                const std::string &message);
+
+  void warn(const std::string &filename,
+            const std::string &function,
+            const int line,
+            const std::string &message);
+
+  void error(const std::string &filename,
+             const std::string &function,
+             const int line,
+             const std::string &message);
+
+  void printWarning(io::output &out,
+                    const std::string &message,
+                    const std::string &code = "");
+
+  void printWarning(const std::string &message,
+                    const std::string &code = "");
+
+  void printError(io::output &out,
+                  const std::string &message,
+                  const std::string &code = "");
+
+  void printError(const std::string &message,
+                  const std::string &code = "");
+}
+
+#endif

--- a/include/occa/tools/misc.hpp
+++ b/include/occa/tools/misc.hpp
@@ -1,11 +1,35 @@
 #ifndef OCCA_TOOLS_MISC_HEADER
 #define OCCA_TOOLS_MISC_HEADER
 
+#include <initializer_list>
+
 #include <occa/defines.hpp>
 #include <occa/types.hpp>
 
 namespace occa {
   udim_t ptrDiff(void *start, void *end);
+
+  template <class TM>
+  TM min(std::initializer_list<TM> values) {
+    TM minValue = *values.begin();
+    for (const TM &value : values) {
+      if (value < minValue) {
+        minValue = value;
+      }
+    }
+    return minValue;
+  }
+
+  template <class TM>
+  TM max(std::initializer_list<TM> values) {
+    TM maxValue = *values.begin();
+    for (const TM &value : values) {
+      if (maxValue < value) {
+        maxValue = value;
+      }
+    }
+    return maxValue;
+  }
 
   template <class TM>
   void ignoreResult(const TM &t) {

--- a/include/occa/tools/string.hpp
+++ b/include/occa/tools/string.hpp
@@ -12,6 +12,7 @@
 #include <occa/types.hpp>
 
 namespace occa {
+  //---[ Helper Methods ]---------------
   std::string strip(const std::string &str);
 
   std::string stripLeft(const std::string &str);
@@ -34,6 +35,9 @@ namespace occa {
   strVector split(const std::string &s,
                   const char delimeter,
                   const char escapeChar = 0);
+
+  std::string join(const strVector &vec,
+                   const std::string &delimiter);
 
   inline char uppercase(const char c) {
     if (('a' <= c) && (c <= 'z')) {
@@ -63,6 +67,30 @@ namespace occa {
     return lowercase(s.c_str(), s.size());
   }
 
+  inline bool startsWith(const std::string &s,
+                         const std::string &match) {
+    const int matchChars = (int) match.size();
+    return ((matchChars <= (int) s.size()) &&
+            (!strncmp(s.c_str(), match.c_str(), matchChars)));
+  }
+
+  inline bool endsWith(const std::string &s,
+                       const std::string &match) {
+    const int sChars = (int) s.size();
+    const int matchChars = (int) match.size();
+    return ((matchChars <= sChars) &&
+            (!strncmp(s.c_str() + (sChars - matchChars),
+                      match.c_str(),
+                      matchChars)));
+  }
+
+  inline bool contains(const std::string &s,
+                       const std::string &match) {
+    return s.find(match) != std::string::npos;
+  }
+  //====================================
+
+  //---[ Stringify ]--------------------
   template <class TM>
   std::string toString(const TM &t) {
     std::stringstream ss;
@@ -134,33 +162,19 @@ namespace occa {
     }
     return ret;
   }
+  //====================================
 
-  inline bool startsWith(const std::string &s,
-                         const std::string &match) {
-    const int matchChars = (int) match.size();
-    return ((matchChars <= (int) s.size()) &&
-            (!strncmp(s.c_str(), match.c_str(), matchChars)));
-  }
+  //---[ Formatters ]-------------------
+  udim_t parseInt(const std::string &str);
+  udim_t parseInt(const char *c);
 
-  inline bool endsWith(const std::string &s,
-                       const std::string &match) {
-    const int sChars = (int) s.size();
-    const int matchChars = (int) match.size();
-    return ((matchChars <= sChars) &&
-            (!strncmp(s.c_str() + (sChars - matchChars),
-                      match.c_str(),
-                      matchChars)));
-  }
+  udim_t parseBinary(const char *c);
 
-  udim_t atoi(const char *c);
-  udim_t atoiBase2(const char *c);
-  udim_t atoi(const std::string &str);
+  double parseFloat(const std::string &str);
+  double parseFloat(const char *c);
 
-  double atof(const char *c);
-  double atof(const std::string &str);
-
-  double atod(const char *c);
-  double atod(const std::string &str);
+  double parseDouble(const std::string &str);
+  double parseDouble(const char *c);
 
   inline char toHexChar(const char c) {
     if (c < 16) {
@@ -247,9 +261,11 @@ namespace occa {
   }
 
   std::string stringifyBytes(udim_t bytes);
-
   void stringifyBytesFraction(std::stringstream &ss,
                               uint64_t fraction);
+
+  std::string stringifyFrequency(udim_t frequency);
+  //====================================
 
   //---[ Color Strings ]----------------
   namespace color {

--- a/include/occa/tools/vector.hpp
+++ b/include/occa/tools/vector.hpp
@@ -27,9 +27,6 @@ namespace occa {
 
   template <>
   dim_t indexOf(const std::vector<long double> &vec, const long double &value);
-
-  std::string join(const std::vector<std::string> &vec,
-                   const std::string &delimiter);
 }
 
 #endif

--- a/include/occa/types/dim.hpp
+++ b/include/occa/types/dim.hpp
@@ -23,6 +23,11 @@ namespace occa {
     dim operator * (const dim &d) const;
     dim operator / (const dim &d) const;
 
+    template <class TM>
+    static inline bool hasNegativeBitSet(const TM &t) {
+      return t & (1 << (sizeof(TM) - 1));
+    }
+
     bool isZero() const;
     bool hasNegativeEntries() const;
 

--- a/src/array/linalg.cpp
+++ b/src/array/linalg.cpp
@@ -38,7 +38,7 @@ namespace occa {
             continue;
           }
 
-          const int idx = occa::atoi(std::string(cStart, c - cStart));
+          const int idx = occa::parseInt(std::string(cStart, c - cStart));
           if (std::find(vec.begin(), vec.end(), idx) == vec.end()) {
             vec.push_back(idx);
             if (minVal > idx) {

--- a/src/io/cache.cpp
+++ b/src/io/cache.cpp
@@ -6,6 +6,7 @@
 #include <occa/tools/env.hpp>
 #include <occa/tools/lex.hpp>
 #include <occa/tools/properties.hpp>
+#include <occa/tools/sys.hpp>
 
 namespace occa {
   namespace io {

--- a/src/io/lock.cpp
+++ b/src/io/lock.cpp
@@ -8,6 +8,7 @@
 #include <occa/io/output.hpp>
 #include <occa/io/utils.hpp>
 #include <occa/tools/env.hpp>
+#include <occa/tools/sys.hpp>
 
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
 #  include <unistd.h>

--- a/src/lang/primitive.cpp
+++ b/src/lang/primitive.cpp
@@ -136,12 +136,12 @@ namespace occa {
       // Handle the multiple other formats with normal digits
       if (decimal || float_) {
         if (float_) {
-          p = (float) occa::atof(std::string(c0, c - c0));
+          p = (float) occa::parseFloat(std::string(c0, c - c0));
         } else {
-          p = (double) occa::atod(std::string(c0, c - c0));
+          p = (double) occa::parseDouble(std::string(c0, c - c0));
         }
       } else {
-        uint64_t value_ = occa::atoi(std::string(c0, c - c0));
+        uint64_t value_ = parseInt(std::string(c0, c - c0));
         if (longs == 0) {
           if (unsigned_) {
             p = (uint32_t) value_;

--- a/src/modes/opencl/device.cpp
+++ b/src/modes/opencl/device.cpp
@@ -168,7 +168,7 @@ namespace occa {
       clInfo.clContext = clContext;
 
       // Build OpenCL program
-      std::string source = io::read(sourceFilename, true);
+      std::string source = io::read(sourceFilename, enums::FILE_TYPE_BINARY);
 
       opencl::buildProgramFromSource(clInfo,
                                      source,

--- a/src/modes/opencl/utils.cpp
+++ b/src/modes/opencl/utils.cpp
@@ -307,7 +307,7 @@ namespace occa {
       cl_int binaryError = 1;
 
       size_t binaryBytes;
-      const char *binary = io::c_read(binaryFilename, &binaryBytes, true);
+      const char *binary = io::c_read(binaryFilename, &binaryBytes, enums::FILE_TYPE_BINARY);
       info.clProgram = clCreateProgramWithBinary(info.clContext,
                                                  1, &(info.clDevice),
                                                  &binaryBytes,

--- a/src/modes/serial/device.cpp
+++ b/src/modes/serial/device.cpp
@@ -435,7 +435,7 @@ namespace occa {
     }
 
     udim_t device::memorySize() const {
-      return sys::installedRAM();
+      return sys::SystemInfo::load().memory.total;
     }
     //==================================
   }

--- a/src/tools/logging.cpp
+++ b/src/tools/logging.cpp
@@ -1,0 +1,76 @@
+#include <occa/tools/env.hpp>
+#include <occa/tools/exception.hpp>
+#include <occa/tools/logging.hpp>
+#include <occa/tools/string.hpp>
+#include <occa/io.hpp>
+
+namespace occa {
+  void _message(const std::string &header,
+                const bool exitInFailure,
+                const std::string &filename,
+                const std::string &function,
+                const int line,
+                const std::string &message) {
+
+    exception exp(header,
+                  filename,
+                  function,
+                  line,
+                  message);
+
+    if (exitInFailure) {
+      throw exp;
+    }
+    io::stderr << exp;
+  }
+
+  void warn(const std::string &filename,
+            const std::string &function,
+            const int line,
+            const std::string &message) {
+    _message("Warning", false,
+             filename, function, line, message);
+  }
+
+  void error(const std::string &filename,
+             const std::string &function,
+             const int line,
+             const std::string &message) {
+    _message("Error", true,
+             filename, function, line, message);
+  }
+
+  void printWarning(io::output &out,
+                    const std::string &message,
+                    const std::string &code) {
+    if (env::OCCA_VERBOSE) {
+      if (code.size()) {
+        out << yellow("Warning " + code);
+      } else {
+        out << yellow("Warning");
+      }
+      out << ": " << message << '\n';
+    }
+  }
+
+  void printWarning(const std::string &message,
+                    const std::string &code) {
+    printWarning(io::stderr, message, code);
+  }
+
+  void printError(io::output &out,
+                  const std::string &message,
+                  const std::string &code) {
+    if (code.size()) {
+      out << red("Error " + code);
+    } else {
+      out << red("Error");
+    }
+    out << ": " << message << '\n';
+  }
+
+  void printError(const std::string &message,
+                  const std::string &code) {
+    printError(io::stderr, message, code);
+  }
+}

--- a/src/tools/styling.cpp
+++ b/src/tools/styling.cpp
@@ -46,21 +46,17 @@ namespace occa {
     }
 
     int fieldGroup::getFieldWidth() const {
-      const int fieldCount = (int) fields.size();
       int maxWidth = 0;
-      for (int i = 0; i < fieldCount; ++i) {
-        const int iWidth = (int) fields[i].name.size();
-        maxWidth = (maxWidth < iWidth) ? iWidth : maxWidth;
+      for (auto &field: fields) {
+        maxWidth = std::max(maxWidth, (int) field.name.size());
       }
       return maxWidth;
     }
 
     int fieldGroup::getValueWidth() const {
-      const int fieldCount = (int) fields.size();
       int maxWidth = 0;
-      for (int i = 0; i < fieldCount; ++i) {
-        const int iWidth = (int) fields[i].value.size();
-        maxWidth = (maxWidth < iWidth) ? iWidth : maxWidth;
+      for (auto &field: fields) {
+        maxWidth = std::max(maxWidth, (int) field.value.size());
       }
       return maxWidth;
     }
@@ -85,8 +81,7 @@ namespace occa {
 
     section& section::add(const std::string &field,
                           const std::string &value) {
-      fieldGroup &fg = groups[groups.size() - 1];
-      fg.add(field, value);
+      groups.back().add(field, value);
       return *this;
     }
 
@@ -96,19 +91,17 @@ namespace occa {
     }
 
     int section::getFieldWidth() const {
-      const int groupCount = (int) groups.size();
       int fieldWidth = 0;
-      for (int i = 0; i < groupCount; ++i) {
-        fieldWidth = std::max(fieldWidth, groups[i].getFieldWidth());
+      for (auto &group : groups) {
+        fieldWidth = std::max(fieldWidth, group.getFieldWidth());
       }
       return fieldWidth;
     }
 
     int section::getValueWidth() const {
-      const int groupCount = (int) groups.size();
       int valueWidth = 0;
-      for (int i = 0; i < groupCount; ++i) {
-        valueWidth = std::max(valueWidth, groups[i].getValueWidth());
+      for (auto &group : groups) {
+        valueWidth = std::max(valueWidth, group.getValueWidth());
       }
       return valueWidth;
     }
@@ -135,20 +128,21 @@ namespace occa {
       const std::string groupDivider = ss.str();
       ss.str("");
 
-      const int groupCount = (int) groups.size();
       if (isFirstSection) {
         ss << sectionDivider;
       }
-      for (int i = 0; i < groupCount; ++i) {
-        const fieldGroup &iGroup = groups[i];
 
-        const int fieldCount = (int) iGroup.size();
+      const int groupCount = (int) groups.size();
+      for (int i = 0; i < groupCount; ++i) {
+        const fieldGroup &group = groups[i];
+
+        const int fieldCount = (int) group.size();
         if (fieldCount == 0) {
           continue;
         }
 
         for (int j = 0; j < fieldCount; ++j) {
-          const field& jField = iGroup.fields[j];
+          const field& field = group.fields[j];
 
           ss << indentStr;
           if (i == 0 && j == 0) {
@@ -158,9 +152,9 @@ namespace occa {
           }
 
           ss << '|'
-             << left(jField.name, fieldWidth, true)
+             << left(field.name, fieldWidth, true)
              << '|'
-             << left(jField.value, valueWidth, true)
+             << left(field.value, valueWidth, true)
              << '\n';
         }
         if (i < (groupCount - 1)) {
@@ -182,25 +176,26 @@ namespace occa {
     }
 
     std::string table::toString(const int indent) const {
-      const int sectionCount = (int) sections.size();
-      std::string str;
-
       int sectionWidth = 0, fieldWidth = 0, valueWidth = 0;
-      for (int i = 0; i < sectionCount; ++i) {
-        const section &iSection = sections[i];
-        sectionWidth = std::max(sectionWidth, (int) iSection.name.size());
-        fieldWidth   = std::max(fieldWidth  , iSection.getFieldWidth());
-        valueWidth   = std::max(valueWidth  , iSection.getValueWidth());
+      for (auto &section : sections) {
+        sectionWidth = std::max(sectionWidth, (int) section.name.size());
+        fieldWidth   = std::max(fieldWidth  , section.getFieldWidth());
+        valueWidth   = std::max(valueWidth  , section.getValueWidth());
       }
 
-      for (int i = 0; i < sectionCount; ++i) {
-        if (sections[i].size()) {
-          str += sections[i].toString(indent,
-                                      sectionWidth,
-                                      fieldWidth,
-                                      valueWidth,
-                                      i == 0);
+      std::string str;
+      bool isFirstSection = true;
+      for (auto &section : sections) {
+        if (section.size()) {
+          str += section.toString(
+            indent,
+            sectionWidth,
+            fieldWidth,
+            valueWidth,
+            isFirstSection
+          );
         }
+        isFirstSection = false;
       }
 
       return str;

--- a/src/tools/sys.cpp
+++ b/src/tools/sys.cpp
@@ -563,7 +563,7 @@ namespace occa {
 
     udim_t SystemInfo::getProcessorCacheSize(const json &systemInfo,
                                              CacheLevel level) {
-#if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
+#if (OCCA_OS & OCCA_LINUX_OS)
       std::string fieldName;
 
       const std::string levelFieldNames[4] = {
@@ -640,7 +640,9 @@ namespace occa {
           break;
       }
 
-      return getSystemInfoField(systemInfo, fieldName);
+      return parseInt(
+        (std::string) getSystemInfoField(systemInfo, fieldName)
+      );
 #elif (OCCA_OS == OCCA_WINDOWS_OS)
       return 0;
 #endif

--- a/src/tools/sys.cpp
+++ b/src/tools/sys.cpp
@@ -13,7 +13,6 @@
 #  include <sys/types.h>
 #  include <sys/stat.h>
 #  include <sys/syscall.h>
-#  include <sys/sysctl.h>
 #  include <sys/time.h>
 #  include <unistd.h>
 #  if (OCCA_OS & OCCA_LINUX_OS)
@@ -43,8 +42,9 @@
 #include <occa/core/base.hpp>
 #include <occa/io.hpp>
 #include <occa/tools/env.hpp>
-#include <occa/tools/hash.hpp>
 #include <occa/tools/exception.hpp>
+#include <occa/tools/hash.hpp>
+#include <occa/tools/json.hpp>
 #include <occa/tools/lex.hpp>
 #include <occa/tools/misc.hpp>
 #include <occa/tools/string.hpp>
@@ -53,6 +53,26 @@
 
 namespace occa {
   namespace sys {
+    CacheInfo::CacheInfo() :
+        l1d(0),
+        l1i(0),
+        l2(0),
+        l3(0) {}
+
+    ProcessorInfo::ProcessorInfo() :
+        name(""),
+        frequency(0),
+        coreCount(0),
+        cache() {}
+
+    MemoryInfo::MemoryInfo() :
+        total(0),
+        available(0) {}
+
+    SystemInfo::SystemInfo() :
+        processor(),
+        memory() {}
+
     //---[ System Info ]----------------
     double currentTime() {
       // Returns the current time in seconds
@@ -131,18 +151,18 @@ namespace occa {
       std::stringstream ss;
 
       switch (month) {
-      case 1 : ss << "Jan"; break;
-      case 2 : ss << "Feb"; break;
-      case 3 : ss << "Mar"; break;
-      case 4 : ss << "Apr"; break;
-      case 5 : ss << "May"; break;
-      case 6 : ss << "Jun"; break;
-      case 7 : ss << "Jul"; break;
-      case 8 : ss << "Aug"; break;
-      case 9 : ss << "Sep"; break;
-      case 10: ss << "Oct"; break;
-      case 11: ss << "Nov"; break;
-      case 12: ss << "Dec"; break;
+        case 1 : ss << "Jan"; break;
+        case 2 : ss << "Feb"; break;
+        case 3 : ss << "Mar"; break;
+        case 4 : ss << "Apr"; break;
+        case 5 : ss << "May"; break;
+        case 6 : ss << "Jun"; break;
+        case 7 : ss << "Jul"; break;
+        case 8 : ss << "Aug"; break;
+        case 9 : ss << "Sep"; break;
+        case 10: ss << "Oct"; break;
+        case 11: ss << "Nov"; break;
+        case 12: ss << "Dec"; break;
       }
 
       ss << ' ' << day << ' ' << year << ' ';
@@ -374,13 +394,13 @@ namespace occa {
 
     int getTID() {
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
-      #if OCCA_OS == OCCA_MACOS_OS & (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12)
+#if OCCA_OS == OCCA_MACOS_OS & (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12)
       uint64_t tid64;
       pthread_threadid_np(NULL, &tid64);
       pid_t tid = (pid_t)tid64;
-      #else
+#else
       pid_t tid = syscall(SYS_gettid);
-      #endif
+#endif
       return tid;
 #else
       return GetCurrentThreadId();
@@ -388,13 +408,16 @@ namespace occa {
     }
 
     void pinToCore(const int core) {
-      const int coreCount = getCoreCount();
+      sys::SystemInfo info = sys::SystemInfo::load();
+      const int coreCount = info.processor.coreCount;
+
 #if OCCA_UNSAFE
-    ignoreResult(coreCount);
+      ignoreResult(coreCount);
 #endif
       OCCA_ERROR("Core to pin (" << core << ") is not in range: [0, "
                  << coreCount << "]",
                  (0 <= core) && (core < coreCount));
+
 #if (OCCA_OS == OCCA_LINUX_OS)
       cpu_set_t cpuSet;
       CPU_ZERO(&cpuSet);
@@ -407,56 +430,94 @@ namespace occa {
     //==================================
 
     //---[ Processor Info ]-------------
-    std::string getFieldFrom(const std::string &command,
-                             const std::string &field) {
-#if (OCCA_OS & OCCA_LINUX_OS)
-      std::string shellToolsFile = env::OCCA_DIR + "include/occa/scripts/shellTools.sh";
+    json SystemInfo::getSystemInfo() {
+#if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
+      std::string content;
 
-      std::stringstream ss;
-
-      ss << "echo \"(. " << shellToolsFile << "; " << command << " '" << field << "')\" | bash";
-
-      std::string sCommand = ss.str();
-
-      FILE *fp;
-      fp = popen(sCommand.c_str(), "r");
-
-      const int bufferSize = 4096;
-      char *buffer = new char[bufferSize];
-
-      ignoreResult( fread(buffer, sizeof(char), bufferSize, fp) );
-
-      pclose(fp);
-
-      int end;
-
-      for (end = 0; end < bufferSize; ++end) {
-        if (buffer[end] == '\n')
-          break;
-      }
-
-      std::string ret(buffer, end);
-
-      delete [] buffer;
-
-      return ret;
+      const std::string command = (
+#if   (OCCA_OS & OCCA_LINUX_OS)
+        "lscpu"
 #else
-      return "";
+        "sysctl -a"
+#endif
+      );
+
+      call(command, content);
+
+      return parseSystemInfoContent(content);
+#else
+      return json();
 #endif
     }
 
-    std::string getProcessorName() {
+    // Colon-delimited with an unknown amount of spacing around the colon
+    // Example:
+    //  key1 : value1
+    //  key2: value2
+    //  key3   : value3
+    json SystemInfo::parseSystemInfoContent(const std::string &content) {
+      json info;
+
+      for (std::string &line : split(content, '\n')) {
+        if (!strip(line).size()) {
+          continue;
+        }
+
+        strVector parts = split(line, ':');
+        if (parts.size() < 2) {
+          continue;
+        }
+
+        const std::string key = lowercase(strip(parts[0]));
+
+        // Remove the key and join back on :
+        parts.erase(parts.begin());
+        const std::string value = strip(
+          join(parts, ":")
+        );
+
+        info[key] = value;
+      }
+
+      return info;
+    }
+
+    json SystemInfo::getSystemInfoField(const json &systemInfo,
+                                        const std::string &field) {
+      const std::string lowerField = lowercase(field);
+
+      if (systemInfo.has(lowerField)) {
+        return systemInfo[lowerField];
+      }
+
+      return json();
+    }
+
+    SystemInfo SystemInfo::load() {
+      json systemInfo = getSystemInfo();
+      SystemInfo info;
+
+      info.setProcessorInfo(systemInfo);
+      info.setMemoryInfo(systemInfo);
+
+      return info;
+    }
+
+    void SystemInfo::setProcessorInfo(const json &systemInfo) {
+      processor.name = getProcessorName(systemInfo);
+      processor.frequency = getProcessorFrequency(systemInfo);
+      processor.coreCount = getCoreCount(systemInfo);
+      processor.cache.l1d = getProcessorCacheSize(systemInfo, CacheLevel::L1D);
+      processor.cache.l1i = getProcessorCacheSize(systemInfo, CacheLevel::L1I);
+      processor.cache.l2  = getProcessorCacheSize(systemInfo, CacheLevel::L2);
+      processor.cache.l3  = getProcessorCacheSize(systemInfo, CacheLevel::L3);
+    }
+
+    std::string SystemInfo::getProcessorName(const json &systemInfo) {
 #if   (OCCA_OS & OCCA_LINUX_OS)
-      return getFieldFrom("getCPUINFOField", "model name");
+      return getSystemInfoField(systemInfo, "Model name");
 #elif (OCCA_OS == OCCA_MACOS_OS)
-      size_t bufferSize = 100;
-      char buffer[100];
-
-      sysctlbyname("machdep.cpu.brand_string",
-                   &buffer, &bufferSize,
-                   NULL, 0);
-
-      return std::string(buffer);
+      return getSystemInfoField(systemInfo, "machdep.cpu.brand_string");
 #elif (OCCA_OS == OCCA_WINDOWS_OS)
       char buffer[MAX_COMPUTERNAME_LENGTH + 1];
       int bytes;
@@ -467,9 +528,11 @@ namespace occa {
 #endif
     }
 
-    int getCoreCount() {
-#if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
-      return sysconf(_SC_NPROCESSORS_ONLN);
+    int SystemInfo::getCoreCount(const json &systemInfo) {
+#if   (OCCA_OS & OCCA_LINUX_OS)
+      return getSystemInfoField(systemInfo, "Model name");
+#elif (OCCA_OS == OCCA_MACOS_OS)
+      return getSystemInfoField(systemInfo, "hw.physicalcpu");
 #elif (OCCA_OS == OCCA_WINDOWS_OS)
       SYSTEM_INFO sysinfo;
       GetSystemInfo(&sysinfo);
@@ -477,113 +540,118 @@ namespace occa {
 #endif
     }
 
-    int getProcessorFrequency() {
+    udim_t SystemInfo::getProcessorFrequency(const json &systemInfo) {
 #if   (OCCA_OS & OCCA_LINUX_OS)
-      std::stringstream ss;
-      float freq = 0;
+      const float frequency = parseFloat(
+        getSystemInfoField(systemInfo, "CPU max MHz")
+      );
+      return (udim_t) (frequency * 1e3);
 
-      ss << getFieldFrom("getLSCPUField", "cpu.*mhz");
-      ss >> freq;
-
-      return (int) freq;
 #elif (OCCA_OS == OCCA_MACOS_OS)
-      uint64_t frequency = 0;
-      size_t size = sizeof(frequency);
+      const float frequency = parseFloat(
+        getSystemInfoField(systemInfo, "hw.cpufrequency")
+      );
+      return (udim_t) frequency;
 
-      int error = sysctlbyname("hw.cpufrequency", &frequency, &size, NULL, 0);
-#if OCCA_UNSAFE
-    ignoreResult(error);
-#endif
-
-      OCCA_ERROR("Error getting CPU Frequency.\n",
-                 error != ENOMEM);
-
-      return frequency / 1.0e6;
 #elif (OCCA_OS == OCCA_WINDOWS_OS)
       LARGE_INTEGER performanceFrequency;
       QueryPerformanceFrequency(&performanceFrequency);
 
-      return (int) (((double) performanceFrequency.QuadPart) / 1000.0);
+      return (udim_t) (((double) performanceFrequency.QuadPart) * 1e3);
 #endif
     }
 
-    std::string getProcessorCacheSize(int level) {
-#if   (OCCA_OS & OCCA_LINUX_OS)
-      std::stringstream field;
+    udim_t SystemInfo::getProcessorCacheSize(const json &systemInfo,
+                                             CacheLevel level) {
+#if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
+      std::string fieldName;
 
-      field << 'L' << level;
+      const std::string levelFieldNames[4] = {
+        "L1d cache",
+        "L1i cache",
+        "L2 cache",
+        "L3 cache",
+      };
 
-      if (level == 1)
-        field << 'd';
+      switch (level) {
+        case CacheLevel::L1D:
+          fieldName = levelFieldNames[0];
+          break;
 
-      field << " cache";
+        case CacheLevel::L1I:
+          fieldName = levelFieldNames[1];
+          break;
 
-      return getFieldFrom("getLSCPUField", field.str());
-#elif (OCCA_OS == OCCA_MACOS_OS)
-      std::stringstream ss;
-      ss << "hw.l" << level;
+        case CacheLevel::L2:
+          fieldName = levelFieldNames[2];
+          break;
 
-      if (level == 1)
-        ss << 'd';
-
-      ss << "cachesize";
-
-      std::string field = ss.str();
-
-      uint64_t cache = 0;
-      size_t size = sizeof(cache);
-
-      int error = sysctlbyname(field.c_str(), &cache, &size, NULL, 0);
-#if OCCA_UNSAFE
-    ignoreResult(error);
-#endif
-
-      OCCA_ERROR("Error getting L" << level << " Cache Size.\n",
-                 error != ENOMEM);
-
-      return stringifyBytes(cache);
-#elif (OCCA_OS == OCCA_WINDOWS_OS)
-      std::stringstream ss;
-      DWORD cache = 0;
-      int bytes = 0;
-
-      PSYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer = NULL;
-
-      GetLogicalProcessorInformation(buffer, (LPDWORD) &bytes);
-
-      OCCA_ERROR("[GetLogicalProcessorInformation] Failed",
-                 (GetLastError() == ERROR_INSUFFICIENT_BUFFER));
-
-      buffer = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION) sys::malloc(bytes);
-
-      bool passed = GetLogicalProcessorInformation(buffer, (LPDWORD) &bytes);
-
-      OCCA_ERROR("[GetLogicalProcessorInformation] Failed",
-                 passed);
-
-      PSYSTEM_LOGICAL_PROCESSOR_INFORMATION pos = buffer;
-      int off = 0;
-      int sk = sizeof(PSYSTEM_LOGICAL_PROCESSOR_INFORMATION);
-
-      while ((off + sk) <= bytes) {
-        if (pos->Relationship == RelationCache) {
-          CACHE_DESCRIPTOR info = pos->Cache;
-          if (info.Level == level) {
-            cache = info.Size;
-            break;
-          }
-        }
-        ++pos;
-        off += sk;
+        case CacheLevel::L3:
+          fieldName = levelFieldNames[3];
+          break;
       }
 
-      sys::free(buffer);
+      const std::string humanReadableSize = lowercase(
+        (std::string) getSystemInfoField(systemInfo, fieldName)
+      );
 
-      return stringifyBytes(cache);
+      int multiplier = 0;
+      if (contains(humanReadableSize, "k")) {
+        // Examples:
+        //   22K
+        //   22 KB
+        //   22 KiB
+        multiplier = (1 << 10);
+      } else if (contains(humanReadableSize, "m")) {
+        // Examples:
+        //   22M
+        //   22 MB
+        //   22 MiB
+        multiplier = (1 << 20);
+      }
+
+      return multiplier * parseInt(humanReadableSize);
+
+#elif (OCCA_OS == OCCA_MACOS_OS)
+      std::string fieldName;
+
+      const std::string levelFieldNames[4] = {
+        "hw.l1dcachesize",
+        "hw.l1icachesize",
+        "hw.l2cachesize",
+        "hw.l3cachesize"
+      };
+
+      switch (level) {
+        case CacheLevel::L1D:
+          fieldName = levelFieldNames[0];
+          break;
+
+        case CacheLevel::L1I:
+          fieldName = levelFieldNames[1];
+          break;
+
+        case CacheLevel::L2:
+          fieldName = levelFieldNames[2];
+          break;
+
+        case CacheLevel::L3:
+          fieldName = levelFieldNames[3];
+          break;
+      }
+
+      return getSystemInfoField(systemInfo, fieldName);
+#elif (OCCA_OS == OCCA_WINDOWS_OS)
+      return 0;
 #endif
     }
 
-    udim_t installedRAM() {
+    void SystemInfo::setMemoryInfo(const json &systemInfo) {
+      memory.total = installedMemory(systemInfo);
+      memory.available = availableMemory();
+    }
+
+    udim_t SystemInfo::installedMemory(const json &systemInfo) {
 #if   (OCCA_OS & OCCA_LINUX_OS)
       struct sysinfo info;
 
@@ -595,20 +663,13 @@ namespace occa {
 
       return info.totalram;
 #elif (OCCA_OS == OCCA_MACOS_OS)
-      int64_t ram;
-
-      int mib[2]   = {CTL_HW, HW_MEMSIZE};
-      size_t bytes = sizeof(ram);
-
-      sysctl(mib, 2, &ram, &bytes, NULL, 0);
-
-      return ram;
+      return getSystemInfoField(systemInfo, "hw.memsize");
 #elif (OCCA_OS == OCCA_WINDOWS_OS)
       return 0;
 #endif
     }
 
-    udim_t availableRAM() {
+    udim_t SystemInfo::availableMemory() {
 #if   (OCCA_OS & OCCA_LINUX_OS)
       struct sysinfo info;
 
@@ -645,7 +706,9 @@ namespace occa {
       return 0;
 #endif
     }
+    //==================================
 
+    //---[ Compiler Info ]--------------
     int compilerVendor(const std::string &compiler) {
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
       const std::string safeCompiler = io::slashToSnake(compiler);
@@ -1024,65 +1087,6 @@ namespace occa {
       return std::string(symbol);
 #endif
     }
-  }
-
-  void _message(const std::string &header,
-                const bool exitInFailure,
-                const std::string &filename,
-                const std::string &function,
-                const int line,
-                const std::string &message) {
-
-    exception exp(header,
-                  filename,
-                  function,
-                  line,
-                  message);
-
-    if (exitInFailure) {
-      throw exp;
-    }
-    io::stderr << exp;
-  }
-
-  void warn(const std::string &filename,
-            const std::string &function,
-            const int line,
-            const std::string &message) {
-    _message("Warning", false,
-             filename, function, line, message);
-  }
-
-  void error(const std::string &filename,
-             const std::string &function,
-             const int line,
-             const std::string &message) {
-    _message("Error", true,
-             filename, function, line, message);
-  }
-
-  void printWarning(io::output &out,
-                    const std::string &message,
-                    const std::string &code) {
-    if (env::OCCA_VERBOSE) {
-      if (code.size()) {
-        out << yellow("Warning " + code);
-      } else {
-        out << yellow("Warning");
-      }
-      out << ": " << message << '\n';
-    }
-  }
-
-  void printError(io::output &out,
-                  const std::string &message,
-                  const std::string &code) {
-    if (code.size()) {
-      out << red("Error " + code);
-    } else {
-      out << red("Error");
-    }
-    out << ": " << message << '\n';
   }
 
   mutex::mutex() {

--- a/src/tools/vector.cpp
+++ b/src/tools/vector.cpp
@@ -36,17 +36,4 @@ namespace occa {
     }
     return -1;
   }
-
-  std::string join(const std::vector<std::string> &vec,
-                   const std::string &delimiter) {
-    const size_t size = vec.size();
-    std::string ret;
-    for (size_t i = 0; i < size; ++i) {
-      if (i) {
-        ret += delimiter;
-      }
-      ret += toString(vec[i]);
-    }
-    return ret;
-  }
 }

--- a/src/types/dim.cpp
+++ b/src/types/dim.cpp
@@ -71,9 +71,11 @@ namespace occa {
   }
 
   bool dim::hasNegativeEntries() const {
-    return ((x & (1 << (sizeof(udim_t) - 1))) ||
-            (y & (1 << (sizeof(udim_t) - 1))) ||
-            (z & (1 << (sizeof(udim_t) - 1))));
+    return (
+      hasNegativeBitSet(x) ||
+      hasNegativeBitSet(y) ||
+      hasNegativeBitSet(z)
+    );
   }
 
   udim_t& dim::operator [] (int i) {

--- a/tests/src/io/utils.cpp
+++ b/tests/src/io/utils.cpp
@@ -3,8 +3,7 @@
 #include <time.h>
 
 #include <occa/io.hpp>
-#include <occa/tools/env.hpp>
-#include <occa/tools/sys.hpp>
+#include <occa/tools.hpp>
 #include <occa/tools/testing.hpp>
 
 void testPathMethods();
@@ -166,7 +165,9 @@ void testIOMethods() {
   // Read
   ASSERT_EQ(occa::io::read(test_foo),
             content);
-  ASSERT_EQ(occa::io::read(test_foo, true),
+  ASSERT_EQ(occa::io::read(test_foo, occa::enums::FILE_TYPE_BINARY),
+            content);
+  ASSERT_EQ(occa::io::read(test_foo, occa::enums::FILE_TYPE_PSEUDO),
             content);
 
   // C Read

--- a/tests/src/tools/string.cpp
+++ b/tests/src/tools/string.cpp
@@ -6,6 +6,7 @@ using namespace occa;
 void testStrip();
 void testEscape();
 void testSplit();
+void testContains();
 void testCaseMethods();
 void testString();
 void testMatchEnds();
@@ -17,6 +18,7 @@ int main(const int argc, const char **argv) {
   testStrip();
   testEscape();
   testSplit();
+  testContains();
   testCaseMethods();
   testString();
   testMatchEnds();
@@ -54,6 +56,14 @@ void testSplit() {
   ASSERT_IN("a", vec);
   ASSERT_IN("b", vec);
   ASSERT_IN("c", vec);
+}
+
+void testContains() {
+  ASSERT_TRUE(contains("abcd", "b"));
+  ASSERT_TRUE(contains("abcd", "bcd"));
+  ASSERT_TRUE(contains("abcd", "abc"));
+  ASSERT_FALSE(contains("abcd", "B"));
+  ASSERT_TRUE(contains("abcd", ""));
 }
 
 void testCaseMethods() {
@@ -147,7 +157,7 @@ void testHex() {
   ASSERT_EQ(stringifyBytes(1L << 42),
             "4 TB");
   ASSERT_EQ(stringifyBytes(1L << 52),
-            toString(1L << 52) + " bytes");
+            "4096 TB");
 }
 
 void testJoin() {

--- a/tests/src/tools/vector.cpp
+++ b/tests/src/tools/vector.cpp
@@ -33,24 +33,10 @@ void testIndexOf() {
   );
 }
 
-void testJoin();
-
 int main(const int argc, const char **argv) {
   testIndexOf<int>();
   testIndexOf<float>();
   testIndexOf<std::string>();
-  testJoin();
 
   return 0;
-}
-
-void testJoin() {
-  strVector vec;
-  vec.push_back("a");
-  vec.push_back("b");
-  vec.push_back("c");
-  ASSERT_EQ(join(vec, ","),
-            "a,b,c");
-  ASSERT_EQ(join(vec, " , "),
-            "a , b , c");
 }


### PR DESCRIPTION
## Description

In issue #399, it was pointed out that `sysctl` was deprecated for a while and then removed. This PR replaces `sysctl` with `lscpu` and removes the usage of `shellTools` at runtime.

<!-- Thank you for contributing! -->
