### PR TITLE
[CUDA] Always use the primary context

### DIFF
--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -30,7 +30,7 @@ namespace occa {
                         cuDeviceGet(&cuDevice, deviceID));
 
         OCCA_CUDA_ERROR("Device: Creating Context",
-                        cuCtxCreate(&cuContext, CU_CTX_SCHED_AUTO, cuDevice));
+                        cuDevicePrimaryCtxRetain(&cuContext, cuDevice));
       }
 
       p2pEnabled = false;
@@ -81,7 +81,7 @@ namespace occa {
       if (cuContext) {
         OCCA_CUDA_DESTRUCTOR_ERROR(
           "Device: Freeing Context",
-          cuCtxDestroy(cuContext)
+          cuDevicePrimaryCtxRelease(cuDevice)
         );
         cuContext = NULL;
       }

--- a/src/occa/internal/modes/cuda/polyfill.hpp
+++ b/src/occa/internal/modes/cuda/polyfill.hpp
@@ -26,7 +26,6 @@ namespace occa {
   typedef struct _CUstream*             CUstream;
 
   //---[ Enums ]------------------------
-  static const int CU_CTX_SCHED_AUTO = 0;
   static const int CU_DEVICE_CPU = 0;
   static const int CU_EVENT_DEFAULT = 0;
   static const int CU_MEM_ATTACH_GLOBAL = 0;
@@ -118,11 +117,11 @@ namespace occa {
   }
 
   //   ---[ Context ]-------------------
-  inline CUresult cuCtxCreate(CUcontext *pctx, unsigned int flags, CUdevice dev) {
+  inline CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
     return OCCA_CUDA_IS_NOT_ENABLED;
   }
 
-  inline CUresult cuCtxDestroy(CUcontext ctx) {
+  inline CUresult cuDevicePrimaryCtxRelease(CUdevice dev) {
     return OCCA_CUDA_IS_NOT_ENABLED;
   }
 


### PR DESCRIPTION
## Description

We haven't seen any benefit from creating our own context. If anything, it makes interoperability with OCCA a lot harder.

Fixes #224 

<!-- Thank you for contributing! -->
