### PR TITLE
[OpenCL] Avoid checking the error code in getDeviceCountInPlatform

### DIFF
--- a/src/occa/internal/modes/opencl/utils.cpp
+++ b/src/occa/internal/modes/opencl/utils.cpp
@@ -95,13 +95,13 @@ namespace occa {
     }
 
     int getDeviceCountInPlatform(int pID, int type) {
-      cl_uint dCount=0;
-
       cl_platform_id clPID = platformID(pID);
+      cl_uint deviceCount = 0;
+      
       clGetDeviceIDs(clPID, deviceType(type),
-                     0, NULL, &dCount);
+                     0, NULL, &deviceCount);
 
-      return dCount;
+      return deviceCount;
     }
 
     cl_device_id deviceID(int pID, int dID, int type) {

--- a/src/occa/internal/modes/opencl/utils.cpp
+++ b/src/occa/internal/modes/opencl/utils.cpp
@@ -95,7 +95,7 @@ namespace occa {
     }
 
     int getDeviceCountInPlatform(int pID, int type) {
-      cl_uint dCount;
+      cl_uint dCount=0;
 
       cl_platform_id clPID = platformID(pID);
       clGetDeviceIDs(clPID, deviceType(type),

--- a/src/occa/internal/modes/opencl/utils.cpp
+++ b/src/occa/internal/modes/opencl/utils.cpp
@@ -98,11 +98,8 @@ namespace occa {
       cl_uint dCount;
 
       cl_platform_id clPID = platformID(pID);
-
-      OCCA_OPENCL_ERROR("OpenCL: Get Device ID Count",
-                        clGetDeviceIDs(clPID,
-                                       deviceType(type),
-                                       0, NULL, &dCount));
+      clGetDeviceIDs(clPID, deviceType(type),
+                     0, NULL, &dCount);
 
       return dCount;
     }


### PR DESCRIPTION
## Description
Similar to #426, AMD's OpenCL will throw a `CL_DEVICE_NOT_FOUND` on checking the deviceIDs on GPU-less head nodes. This PR avoids checking the error code returned when getting device counts, which avoids `occa info` failing on head nodes. 



<!-- Thank you for contributing! -->
