### PR TITLE
[Core][Streams] New API to wrap native backend streams

### DIFF
--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -397,7 +397,7 @@ namespace occa {
      *   Wrap a native backend stream object inside a [[stream]] for the device.
      *   The simplest example would be on a `CUDA` device, where a pointer to a cuStream_t, created via cudaStreamCreate, is passed in.
      *
-     *   > Note that automatic garbage collection is not set for wrapped memory objects.
+     *   > Note that automatic garbage collection is not set for wrapped stream objects.
      *
      * Returns:
      *   The wrapped [[stream]]

--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -391,6 +391,22 @@ namespace occa {
     stream createStream(const occa::json &props = occa::json());
 
     /**
+     * @startDoc{wrapStream}
+     *
+     * Description:
+     *   Wrap a native backend stream object inside a [[stream]] for the device.
+     *   The simplest example would be on a `CUDA` device, where a pointer to a cuStream_t, created via cudaStreamCreate, is passed in.
+     *
+     *   > Note that automatic garbage collection is not set for wrapped memory objects.
+     *
+     * Returns:
+     *   The wrapped [[stream]]
+     *
+     * @endDoc
+     */
+    stream wrapStream(void* ptr, const occa::json &props = occa::json());
+
+    /**
      * @startDoc{getStream}
      *
      * Description:

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -256,6 +256,14 @@ namespace occa {
     return modeDevice->createStream(streamProperties(props));
   }
 
+  stream device::wrapStream(void* ptr, const occa::json &props) {
+    assertInitialized();
+
+    occa::json streamProps = streamProperties(props);
+
+    return modeDevice->wrapStream(ptr, streamProps);
+  }
+
   stream device::getStream() {
     assertInitialized();
     return modeDevice->currentStream;

--- a/src/occa/internal/core/device.hpp
+++ b/src/occa/internal/core/device.hpp
@@ -71,6 +71,7 @@ namespace occa {
 
     //  |---[ Stream ]------------------
     virtual modeStream_t* createStream(const occa::json &props) = 0;
+    virtual modeStream_t* wrapStream(void *ptr, const occa::json &props) = 0;
 
     virtual streamTag tagStream() = 0;
     virtual void waitFor(streamTag tag) = 0;

--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -144,6 +144,11 @@ namespace occa {
       return new stream(this, props, cuStream);
     }
 
+    modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
+      CUstream cuStream = *reinterpret_cast<CUstream*>(ptr);
+      return new stream(this, props, cuStream, true);
+    }
+
     occa::streamTag device::tagStream() {
       CUevent cuEvent = NULL;
 

--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -145,7 +145,8 @@ namespace occa {
     }
 
     modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
-      CUstream cuStream = *reinterpret_cast<CUstream*>(ptr);
+      OCCA_ERROR("A nullptr was passed to cuda::device::wrapStream",nullptr != ptr);
+      CUstream cuStream = *static_cast<CUstream*>(ptr);
       return new stream(this, props, cuStream, true);
     }
 

--- a/src/occa/internal/modes/cuda/device.hpp
+++ b/src/occa/internal/modes/cuda/device.hpp
@@ -46,6 +46,7 @@ namespace occa {
 
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::json &props);
+      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props);
 
       virtual streamTag tagStream();
       virtual void waitFor(streamTag tag);

--- a/src/occa/internal/modes/cuda/stream.cpp
+++ b/src/occa/internal/modes/cuda/stream.cpp
@@ -5,15 +5,18 @@ namespace occa {
   namespace cuda {
     stream::stream(modeDevice_t *modeDevice_,
                    const occa::json &properties_,
-                   CUstream cuStream_) :
+                   CUstream cuStream_, bool isWrapped_) :
       modeStream_t(modeDevice_, properties_),
-      cuStream(cuStream_) {}
+      cuStream(cuStream_),
+      isWrapped(isWrapped_) {}
 
     stream::~stream() {
-      OCCA_CUDA_DESTRUCTOR_ERROR(
-        "Device: freeStream",
-        cuStreamDestroy(cuStream)
-      );
+      if (!isWrapped) {
+        OCCA_CUDA_DESTRUCTOR_ERROR(
+          "Device: freeStream",
+          cuStreamDestroy(cuStream)
+        );
+      }
     }
   }
 }

--- a/src/occa/internal/modes/cuda/stream.hpp
+++ b/src/occa/internal/modes/cuda/stream.hpp
@@ -12,9 +12,12 @@ namespace occa {
     public:
       CUstream cuStream;
 
+      bool isWrapped;
+
       stream(modeDevice_t *modeDevice_,
              const occa::json &properties_,
-             CUstream cuStream_);
+             CUstream cuStream_,
+             bool isWrapped_=false);
 
       virtual ~stream();
     };

--- a/src/occa/internal/modes/dpcpp/device.cpp
+++ b/src/occa/internal/modes/dpcpp/device.cpp
@@ -88,6 +88,11 @@ namespace occa
       return new occa::dpcpp::stream(this, props, q);
     }
 
+    modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
+      ::sycl::queue q = *reinterpret_cast<::sycl::queue*>(ptr);
+      return new stream(this, props, q);
+    }
+
     occa::streamTag device::tagStream()
     {
       //@note: This creates a host event which will return immediately.

--- a/src/occa/internal/modes/dpcpp/device.cpp
+++ b/src/occa/internal/modes/dpcpp/device.cpp
@@ -89,7 +89,8 @@ namespace occa
     }
 
     modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
-      ::sycl::queue q = *reinterpret_cast<::sycl::queue*>(ptr);
+      OCCA_ERROR("A nullptr was passed to dpcpp::device::wrapStream",nullptr != ptr);
+      ::sycl::queue q = *static_cast<::sycl::queue*>(ptr);
       return new stream(this, props, q);
     }
 

--- a/src/occa/internal/modes/dpcpp/device.hpp
+++ b/src/occa/internal/modes/dpcpp/device.hpp
@@ -37,6 +37,7 @@ namespace occa
 
       //---[ Stream ]-------------------
       virtual modeStream_t *createStream(const occa::json &props) override;
+      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props) override;
 
       virtual occa::streamTag tagStream() override;
       virtual void waitFor(occa::streamTag tag) override;

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -129,7 +129,8 @@ namespace occa {
     }
 
     modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
-      hipStream_t hipStream = *reinterpret_cast<hipStream_t*>(ptr);
+      OCCA_ERROR("A nullptr was passed to hip::device::wrapStream",nullptr != ptr);
+      hipStream_t hipStream = *static_cast<hipStream_t*>(ptr);
       return new stream(this, props, hipStream);
     }
 

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -128,6 +128,11 @@ namespace occa {
       return new stream(this, props, hipStream);
     }
 
+    modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
+      hipStream_t hipStream = *reinterpret_cast<hipStream_t*>(ptr);
+      return new stream(this, props, hipStream);
+    }
+
     occa::streamTag device::tagStream() {
       hipEvent_t hipEvent = NULL;
 

--- a/src/occa/internal/modes/hip/device.hpp
+++ b/src/occa/internal/modes/hip/device.hpp
@@ -37,6 +37,7 @@ namespace occa {
 
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::json &props);
+      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props);
 
       virtual streamTag tagStream();
       virtual void waitFor(streamTag tag);

--- a/src/occa/internal/modes/hip/stream.cpp
+++ b/src/occa/internal/modes/hip/stream.cpp
@@ -5,13 +5,17 @@ namespace occa {
   namespace hip {
     stream::stream(modeDevice_t *modeDevice_,
                    const occa::json &properties_,
-                   hipStream_t hipStream_) :
+                   hipStream_t hipStream_,
+                   bool isWrapped_) :
       modeStream_t(modeDevice_, properties_),
-      hipStream(hipStream_) {}
+      hipStream(hipStream_),
+      isWrapped(isWrapped_) {}
 
     stream::~stream() {
-      OCCA_HIP_ERROR("Device: freeStream",
-                      hipStreamDestroy(hipStream));
+      if (!isWrapped) {
+        OCCA_HIP_ERROR("Device: freeStream",
+                        hipStreamDestroy(hipStream));
+      }
     }
   }
 }

--- a/src/occa/internal/modes/hip/stream.hpp
+++ b/src/occa/internal/modes/hip/stream.hpp
@@ -10,9 +10,12 @@ namespace occa {
     public:
       hipStream_t hipStream;
 
+      bool isWrapped;
+
       stream(modeDevice_t *modeDevice_,
              const occa::json &properties_,
-             hipStream_t hipStream_);
+             hipStream_t hipStream_,
+             bool isWrapped_=false);
 
       virtual ~stream();
     };

--- a/src/occa/internal/modes/metal/device.cpp
+++ b/src/occa/internal/modes/metal/device.cpp
@@ -74,6 +74,11 @@ namespace occa {
       return new stream(this, props, metalCommandQueue);
     }
 
+    modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
+      api::metal::commandQueue_t q = *reinterpret_cast<api::metal::commandQueue_t*>(ptr);
+      return new stream(this, props, q, true);
+    }
+
     occa::streamTag device::tagStream() {
       metal::stream &stream = (
         *((metal::stream*) (currentStream.getModeStream()))

--- a/src/occa/internal/modes/metal/device.cpp
+++ b/src/occa/internal/modes/metal/device.cpp
@@ -75,7 +75,8 @@ namespace occa {
     }
 
     modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
-      api::metal::commandQueue_t q = *reinterpret_cast<api::metal::commandQueue_t*>(ptr);
+      OCCA_ERROR("A nullptr was passed to metal::device::wrapStream",nullptr != ptr);
+      api::metal::commandQueue_t q = *static_cast<api::metal::commandQueue_t*>(ptr);
       return new stream(this, props, q, true);
     }
 

--- a/src/occa/internal/modes/metal/device.hpp
+++ b/src/occa/internal/modes/metal/device.hpp
@@ -34,6 +34,7 @@ namespace occa {
 
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::json &props);
+      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props);
 
       virtual streamTag tagStream();
       virtual void waitFor(streamTag tag);

--- a/src/occa/internal/modes/metal/stream.cpp
+++ b/src/occa/internal/modes/metal/stream.cpp
@@ -4,12 +4,16 @@ namespace occa {
   namespace metal {
     stream::stream(modeDevice_t *modeDevice_,
                    const occa::json &properties_,
-                   api::metal::commandQueue_t metalCommandQueue_) :
+                   api::metal::commandQueue_t metalCommandQueue_,
+                   bool isWrapped_) :
         modeStream_t(modeDevice_, properties_),
-        metalCommandQueue(metalCommandQueue_) {}
+        metalCommandQueue(metalCommandQueue_),
+        isWrapped(isWrapped_) {}
 
     stream::~stream() {
-      metalCommandQueue.free();
+      if (!isWrapped) {
+        metalCommandQueue.free();
+      }
     }
   }
 }

--- a/src/occa/internal/modes/metal/stream.hpp
+++ b/src/occa/internal/modes/metal/stream.hpp
@@ -10,9 +10,12 @@ namespace occa {
     public:
       api::metal::commandQueue_t metalCommandQueue;
 
+      bool isWrapped;
+
       stream(modeDevice_t *modeDevice_,
              const occa::json &properties_,
-             api::metal::commandQueue_t metalCommandQueue_);
+             api::metal::commandQueue_t metalCommandQueue_,
+             bool isWrapped_=false);
 
       virtual ~stream();
     };

--- a/src/occa/internal/modes/opencl/device.cpp
+++ b/src/occa/internal/modes/opencl/device.cpp
@@ -107,6 +107,11 @@ namespace occa {
       return new stream(this, props, commandQueue);
     }
 
+    modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
+      cl_command_queue commandQueue = *reinterpret_cast<cl_command_queue*>(ptr);
+      return new stream(this, props, commandQueue, true);
+    }
+
     occa::streamTag device::tagStream() {
       cl_event clEvent;
 

--- a/src/occa/internal/modes/opencl/device.cpp
+++ b/src/occa/internal/modes/opencl/device.cpp
@@ -109,6 +109,7 @@ namespace occa {
 
     modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
       OCCA_ERROR("A nullptr was passed to opencl::device::wrapStream",nullptr != ptr);
+
       cl_command_queue commandQueue = *static_cast<cl_command_queue*>(ptr);
       OCCA_OPENCL_ERROR("Device: Retaining Command Queue",
                         clRetainCommandQueue(commandQueue));

--- a/src/occa/internal/modes/opencl/device.cpp
+++ b/src/occa/internal/modes/opencl/device.cpp
@@ -108,8 +108,12 @@ namespace occa {
     }
 
     modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
-      cl_command_queue commandQueue = *reinterpret_cast<cl_command_queue*>(ptr);
-      return new stream(this, props, commandQueue, true);
+      OCCA_ERROR("A nullptr was passed to opencl::device::wrapStream",nullptr != ptr);
+      cl_command_queue commandQueue = *static_cast<cl_command_queue*>(ptr);
+      OCCA_OPENCL_ERROR("Device: Retaining Command Queue",
+                        clRetainCommandQueue(commandQueue));
+
+      return new stream(this, props, commandQueue);
     }
 
     occa::streamTag device::tagStream() {

--- a/src/occa/internal/modes/opencl/device.hpp
+++ b/src/occa/internal/modes/opencl/device.hpp
@@ -35,6 +35,7 @@ namespace occa {
 
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::json &props);
+      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props);
 
       virtual streamTag tagStream();
       virtual void waitFor(streamTag tag);

--- a/src/occa/internal/modes/opencl/polyfill.hpp
+++ b/src/occa/internal/modes/opencl/polyfill.hpp
@@ -428,6 +428,10 @@ namespace occa {
     return NULL;
   }
 
+  inline cl_int clRetainCommandQueue(cl_command_queue command_queue) {
+    return OCCA_OPENCL_IS_NOT_ENABLED;
+  }
+
   inline cl_int clReleaseCommandQueue(cl_command_queue command_queue) {
     return OCCA_OPENCL_IS_NOT_ENABLED;
   }

--- a/src/occa/internal/modes/opencl/stream.cpp
+++ b/src/occa/internal/modes/opencl/stream.cpp
@@ -5,13 +5,17 @@ namespace occa {
   namespace opencl {
     stream::stream(modeDevice_t *modeDevice_,
                    const occa::json &properties_,
-                   cl_command_queue commandQueue_) :
+                   cl_command_queue commandQueue_,
+                   bool isWrapped_) :
       modeStream_t(modeDevice_, properties_),
-      commandQueue(commandQueue_) {}
+      commandQueue(commandQueue_),
+      isWrapped(isWrapped_) {}
 
     stream::~stream() {
-      OCCA_OPENCL_ERROR("Device: Freeing cl_command_queue",
-                        clReleaseCommandQueue(commandQueue));
+      if (!isWrapped) {
+        OCCA_OPENCL_ERROR("Device: Freeing cl_command_queue",
+                          clReleaseCommandQueue(commandQueue));
+      }
     }
   }
 }

--- a/src/occa/internal/modes/opencl/stream.cpp
+++ b/src/occa/internal/modes/opencl/stream.cpp
@@ -5,17 +5,13 @@ namespace occa {
   namespace opencl {
     stream::stream(modeDevice_t *modeDevice_,
                    const occa::json &properties_,
-                   cl_command_queue commandQueue_,
-                   bool isWrapped_) :
+                   cl_command_queue commandQueue_) :
       modeStream_t(modeDevice_, properties_),
-      commandQueue(commandQueue_),
-      isWrapped(isWrapped_) {}
+      commandQueue(commandQueue_) {}
 
     stream::~stream() {
-      if (!isWrapped) {
-        OCCA_OPENCL_ERROR("Device: Freeing cl_command_queue",
-                          clReleaseCommandQueue(commandQueue));
-      }
+      OCCA_OPENCL_ERROR("Device: Freeing cl_command_queue",
+                        clReleaseCommandQueue(commandQueue));
     }
   }
 }

--- a/src/occa/internal/modes/opencl/stream.hpp
+++ b/src/occa/internal/modes/opencl/stream.hpp
@@ -14,8 +14,7 @@ namespace occa {
 
       stream(modeDevice_t *modeDevice_,
              const occa::json &properties_,
-             cl_command_queue commandQueue_,
-             bool isWrapped_=false);
+             cl_command_queue commandQueue_);
 
       virtual ~stream();
     };

--- a/src/occa/internal/modes/opencl/stream.hpp
+++ b/src/occa/internal/modes/opencl/stream.hpp
@@ -10,9 +10,12 @@ namespace occa {
     public:
       cl_command_queue commandQueue;
 
+      bool isWrapped;
+
       stream(modeDevice_t *modeDevice_,
              const occa::json &properties_,
-             cl_command_queue commandQueue_);
+             cl_command_queue commandQueue_,
+             bool isWrapped_=false);
 
       virtual ~stream();
     };

--- a/src/occa/internal/modes/serial/device.cpp
+++ b/src/occa/internal/modes/serial/device.cpp
@@ -47,6 +47,10 @@ namespace occa {
       return new stream(this, props);
     }
 
+    modeStream_t* device::wrapStream(void* ptr, const occa::json &props) {
+      return new stream(this, props);
+    }
+
     occa::streamTag device::tagStream() {
       return new occa::serial::streamTag(this, sys::currentTime());
     }

--- a/src/occa/internal/modes/serial/device.hpp
+++ b/src/occa/internal/modes/serial/device.hpp
@@ -23,6 +23,7 @@ namespace occa {
 
       //---[ Stream ]-------------------
       virtual modeStream_t* createStream(const occa::json &props);
+      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props);
 
       virtual streamTag tagStream();
       virtual void waitFor(streamTag tag);


### PR DESCRIPTION
## Description

Adds `device::wrapStream` method to wrap native backend stream objects. Alternative solution to the functionality proposed in #379. 



<!-- Thank you for contributing! -->
