### PR TITLE
[Fix] kernel header defines can be numbers

### DIFF
--- a/src/core/kernel.cpp
+++ b/src/core/kernel.cpp
@@ -222,7 +222,8 @@ namespace occa {
 
     // Add defines
     for (const auto &entry : props["defines"].object()) {
-      if (entry.second.isString()) {
+      if (entry.second.isString() || entry.second.isNumber() ||
+        entry.second.isBool() || entry.second.isNull()) {
         kernelHeader += "#define ";
         kernelHeader += ' ';
         kernelHeader += entry.first;


### PR DESCRIPTION
## Description

Since #442 the kernels in our calling code refused to compile, because we set numerical defines.
It seems safe do allow this? It fixes our things at least.