### PR TITLE
[Bugfix][OpenCL] Update opencl timing to give meaningful results.

### DIFF
--- a/src/occa/internal/modes/opencl/device.cpp
+++ b/src/occa/internal/modes/opencl/device.cpp
@@ -112,11 +112,11 @@ namespace occa {
 
 #ifdef CL_VERSION_1_2
       OCCA_OPENCL_ERROR("Device: Tagging Stream",
-                        clEnqueueMarkerWithWaitList(getCommandQueue(),
+                        clEnqueueBarrierWithWaitList(getCommandQueue(),
                                                     0, NULL, &clEvent));
 #else
       OCCA_OPENCL_ERROR("Device: Tagging Stream",
-                        clEnqueueMarker(getCommandQueue(),
+                        clEnqueueBarrier(getCommandQueue(),
                                         &clEvent));
 #endif
 
@@ -140,9 +140,9 @@ namespace occa {
         dynamic_cast<occa::opencl::streamTag*>(endTag.getModeStreamTag())
       );
 
-      finish();
+      waitFor(endTag);
 
-      return (clEndTag->getTime() - clStartTag->getTime());
+      return (clEndTag->endTime() - clStartTag->startTime());
     }
 
     cl_command_queue& device::getCommandQueue() const {

--- a/src/occa/internal/modes/opencl/polyfill.hpp
+++ b/src/occa/internal/modes/opencl/polyfill.hpp
@@ -91,6 +91,7 @@ namespace occa {
   static cl_mem_flags CL_MEM_ALLOC_HOST_PTR = 2;
 
   static cl_profiling_info CL_PROFILING_COMMAND_END = 0;
+  static cl_profiling_info CL_PROFILING_COMMAND_START = 1;
 
   static cl_program_build_info CL_PROGRAM_BUILD_LOG = 0;
 
@@ -204,6 +205,18 @@ namespace occa {
   }
 
   inline cl_int clEnqueueMarkerWithWaitList(cl_command_queue  command_queue ,
+                                            cl_uint  num_events_in_wait_list ,
+                                            const cl_event  *event_wait_list ,
+                                            cl_event  *event) {
+    return OCCA_OPENCL_IS_NOT_ENABLED;
+  }
+
+  inline cl_int clEnqueueBarrier(cl_command_queue command_queue,
+                                cl_event *event) {
+    return OCCA_OPENCL_IS_NOT_ENABLED;
+  }
+
+  inline cl_int clEnqueueBarrierWithWaitList(cl_command_queue  command_queue ,
                                             cl_uint  num_events_in_wait_list ,
                                             const cl_event  *event_wait_list ,
                                             cl_event  *event) {

--- a/src/occa/internal/modes/opencl/streamTag.cpp
+++ b/src/occa/internal/modes/opencl/streamTag.cpp
@@ -7,24 +7,40 @@ namespace occa {
                          cl_event clEvent_) :
       modeStreamTag_t(modeDevice_),
       clEvent(clEvent_),
-      time(-1) {}
+      start_time(-1),
+      end_time(-1) {}
 
     streamTag::~streamTag() {
       OCCA_OPENCL_ERROR("streamTag: Freeing cl_event",
                         clReleaseEvent(clEvent));
     }
 
-    double streamTag::getTime() {
-      if (time < 0) {
+    double streamTag::startTime() {
+      if (start_time < 0) {
+        cl_ulong clTime;
+        OCCA_OPENCL_ERROR("streamTag: Getting event profiling info",
+                          clGetEventProfilingInfo(clEvent,
+                                                  CL_PROFILING_COMMAND_START,
+                                                  sizeof(cl_ulong),
+                                                  &clTime, NULL));
+        constexpr double nanoseconds{1.0e-9};
+        start_time = nanoseconds * static_cast<double>(clTime);
+      }
+      return start_time;
+    }
+
+    double streamTag::endTime() {
+      if (end_time < 0) {
         cl_ulong clTime;
         OCCA_OPENCL_ERROR("streamTag: Getting event profiling info",
                           clGetEventProfilingInfo(clEvent,
                                                   CL_PROFILING_COMMAND_END,
                                                   sizeof(cl_ulong),
                                                   &clTime, NULL));
-        time = 1.0e-9 * clTime;
+        constexpr double nanoseconds{1.0e-9};
+        end_time = nanoseconds * static_cast<double>(clTime);
       }
-      return time;
+      return end_time;
     }
   }
 }

--- a/src/occa/internal/modes/opencl/streamTag.hpp
+++ b/src/occa/internal/modes/opencl/streamTag.hpp
@@ -9,14 +9,16 @@ namespace occa {
     class streamTag : public occa::modeStreamTag_t {
     public:
       cl_event clEvent;
-      double time;
+      double start_time;
+      double end_time;
 
       streamTag(modeDevice_t *modeDevice_,
                 cl_event clEvent_);
 
       virtual ~streamTag();
 
-      double getTime();
+      double startTime();
+      double endTime();
     };
   }
 }


### PR DESCRIPTION
Currently using `device::tagStream` and `device::timeBetween` to time kernels with the OpenCL backend results in negative values.