### PR TITLE
[Tests] Update GitHub build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,17 +30,17 @@ jobs:
             OCCA_COVERAGE: 1
             useCMake: true
 
+          - name: "[Ubuntu] clang-11"
+            os: ubuntu-latest
+            CC: clang-11
+            CXX: clang++-11
+            CXXFLAGS: -Wno-uninitialized
+            OCCA_COVERAGE: 0
+
           - name: "[Ubuntu] clang-10"
             os: ubuntu-latest
             CC: clang-10
             CXX: clang++-10
-            CXXFLAGS: -Wno-uninitialized
-            OCCA_COVERAGE: 0
-
-          - name: "[Ubuntu] clang-9"
-            os: ubuntu-latest
-            CC: clang-9
-            CXX: clang++-9
             CXXFLAGS: -Wno-uninitialized
             OCCA_COVERAGE: 0
 


### PR DESCRIPTION
## Description

ubuntu-latest has moved beyond 20210517.1, from which point clang-9 is no longer included - 10/11/12 are available.

Drop clang 9, use clang 11 instead.