### PR TITLE
[HIP] Fix the way hip sets arguments, I broke it on #438

### DIFF
--- a/src/occa/internal/modes/hip/kernel.cpp
+++ b/src/occa/internal/modes/hip/kernel.cpp
@@ -85,7 +85,7 @@ namespace occa {
           padding = 0;
         }
 
-        ::memcpy(dataPtr, arg.ptr(), bytes);
+        ::memcpy(dataPtr, &arg.value.value.int64_, bytes);
         dataPtr += bytes;
       }
 


### PR DESCRIPTION
## Description

I didn't realize HIP was copying the raw pointer and not the pointer value


<!-- Thank you for contributing! -->
