### PR TITLE
[Examples] Fix out-of-bounds access

### DIFF
--- a/examples/cpp/05_arrays/main.cpp
+++ b/examples/cpp/05_arrays/main.cpp
@@ -30,8 +30,8 @@ int main(int argc, const char **argv) {
   }
 
   // Uses the background device
-  occa::array<float> array_a(10);
-  occa::array<float> array_b(10);
+  occa::array<float> array_a(entries);
+  occa::array<float> array_b(entries);
 
   // Copy over host data
   array_a.copyFrom(a);


### PR DESCRIPTION
## Description

I hard-coded array lengths to `10` when the host arrays had a size of `5`, causing out-of-bounds errors

Fixes #467

<!-- Thank you for contributing! -->
