### PR TITLE
[Fix] Add exception for one Fortran test that doesn't fit the standard CMake functions

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,10 @@ function(add_occa_test test_source)
   target_include_directories(${cmake_test_target} PRIVATE
     $<BUILD_INTERFACE:${OCCA_SOURCE_DIR}/src>)
 
+  if (${test_source} MATCHES "typedefs.f90")
+    target_link_libraries(${cmake_test_target} libtypedefs_helper libocca ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+  endif()
+
   add_test(
     NAME ${cmake_test_target}
     COMMAND ${test_binary})
@@ -41,6 +45,12 @@ if (ENABLE_FORTRAN)
     RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "src/*.f90")
 
   list(APPEND occa_tests ${occa_fortran_tests})
+
+  list(FILTER occa_tests
+    EXCLUDE REGEX "src/fortran/typedefs_helper.cpp")
+
+  add_library(libtypedefs_helper SHARED "src/fortran/typedefs_helper.cpp")
+  target_link_libraries(libtypedefs_helper libocca)
 else()
   list(FILTER occa_tests
     EXCLUDE REGEX "src/fortran")


### PR DESCRIPTION
## Description

One of the Fortran tests is weird in that it uses a cpp file as a library.
This file should *not* be used to build a standalone executable, but built as a library and then linked to the one test that uses it.

Perhaps there is a nicer way to fix this (the current commit is a bit ad-hoc), but as it stands it spits out linker errors if I build with `ENABLE_FORTRAN = ON` so it does need some attention.
