### PR TITLE
[#450][IO] Don't cache the cache path

### DIFF
--- a/src/occa/internal/io/utils.cpp
+++ b/src/occa/internal/io/utils.cpp
@@ -51,20 +51,12 @@ namespace occa {
     static const unsigned char DT_DIR = 'd';
 #endif
 
-    const std::string& cachePath() {
-      static std::string path;
-      if (path.size() == 0) {
-        path = env::OCCA_CACHE_DIR + "cache/";
-      }
-      return path;
+    std::string cachePath() {
+      return env::OCCA_CACHE_DIR + "cache/";
     }
 
-    const std::string& libraryPath() {
-      static std::string path;
-      if (path.size() == 0) {
-        path = env::OCCA_CACHE_DIR + "libraries/";
-      }
-      return path;
+    std::string libraryPath() {
+      return env::OCCA_CACHE_DIR + "libraries/";
     }
 
     std::string currentWorkingDirectory() {

--- a/src/occa/internal/io/utils.hpp
+++ b/src/occa/internal/io/utils.hpp
@@ -20,8 +20,8 @@ namespace occa {
   }
 
   namespace io {
-    const std::string& cachePath();
-    const std::string& libraryPath();
+    std::string cachePath();
+    std::string libraryPath();
 
     std::string currentWorkingDirectory();
 


### PR DESCRIPTION
## Description

The cached `cachePath()` was making any updates to `OCCA_CACHE_PATH` noop
Fixes #450 