### PR TITLE
[Tests] Fix CMake build of Fortran tests

### DIFF
--- a/examples/fortran/CMakeLists.txt
+++ b/examples/fortran/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_subdirectory(01_add_vectors)
-add_subdirectory(02_background_device)
 add_subdirectory(03_static_compilation)
 add_subdirectory(04_reduction)
 add_subdirectory(09_streams)
 add_subdirectory(10_mpi)
-add_subdirectory(11_mpi_unified_memory)


### PR DESCRIPTION
## Description

These tests have been removed, and CMake mustn't try to build them.