### PR TITLE
[Core] Make getDeviceCount syntax match new device::setup syntax

### DIFF
--- a/include/occa/core/base.hpp
+++ b/include/occa/core/base.hpp
@@ -148,6 +148,7 @@ namespace occa {
   //---[ Helper Methods ]---------------
   bool modeIsEnabled(const std::string &mode);
 
+  int getDeviceCount(const std::string &props);
   int getDeviceCount(const occa::json &props);
 
   void printModeInfo();

--- a/src/core/base.cpp
+++ b/src/core/base.cpp
@@ -263,6 +263,10 @@ namespace occa {
     return getMode(mode);
   }
 
+  int getDeviceCount(const std::string &props) {
+    return getDeviceCount(json::parse(props));
+  }
+
   int getDeviceCount(const occa::json &props) {
     std::string modeName = props["mode"];
     mode_t *mode = getMode(modeName);


### PR DESCRIPTION
## Description

I noticed the device::setup syntax when passing a string has subtly changed from `device.setup("mode: 'Serial'")` to `device.setup("{mode: 'Serial'}")`. Forwarding that syntax change to the getDeviceCount API. 


<!-- Thank you for contributing! -->
