### PR TITLE
[Refactor] Move modeIsEnabled back to public API

### DIFF
--- a/include/occa/core/base.hpp
+++ b/include/occa/core/base.hpp
@@ -146,6 +146,8 @@ namespace occa {
   //====================================
 
   //---[ Helper Methods ]---------------
+  bool modeIsEnabled(const std::string &mode);
+
   int getDeviceCount(const occa::properties &props);
 
   void printModeInfo();

--- a/src/core/base.cpp
+++ b/src/core/base.cpp
@@ -253,6 +253,10 @@ namespace occa {
   //====================================
 
   //---[ Helper Methods ]---------------
+  bool modeIsEnabled(const std::string &mode) {
+    return getMode(mode);
+  }
+
   int getDeviceCount(const occa::properties &props) {
     std::string modeName = props["mode"];
     mode_t *mode = getMode(modeName);

--- a/src/occa/internal/modes.cpp
+++ b/src/occa/internal/modes.cpp
@@ -66,10 +66,6 @@ namespace occa {
     isInitialized = true;
   }
 
-  bool modeIsEnabled(const std::string &mode) {
-    return getMode(mode);
-  }
-
   mode_t* getMode(const std::string &mode) {
     const std::string caseInsensitiveMode = lowercase(mode);
     strToModeMap &modeMap = getModeMap();

--- a/src/occa/internal/modes.hpp
+++ b/src/occa/internal/modes.hpp
@@ -43,8 +43,6 @@ namespace occa {
 
   void initializeModes();
 
-  bool modeIsEnabled(const std::string &mode);
-
   mode_t* getMode(const std::string &mode);
 
   mode_t* getModeFromProps(const occa::properties &props);


### PR DESCRIPTION
## Description

Accidentally moved the `modeIsEnabled` method into `internals`. Moving it back to making it publicly available

<!-- Thank you for contributing! -->
