### PR TITLE
[OpenMP] Fix conflict with re-used stringstream in closure

### DIFF
--- a/src/occa/internal/modes/openmp/utils.cpp
+++ b/src/occa/internal/modes/openmp/utils.cpp
@@ -54,17 +54,18 @@ namespace occa {
         [&](const strVector &tempFilenames) -> bool {
           const std::string &tempBinaryFilename = tempFilenames[0];
           const std::string &tempOutFilename = tempFilenames[1];
+          std::stringstream ss_;
 
           // Try to compile a minimal OpenMP file to see whether
           // the compiler supports OpenMP or not
           std::string flag = baseCompilerFlag(vendor_);
-          ss << compiler
+          ss_ << compiler
              << ' '    << flag
              << ' '    << srcFilename
              << " -o " << tempBinaryFilename
              << " > /dev/null 2>&1";
 
-          const std::string compileLine = ss.str();
+          const std::string compileLine = ss_.str();
           const int compileError = system(compileLine.c_str());
 
           if (compileError) {


### PR DESCRIPTION
## Description

Previously this used the 'ss' stringstream both inside the closure and outside,
resulting in the first element of the compiler invocation (i.e. the compiler executable)
sometimes ending up in flag, instead of the actual OpenMP flag.