### PR TITLE
[Bugfix][DPCPP] Remove C++17 features from DPC++ headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
 endif()
 
+# CMake will decay to a previous C++ standard if a compiler does not support C++17
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -215,12 +216,8 @@ if(ENABLE_DPCPP)
     message(CHECK_PASS "found all components")
     set(OCCA_DPCPP_ENABLED 1)
     
-    set(SYCL_CXX_FLAGS "-fsycl")
-    message("-- SYCL CXX flags: ${SYCL_CXX_FLAGS}")
-  
     target_include_directories(libocca PRIVATE ${SYCL_INCLUDE_DIRS})
     target_link_libraries(libocca PRIVATE ${SYCL_LIBRARIES})
-    target_compile_options(libocca BEFORE PRIVATE "${SYCL_CXX_FLAGS}")
   endif()
 endif(ENABLE_DPCPP)
 #=======================================
@@ -300,10 +297,6 @@ file(
 if(OCCA_OPENMP_ENABLED)
   set_source_files_properties(${OCCA_SRC_cpp} PROPERTIES
     COMPILE_FLAGS ${OpenMP_CXX_FLAGS})
-endif()
-
-if(OCCA_DPCPP_ENABLED)
-  set_source_files_properties(${OCCA_SRC_cpp} PROPERTIES COMPILE_FLAGS ${SYCL_CXX_FLAGS})
 endif()
 
 if(ENABLE_FORTRAN)

--- a/src/occa/internal/lang/expr/dpcppAtomicNode.cpp
+++ b/src/occa/internal/lang/expr/dpcppAtomicNode.cpp
@@ -32,17 +32,13 @@ namespace occa
     void dpcppAtomicNode::print(printer &pout) const
     {
 
-      pout << sycl_atomic_ref;
-      pout << "<";
+      pout << "sycl::ONEAPI::atomic_ref<";
 
       // Currently CUDA only supports atomics on fundamental types:
       // assume that we can safefuly ignore the pointer types for now
       // and simply print the typename.
-      pout << atomic_type.name();
-      pout << ",";
-
-      pout << memory_order_relaxed;
-      pout << ",";
+      pout << atomic_type.name() << ",";
+      pout << "sycl::ONEAPI::memory_order::relaxed,";
 
       //  The SYCL standard states,
       // 
@@ -53,16 +49,15 @@ namespace occa
       //  Currently OCCA does not address system-wide atomics;
       //  therefore, assume for now that we can always safely
       //  use `memory_scope::device`.
-      pout << memory_scope_device;
-      pout << ",";
+      pout << "sycl::ONEAPI::memory_scope::device,";
 
       if(atomic_type.hasAttribute("shared"))
       {
-        pout << address_space_local_space;
+        pout << "sycl::access::address_space::global_space";
       }
       else
       {
-        pout << address_space_global_space;
+        pout << "sycl::access::address_space::local_space";
       }
 
       pout << ">(";

--- a/src/occa/internal/lang/expr/dpcppAtomicNode.hpp
+++ b/src/occa/internal/lang/expr/dpcppAtomicNode.hpp
@@ -35,15 +35,6 @@ namespace occa
       virtual void print(printer &pout) const;
 
       virtual void debugPrint(const std::string &prefix) const;
-
-    private:
-      inline static const std::string sycl_atomic_ref{"sycl::ONEAPI::atomic_ref"};
-      inline static const std::string memory_order_relaxed{"sycl::ONEAPI::memory_order::relaxed"};
-
-      inline static const std::string memory_scope_device{"sycl::ONEAPI::memory_scope::device"};
-
-      inline static const std::string address_space_global_space{"sycl::access::address_space::global_space"};
-      inline static const std::string address_space_local_space{"sycl::access::address_space::local_space"};
     };
   }
 }

--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -68,12 +68,12 @@ namespace occa
 
       std::string dpcppParser::getOuterIterator(const int loopIndex)
       {
-        return work_item_name + ".get_group(" + occa::toString(dpcppDimensionOrder(loopIndex)) + ")";
+        return "item_.get_group(" + occa::toString(dpcppDimensionOrder(loopIndex)) + ")";
       }
 
       std::string dpcppParser::getInnerIterator(const int loopIndex)
       {
-        return work_item_name + ".get_local_id(" + occa::toString(dpcppDimensionOrder(loopIndex)) + ")";
+        return "item_.get_local_id(" + occa::toString(dpcppDimensionOrder(loopIndex)) + ")";
       }
 
       // @note: As of SYCL 2020 this will need to change from `CL/sycl.hpp` to `sycl.hpp`
@@ -82,7 +82,7 @@ namespace occa
         root.addFirst(
             *(new directiveStatement(
                 &root,
-                directiveToken(root.source->origin, "include <" + sycl_header + ">"))));
+                directiveToken(root.source->origin, "include <sycl.hpp>"))));
       }
 
       void dpcppParser::addExtensions()
@@ -131,7 +131,7 @@ namespace occa
                        statement_t &barrierSmnt = (*(new sourceCodeStatement(
                            emptySmnt.up,
                            emptySmnt.source,
-                           work_item_name + ".barrier(sycl::access::fence_space::local_space);")));
+                           "item_.barrier(sycl::access::fence_space::local_space);")));
 
                        emptySmnt.replaceWith(barrierSmnt);
 
@@ -158,16 +158,16 @@ namespace occa
                          if (!success)
                            return;
 
-                         variable_t sycl_nditem(syclNdItem, work_item_name);
+                         variable_t sycl_nditem(syclNdItem, "item_");
 
-                         variable_t sycl_handler(syclHandler, group_handler_name);
+                         variable_t sycl_handler(syclHandler, "handler_");
                          sycl_handler.vartype.setReferenceToken(
                              new operatorToken(sycl_handler.source->origin, op::address));
 
-                         variable_t sycl_ndrange(syclNdRange, ndrange_name);
+                         variable_t sycl_ndrange(syclNdRange, "range_");
                          sycl_ndrange += pointer_t();
 
-                         variable_t sycl_queue(syclQueue, queue_name);
+                         variable_t sycl_queue(syclQueue, "queue_");
                          sycl_queue += pointer_t();
 
                          function->addArgumentFirst(sycl_ndrange);
@@ -268,7 +268,7 @@ namespace occa
               {
                 auto *shared_value = new dpcppLocalMemoryNode(var.source->clone(),
                                                               var.vartype,
-                                                              work_item_name);
+                                                              "item_");
 
                 decl.setValue(shared_value);
                 var.vartype.setType(auto_);

--- a/src/occa/internal/lang/modes/dpcpp.hpp
+++ b/src/occa/internal/lang/modes/dpcpp.hpp
@@ -47,12 +47,6 @@ namespace occa
       static bool transformAtomicBasicExpressionStatement(expressionStatement &exprSmnt);
 
       private:
-        inline static const std::string sycl_header{"CL/sycl.hpp"};
-        inline static const std::string queue_name{"queue_"};
-        inline static const std::string ndrange_name{"range_"};
-        inline static const std::string group_handler_name{"handler_"};
-        inline static const std::string work_item_name{"item_"};
-
         inline int dpcppDimensionOrder(const int index) { return 2 - index; }
       };
     } // namespace okl


### PR DESCRIPTION
## Description
Fixes #523 . Removes `static inline const` members from classes used by the DPC++ backend.
