### PR TITLE
[Internal] Fix another conflict with re-used stringstream in closure

### DIFF
--- a/src/occa/internal/utils/sys.cpp
+++ b/src/occa/internal/utils/sys.cpp
@@ -742,13 +742,14 @@ namespace occa {
           [&](const strVector &tempFilenames) -> bool {
             const std::string &tempBinaryFilename = tempFilenames[0];
             const std::string &tempBuildLogFilename = tempFilenames[1];
+            std::stringstream ss_;
 
-            ss << compiler
+            ss_ << compiler
                << ' '    << srcFilename
                << " -o " << tempBinaryFilename
                << " > " << tempBuildLogFilename << " 2>&1";
 
-            const std::string compileLine = ss.str();
+            const std::string compileLine = ss_.str();
             ignoreResult( system(compileLine.c_str()) );
 
             OCCA_ERROR(


### PR DESCRIPTION
## Description

Thanks for the quick responses! I didn't hit this one personally, but I think it theoretically has the same issue as #510, so best to fix that pre-emptively.

In general, can the compiler check for this? Would it be better to not use the `[&]` defaults but use explicit capture lists? Then `-Wshadow` would work, right?