### PR TITLE
[Core] Adds wrapMemory

### DIFF
--- a/include/occa/c/base.h
+++ b/include/occa/c/base.h
@@ -73,6 +73,15 @@ void* occaTypedUMalloc(const occaUDim_t entries,
                        const occaDtype type,
                        const void *src,
                        occaProperties props);
+
+occaMemory occaWrapMemory(const void *ptr,
+                          const occaUDim_t entries,
+                          occaProperties props);
+
+occaMemory occaTypedWrapMemory(const void *ptr,
+                               const occaUDim_t entries,
+                               const occaDtype dtype,
+                               occaProperties props);
 //======================================
 
 OCCA_END_EXTERN_C

--- a/include/occa/c/base.h
+++ b/include/occa/c/base.h
@@ -75,7 +75,7 @@ void* occaTypedUMalloc(const occaUDim_t entries,
                        occaProperties props);
 
 occaMemory occaWrapMemory(const void *ptr,
-                          const occaUDim_t entries,
+                          const occaUDim_t bytes,
                           occaProperties props);
 
 occaMemory occaTypedWrapMemory(const void *ptr,

--- a/include/occa/c/device.h
+++ b/include/occa/c/device.h
@@ -90,7 +90,7 @@ void* occaDeviceTypedUMalloc(occaDevice device,
 
 occaMemory occaDeviceWrapMemory(occaDevice device,
                                 const void *ptr,
-                                const occaUDim_t entries,
+                                const occaUDim_t bytes,
                                 occaProperties props);
 
 occaMemory occaDeviceTypedWrapMemory(occaDevice device,

--- a/include/occa/c/device.h
+++ b/include/occa/c/device.h
@@ -84,9 +84,20 @@ void* occaDeviceUMalloc(occaDevice device,
 
 void* occaDeviceTypedUMalloc(occaDevice device,
                              const occaUDim_t entries,
-                             const occaDtype type,
+                             const occaDtype dtype,
                              const void *src,
                              occaProperties props);
+
+occaMemory occaDeviceWrapMemory(occaDevice device,
+                                const void *ptr,
+                                const occaUDim_t entries,
+                                occaProperties props);
+
+occaMemory occaDeviceTypedWrapMemory(occaDevice device,
+                                     const void *ptr,
+                                     const occaUDim_t entries,
+                                     const occaDtype dtype,
+                                     occaProperties props);
 //======================================
 
 OCCA_END_EXTERN_C

--- a/include/occa/core/base.hpp
+++ b/include/occa/core/base.hpp
@@ -122,11 +122,20 @@ namespace occa {
   void memcpy(memory dest, memory src,
               const occa::properties &props);
 
-  namespace cpu {
-    occa::memory wrapMemory(void *ptr,
-                            const udim_t bytes,
-                            const occa::properties &props = occa::properties());
-  }
+  occa::memory wrapMemory(const void *ptr,
+                          const dim_t entries,
+                          const dtype_t &dtype,
+                          const occa::properties &props = occa::properties());
+
+  template <class TM = void>
+  occa::memory wrapMemory(const TM *ptr,
+                          const dim_t entries,
+                          const occa::properties &props);
+
+  template <>
+  occa::memory wrapMemory<void>(const void *ptr,
+                                const dim_t entries,
+                                const occa::properties &props);
   //====================================
 
   //---[ Free Functions ]---------------

--- a/include/occa/core/base.tpp
+++ b/include/occa/core/base.tpp
@@ -12,4 +12,11 @@ namespace occa {
               const occa::properties &props) {
     return (TM*) umalloc(entries, dtype::get<TM>(), src, props);
   }
+
+  template <class TM>
+  occa::memory wrapMemory(const TM *ptr,
+                          const dim_t entries,
+                          const occa::properties &props) {
+    return getDevice().wrapMemory(ptr, entries, occa::dtype::get<TM>(), props);
+  }
 }

--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -174,6 +174,16 @@ namespace occa {
     template <class TM = void>
     TM* umalloc(const dim_t entries,
                 const occa::properties &props);
+
+    template <class TM = void>
+    occa::memory wrapMemory(const TM *ptr,
+                            const dim_t entries,
+                            const occa::properties &props = occa::properties());
+
+    occa::memory wrapMemory(const void *ptr,
+                            const dim_t entries,
+                            const dtype_t &dtype,
+                            const occa::properties &props = occa::properties());
     //  |===============================
   };
 

--- a/include/occa/core/device.tpp
+++ b/include/occa/core/device.tpp
@@ -38,4 +38,16 @@ namespace occa {
                       const occa::properties &props) {
     return (TM*) umalloc(entries, dtype::get<TM>(), props);
   }
+
+  template <>
+  occa::memory device::wrapMemory<void>(const void *ptr,
+                                        const dim_t entries,
+                                        const occa::properties &props);
+
+  template <class TM>
+  occa::memory device::wrapMemory(const TM *ptr,
+                                  const dim_t entries,
+                                  const occa::properties &props) {
+    return wrapMemory(ptr, entries, occa::dtype::get<TM>(), props);
+  }
 }

--- a/include/occa/core/memory.hpp
+++ b/include/occa/core/memory.hpp
@@ -158,13 +158,6 @@ namespace occa {
   std::ostream& operator << (std::ostream &out,
                            const occa::memory &memory);
 
-  namespace cpu {
-    occa::memory wrapMemory(occa::device dev,
-                            void *ptr,
-                            const udim_t bytes,
-                            const occa::properties &props = occa::properties());
-  }
-
   template <>
   void* memory::ptr<void>();
 

--- a/src/c/base.cpp
+++ b/src/c/base.cpp
@@ -1,5 +1,6 @@
 #include <occa/internal/c/types.hpp>
 #include <occa/c/base.h>
+#include <occa/c/dtype.h>
 #include <occa/internal/utils/env.hpp>
 
 OCCA_START_EXTERN_C
@@ -143,18 +144,10 @@ occaKernel occaBuildKernelFromBinary(const char *filename,
 occaMemory occaMalloc(const occaUDim_t bytes,
                       const void *src,
                       occaProperties props) {
-  occa::memory memory;
-
-  if (occa::c::isDefault(props)) {
-    memory = occa::malloc(bytes, src);
-  } else {
-    memory = occa::malloc(bytes,
-                          src,
-                          occa::c::properties(props));
-  }
-  memory.dontUseRefs();
-
-  return occa::c::newOccaType(memory);
+  return occaTypedMalloc(bytes,
+                         occaDtypeByte,
+                         src,
+                         props);
 }
 
 occaMemory occaTypedMalloc(const occaUDim_t entries,
@@ -180,16 +173,10 @@ occaMemory occaTypedMalloc(const occaUDim_t entries,
 void* occaUMalloc(const occaUDim_t bytes,
                   const void *src,
                   occaProperties props) {
-
-  if (occa::c::isDefault(props)) {
-    return occa::umalloc(bytes,
-                         occa::dtype::byte,
-                         src);
-  }
-  return occa::umalloc(bytes,
-                       occa::dtype::byte,
-                       src,
-                       occa::c::properties(props));
+  return occaTypedUMalloc(bytes,
+                          occaDtypeByte,
+                          src,
+                          props);
 }
 
 void* occaTypedUMalloc(const occaUDim_t entries,
@@ -205,6 +192,32 @@ void* occaTypedUMalloc(const occaUDim_t entries,
                        dtype_,
                        src,
                        occa::c::properties(props));
+}
+
+occaMemory occaWrapMemory(const void *ptr,
+                          const occaUDim_t bytes,
+                          occaProperties props) {
+  return occaTypedWrapMemory(ptr,
+                             bytes,
+                             occaDtypeByte,
+                             props);
+}
+
+occaMemory occaTypedWrapMemory(const void *ptr,
+                               const occaUDim_t entries,
+                               const occaDtype dtype,
+                               occaProperties props) {
+  const occa::dtype_t &dtype_ = occa::c::dtype(dtype);
+
+  occa::memory memory;
+  if (occa::c::isDefault(props)) {
+    memory = occa::wrapMemory(ptr, entries, dtype_);
+  } else {
+    memory = occa::wrapMemory(ptr, entries, dtype_, occa::c::properties(props));
+  }
+  memory.dontUseRefs();
+
+  return occa::c::newOccaType(memory);
 }
 //======================================
 

--- a/src/c/device.cpp
+++ b/src/c/device.cpp
@@ -1,5 +1,6 @@
 #include <occa/internal/c/types.hpp>
 #include <occa/c/device.h>
+#include <occa/c/dtype.h>
 
 OCCA_START_EXTERN_C
 
@@ -188,18 +189,11 @@ occaMemory occaDeviceMalloc(occaDevice device,
                             const occaUDim_t bytes,
                             const void *src,
                             occaProperties props) {
-  occa::device device_ = occa::c::device(device);
-  occa::memory memory;
-  if (occa::c::isDefault(props)) {
-    memory = device_.malloc(bytes, src);
-  } else {
-    memory = device_.malloc(bytes,
-                            src,
-                            occa::c::properties(props));
-  }
-  memory.dontUseRefs();
-
-  return occa::c::newOccaType(memory);
+  return occaDeviceTypedMalloc(device,
+                               bytes,
+                               occaDtypeByte,
+                               src,
+                               props);
 }
 
 occaMemory occaDeviceTypedMalloc(occaDevice device,
@@ -228,17 +222,11 @@ void* occaDeviceUMalloc(occaDevice device,
                         const occaUDim_t bytes,
                         const void *src,
                         occaProperties props) {
-  occa::device device_ = occa::c::device(device);
-
-  if (occa::c::isDefault(props)) {
-    return device_.umalloc(bytes,
-                           occa::dtype::byte,
-                           src);
-  }
-  return device_.umalloc(bytes,
-                         occa::dtype::byte,
-                         src,
-                         occa::c::properties(props));
+  return occaDeviceTypedUMalloc(device,
+                                bytes,
+                                occaDtypeByte,
+                                src,
+                                props);
 }
 
 void* occaDeviceTypedUMalloc(occaDevice device,
@@ -256,6 +244,36 @@ void* occaDeviceTypedUMalloc(occaDevice device,
                          dtype_,
                          src,
                          occa::c::properties(props));
+}
+
+occaMemory occaDeviceWrapMemory(occaDevice device,
+                                const void *ptr,
+                                const occaUDim_t bytes,
+                                occaProperties props) {
+  return occaDeviceTypedWrapMemory(device,
+                                   ptr,
+                                   bytes,
+                                   occaDtypeByte,
+                                   props);
+}
+
+occaMemory occaDeviceTypedWrapMemory(occaDevice device,
+                                     const void *ptr,
+                                     const occaUDim_t entries,
+                                     const occaDtype dtype,
+                                     occaProperties props) {
+  occa::device device_ = occa::c::device(device);
+  const occa::dtype_t &dtype_ = occa::c::dtype(dtype);
+
+  occa::memory memory;
+  if (occa::c::isDefault(props)) {
+    memory = device_.wrapMemory(ptr, entries, dtype_);
+  } else {
+    memory = device_.wrapMemory(ptr, entries, dtype_, occa::c::properties(props));
+  }
+  memory.dontUseRefs();
+
+  return occa::c::newOccaType(memory);
 }
 //======================================
 

--- a/src/c/memory.cpp
+++ b/src/c/memory.cpp
@@ -157,30 +157,4 @@ void occaMemoryDetach(occaMemory memory) {
   occa::c::memory(memory).detach();
 }
 
-occaMemory occaWrapCpuMemory(occaDevice device,
-                             void *ptr,
-                             occaUDim_t bytes,
-                             occaProperties props) {
-  occa::device device_ = (
-    occa::c::isDefault(device)
-    ? occa::getDevice()
-    : occa::c::device(device)
-  );
-
-  occa::memory mem;
-  if (occa::c::isDefault(props)) {
-    mem = occa::cpu::wrapMemory(device_,
-                                ptr,
-                                bytes);
-  } else {
-    mem = occa::cpu::wrapMemory(device_,
-                                ptr,
-                                bytes,
-                                occa::c::properties(props));
-  }
-  mem.dontUseRefs();
-
-  return occa::c::newOccaType(mem);
-}
-
 OCCA_END_EXTERN_C

--- a/src/core/base.cpp
+++ b/src/core/base.cpp
@@ -126,6 +126,20 @@ namespace occa {
     return getDevice().umalloc(entries, dtype::byte, src, props);
   }
 
+  occa::memory wrapMemory(const void *ptr,
+                          const dim_t entries,
+                          const dtype_t &dtype,
+                          const occa::properties &props) {
+    return getDevice().wrapMemory(ptr, entries, dtype, props);
+  }
+
+  template <>
+  occa::memory wrapMemory<void>(const void *ptr,
+                                const dim_t entries,
+                                const occa::properties &props) {
+    return getDevice().wrapMemory(ptr, entries, dtype::byte, props);
+  }
+
   void memcpy(void *dest, const void *src,
               const dim_t bytes,
               const occa::properties &props) {
@@ -217,14 +231,6 @@ namespace occa {
   void memcpy(memory dest, memory src,
               const occa::properties &props) {
     memcpy(dest, src, -1, 0, 0, props);
-  }
-
-  namespace cpu {
-    occa::memory wrapMemory(void *ptr,
-                            const udim_t bytes,
-                            const occa::properties &props) {
-      return occa::cpu::wrapMemory(getDevice(), ptr, bytes, props);
-    }
   }
   //====================================
 

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -442,8 +442,7 @@ namespace occa {
     }
 
     const dim_t bytes = entries * dtype.bytes();
-    OCCA_ERROR("Trying to allocate "
-               << "negative bytes (" << bytes << ")",
+    OCCA_ERROR("Trying to allocate negative bytes (" << bytes << ")",
                bytes >= 0);
 
     occa::properties memProps = memoryProperties(props);
@@ -538,6 +537,33 @@ namespace occa {
                         const dtype_t &dtype,
                         const occa::properties &props) {
     return umalloc(entries, dtype, NULL, props);
+  }
+
+  template <>
+  occa::memory device::wrapMemory<void>(const void *ptr,
+                                        const dim_t entries,
+                                        const occa::properties &props) {
+    return wrapMemory(ptr, entries, dtype::byte, props);
+  }
+
+  occa::memory device::wrapMemory(const void *ptr,
+                                  const dim_t entries,
+                                  const dtype_t &dtype,
+                                  const occa::properties &props) {
+    assertInitialized();
+
+    const dim_t bytes = entries * dtype.bytes();
+    OCCA_ERROR("Trying to wrap a pointer with negative bytes (" << bytes << ")",
+               bytes >= 0);
+
+    occa::properties memProps = memoryProperties(props);
+
+    memory mem(modeDevice->wrapMemory(ptr, bytes, memProps));
+
+    mem.setDtype(dtype);
+    mem.dontUseRefs();
+
+    return mem;
   }
   //  |=================================
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -536,18 +536,4 @@ namespace occa {
     out << memory.properties();
     return out;
   }
-
-  namespace cpu {
-    occa::memory wrapMemory(occa::device device,
-                            void *ptr,
-                            const udim_t bytes,
-                            const occa::properties &props) {
-      static occa::properties defaultProps(
-        "use_host_pointer: true,"
-        "own_host_pointer: false"
-      );
-
-      return device.malloc(bytes, ptr, defaultProps + props);
-    }
-  }
 }

--- a/src/occa/internal/core/device.hpp
+++ b/src/occa/internal/core/device.hpp
@@ -115,6 +115,10 @@ namespace occa {
                                  const void* src,
                                  const occa::properties &props) = 0;
 
+    virtual modeMemory_t* wrapMemory(const void *ptr,
+                                     const udim_t bytes,
+                                     const occa::properties &props) = 0;
+
     virtual udim_t memorySize() const = 0;
     //  |===============================
     //==================================

--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -509,6 +509,20 @@ namespace occa {
       return &mem;
     }
 
+    modeMemory_t* device::wrapMemory(const void *ptr,
+                                     const udim_t bytes,
+                                     const occa::properties &props) {
+      memory *mem = new memory(this,
+                               bytes,
+                               props);
+
+      mem->ptr = (char*) ptr;
+      mem->mappedPtr = NULL;
+      mem->isUnified = props.get("unified", false);
+
+      return mem;
+    }
+
     udim_t device::memorySize() const {
       return cuda::getDeviceMemorySize(cuDevice);
     }

--- a/src/occa/internal/modes/cuda/device.hpp
+++ b/src/occa/internal/modes/cuda/device.hpp
@@ -101,6 +101,10 @@ namespace occa {
                                  const void *src,
                                  const occa::properties &props);
 
+      modeMemory_t* wrapMemory(const void *ptr,
+                               const udim_t bytes,
+                               const occa::properties &props);
+
       virtual udim_t memorySize() const;
       //================================
     };

--- a/src/occa/internal/modes/cuda/utils.cpp
+++ b/src/occa/internal/modes/cuda/utils.cpp
@@ -222,23 +222,6 @@ namespace occa {
       return occa::device(&dev);
     }
 
-    occa::memory wrapMemory(occa::device device,
-                            void *ptr,
-                            const udim_t bytes,
-                            const occa::properties &props) {
-
-      cuda::memory &mem = *(new cuda::memory(device.getModeDevice(),
-                                             bytes,
-                                             props));
-      mem.dontUseRefs();
-
-      mem.ptr = (char*) ptr;
-      mem.mappedPtr = NULL;
-      mem.isUnified = props.get("unified", false);
-
-      return occa::memory(&mem);
-    }
-
     void warn(CUresult errorCode,
               const std::string &filename,
               const std::string &function,

--- a/src/occa/internal/modes/cuda/utils.hpp
+++ b/src/occa/internal/modes/cuda/utils.hpp
@@ -78,11 +78,6 @@ namespace occa {
                             CUcontext context,
                             const occa::properties &props = occa::properties());
 
-    occa::memory wrapMemory(occa::device device,
-                            void *ptr,
-                            const udim_t bytes,
-                            const occa::properties &props = occa::properties());
-
     void warn(CUresult errorCode,
               const std::string &filename,
               const std::string &function,

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -442,6 +442,19 @@ namespace occa {
       return &mem;
     }
 
+    modeMemory_t* device::wrapMemory(const void *ptr,
+                                     const udim_t bytes,
+                                     const occa::properties &props) {
+      memory *mem = new memory(this,
+                               bytes,
+                               props);
+
+      mem->ptr = (char*) ptr;
+      mem->mappedPtr = NULL;
+
+      return mem;
+    }
+
     udim_t device::memorySize() const {
       return hip::getDeviceMemorySize(hipDevice);
     }

--- a/src/occa/internal/modes/hip/device.hpp
+++ b/src/occa/internal/modes/hip/device.hpp
@@ -87,6 +87,10 @@ namespace occa {
                                         const void *src,
                                         const occa::properties &props);
 
+      modeMemory_t* wrapMemory(const void *ptr,
+                               const udim_t bytes,
+                               const occa::properties &props);
+
       virtual udim_t memorySize() const;
       //================================
     };

--- a/src/occa/internal/modes/hip/utils.cpp
+++ b/src/occa/internal/modes/hip/utils.cpp
@@ -191,22 +191,6 @@ namespace occa {
       return occa::device(&dev);
     }
 
-    occa::memory wrapMemory(occa::device device,
-                            void *ptr,
-                            const udim_t bytes,
-                            const occa::properties &props) {
-
-      hip::memory &mem = *(new hip::memory(device.getModeDevice(),
-                                           bytes,
-                                           props));
-      mem.dontUseRefs();
-
-      mem.ptr = (char*) ptr;
-      mem.mappedPtr = NULL;
-
-      return occa::memory(&mem);
-    }
-
     void warn(hipError_t errorCode,
               const std::string &filename,
               const std::string &function,

--- a/src/occa/internal/modes/hip/utils.hpp
+++ b/src/occa/internal/modes/hip/utils.hpp
@@ -77,11 +77,6 @@ namespace occa {
     occa::device wrapDevice(hipDevice_t device,
                             const occa::properties &props = occa::properties());
 
-    occa::memory wrapMemory(occa::device device,
-                            void *ptr,
-                            const udim_t bytes,
-                            const occa::properties &props = occa::properties());
-
     void warn(hipError_t errorCode,
               const std::string &filename,
               const std::string &function,

--- a/src/occa/internal/modes/metal/device.cpp
+++ b/src/occa/internal/modes/metal/device.cpp
@@ -262,6 +262,18 @@ namespace occa {
       return mem;
     }
 
+    modeMemory_t* device::wrapMemory(const void *ptr,
+                                     const udim_t bytes,
+                                     const occa::properties &props) {
+      memory *mem = new memory(this,
+                               bytes,
+                               props);
+
+      mem->metalBuffer = api::metal::buffer_t(const_cast<void*>(ptr));
+
+      return mem;
+    }
+
     udim_t device::memorySize() const {
       return metalDevice.getMemorySize();
     }

--- a/src/occa/internal/modes/metal/device.hpp
+++ b/src/occa/internal/modes/metal/device.hpp
@@ -76,6 +76,10 @@ namespace occa {
                                    const void *src,
                                    const occa::properties &props);
 
+      modeMemory_t* wrapMemory(const void *ptr,
+                               const udim_t bytes,
+                               const occa::properties &props);
+
       virtual udim_t memorySize() const;
       //================================
     };

--- a/src/occa/internal/modes/opencl/device.cpp
+++ b/src/occa/internal/modes/opencl/device.cpp
@@ -382,6 +382,18 @@ namespace occa {
       return mem;
     }
 
+    modeMemory_t* device::wrapMemory(const void *ptr,
+                                     const udim_t bytes,
+                                     const occa::properties &props) {
+      memory *mem = new memory(this,
+                               bytes,
+                               props);
+
+      mem->clMem = (cl_mem) ptr;
+
+      return mem;
+    }
+
     udim_t device::memorySize() const {
       return opencl::getDeviceMemorySize(clDevice);
     }

--- a/src/occa/internal/modes/opencl/device.hpp
+++ b/src/occa/internal/modes/opencl/device.hpp
@@ -88,6 +88,10 @@ namespace occa {
                                         const void *src,
                                         const occa::properties &props);
 
+      modeMemory_t* wrapMemory(const void *ptr,
+                               const udim_t bytes,
+                               const occa::properties &props);
+
       virtual udim_t memorySize() const;
       //================================
     };

--- a/src/occa/internal/modes/opencl/utils.cpp
+++ b/src/occa/internal/modes/opencl/utils.cpp
@@ -478,21 +478,6 @@ namespace occa {
       return occa::device(&dev);
     }
 
-    occa::memory wrapMemory(occa::device device,
-                            cl_mem clMem,
-                            const udim_t bytes,
-                            const occa::properties &props) {
-
-      opencl::memory &mem = *(new opencl::memory(device.getModeDevice(),
-                                                 bytes,
-                                                 props));
-      mem.dontUseRefs();
-
-      mem.clMem = clMem;
-
-      return occa::memory(&mem);
-    }
-
     void warn(cl_int errorCode,
               const std::string &filename,
               const std::string &function,

--- a/src/occa/internal/modes/serial/device.cpp
+++ b/src/occa/internal/modes/serial/device.cpp
@@ -434,6 +434,19 @@ namespace occa {
       return mem;
     }
 
+    modeMemory_t* device::wrapMemory(const void *ptr,
+                                     const udim_t bytes,
+                                     const occa::properties &props) {
+      memory *mem = new memory(this,
+                               bytes,
+                               props);
+
+      mem->ptr = (char*) const_cast<void*>(ptr);
+      mem->isOrigin = props.get("own_host_pointer", false);
+
+      return mem;
+    }
+
     udim_t device::memorySize() const {
       return sys::SystemInfo::load().memory.total;
     }

--- a/src/occa/internal/modes/serial/device.hpp
+++ b/src/occa/internal/modes/serial/device.hpp
@@ -66,6 +66,10 @@ namespace occa {
                                    const void *src,
                                    const occa::properties &props);
 
+      modeMemory_t* wrapMemory(const void *ptr,
+                               const udim_t bytes,
+                               const occa::properties &props);
+
       virtual udim_t memorySize() const;
       //================================
     };

--- a/tests/src/c/memory.cpp
+++ b/tests/src/c/memory.cpp
@@ -8,13 +8,11 @@
 void testInit();
 void testUvaMethods();
 void testCopyMethods();
-void testInteropMethods();
 
 int main(const int argc, const char **argv) {
   testInit();
   testUvaMethods();
   testCopyMethods();
-  testInteropMethods();
 
   return 0;
 }
@@ -228,54 +226,5 @@ void testCopyMethods() {
   delete [] data4;
   occaFreeUvaPtr(o_data2);
   occaFreeUvaPtr(o_data4);
-  occaFree(&props);
-}
-
-void testInteropMethods() {
-  const int entries = 10;
-  const size_t bytes = entries * sizeof(int);
-
-  occaMemory mem1 = occaMalloc(bytes, NULL, occaDefault);
-  occaMemory mem2 = occaMemoryClone(mem1);
-
-  ASSERT_EQ(occaMemorySize(mem1),
-            occaMemorySize(mem2));
-
-  ASSERT_NEQ(occa::c::memory(mem1),
-             occa::c::memory(mem2));
-
-  int *ptr = (int*) occaMemoryPtr(mem2, occaDefault);
-  occaMemoryDetach(mem2);
-
-  for (int i = 0; i < entries; ++i) {
-    ptr[i] = i;
-  }
-
-  mem2 = occaWrapCpuMemory(occaHost(),
-                           ptr,
-                           bytes,
-                           occaDefault);
-
-  mem2 = occaWrapCpuMemory(occaDefault,
-                           ptr,
-                           bytes,
-                           occaDefault);
-
-  occaProperties props = (
-    occaCreatePropertiesFromString("foo: 'bar'")
-  );
-
-  mem2 = occaWrapCpuMemory(occaHost(),
-                           ptr,
-                           bytes,
-                           props);
-
-  mem2 = occaWrapCpuMemory(occaDefault,
-                           ptr,
-                           bytes,
-                           props);
-
-  occaFree(&mem1);
-  occaFree(&mem2);
   occaFree(&props);
 }

--- a/tests/src/core/device.cpp
+++ b/tests/src/core/device.cpp
@@ -2,9 +2,11 @@
 #include <occa/internal/utils/testing.hpp>
 
 void testProperties();
+void testWrapMemory();
 
 int main(const int argc, const char **argv) {
   testProperties();
+  testWrapMemory();
 
   return 0;
 }
@@ -96,4 +98,27 @@ void testProperties() {
     1,
     (int) device.kernelProperties()["one"]
   );
+}
+
+void testWrapMemory() {
+  occa::device device("mode: 'Serial'");
+
+  const occa::udim_t bytes = 1 * sizeof(int);
+  int value = 4660;
+  int *hostPtr = &value;
+
+  occa::memory mem = device.wrapMemory((void*) hostPtr, bytes);
+  ASSERT_EQ(mem.ptr<int>()[0], value);
+  ASSERT_EQ(mem.ptr<int>(), hostPtr);
+  ASSERT_EQ((int) mem.length<int>(), 1);
+
+  mem = device.wrapMemory(hostPtr, 1);
+  ASSERT_EQ(mem.ptr<int>()[0], value);
+  ASSERT_EQ(mem.ptr<int>(), hostPtr);
+  ASSERT_EQ((int) mem.length<int>(), 1);
+
+  mem = device.wrapMemory(hostPtr, 1, "use_host_pointer: false");
+  ASSERT_EQ(mem.ptr<int>()[0], value);
+  ASSERT_EQ(mem.ptr<int>(), hostPtr);
+  ASSERT_EQ((int) mem.length<int>(), 1);
 }

--- a/tests/src/core/memory.cpp
+++ b/tests/src/core/memory.cpp
@@ -2,12 +2,10 @@
 #include <occa/internal/utils/testing.hpp>
 
 void testMalloc();
-void testCpuWrapMemory();
 void testSlice();
 
 int main(const int argc, const char **argv) {
   testMalloc();
-  testCpuWrapMemory();
   testSlice();
 
   return 0;
@@ -41,20 +39,6 @@ void testMalloc() {
   ASSERT_EQ(mem.ptr<int>(), hostPtr);
 
   mem = occa::malloc(bytes, hostPtr, "use_host_pointer: false");
-  ASSERT_EQ(mem.ptr<int>()[0], value);
-  ASSERT_NEQ(mem.ptr<int>(), hostPtr);
-}
-
-void testCpuWrapMemory() {
-  const occa::udim_t bytes = 1 * sizeof(int);
-  int value = 4660;
-  int *hostPtr = &value;
-
-  occa::memory mem = occa::cpu::wrapMemory(hostPtr, bytes);
-  ASSERT_EQ(mem.ptr<int>()[0], value);
-  ASSERT_EQ(mem.ptr<int>(), hostPtr);
-
-  mem = occa::cpu::wrapMemory(hostPtr, bytes, "use_host_pointer: false");
   ASSERT_EQ(mem.ptr<int>()[0], value);
   ASSERT_NEQ(mem.ptr<int>(), hostPtr);
 }


### PR DESCRIPTION
## Description

Adds a `device.wrapMemory()` method for better interoperability with backends. Should fix https://github.com/CEED/libCEED/issues/678

Note: This consolidates some utility methods that were moved to the internal API
- `occa::cpu::wrapMemory`
- `occa::opencl::wrapMemory`
- `occa::cuda::wrapMemory`