### PR TITLE
[HIP] Update ptr ref hackery

### DIFF
--- a/src/occa/internal/modes/hip/memory.cpp
+++ b/src/occa/internal/modes/hip/memory.cpp
@@ -12,11 +12,7 @@ namespace occa {
                    udim_t size_,
                    const occa::properties &properties_) :
       occa::modeMemory_t(modeDevice_, size_, properties_),
-#ifdef __HIP_PLATFORM_HCC__
-      hipPtr(ptr),
-#else
-      hipPtr((hipDeviceptr_t&) ptr),
-#endif
+      hipPtr(reinterpret_cast<hipDeviceptr_t&>(ptr)),
       mappedPtr(NULL) {}
 
     memory::~memory() {

--- a/src/occa/internal/modes/hip/memory.hpp
+++ b/src/occa/internal/modes/hip/memory.hpp
@@ -19,7 +19,7 @@ namespace occa {
       friend void* getMappedPtr(occa::memory mem);
 
     public:
-      hipDeviceptr_t hipPtr;
+      hipDeviceptr_t &hipPtr;
       char *mappedPtr;
 
       memory(modeDevice_t *modeDevice_,


### PR DESCRIPTION
## Description

`modeMemory_t` has a `ptr` field so backends don't have to implement the `ptr()` method. This has led to some pointer reference hackery we should probably remove in the future :sweat_smile: 


<!-- Thank you for contributing! -->
