### PR TITLE
Add MPI::MPI_Fortran to link_libraries of fortran mpi example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -96,7 +96,7 @@ if (ENABLE_FORTRAN)
 
   macro(compile_fortran_mpi_example_with_modes target file)
     add_executable(examples_fortran_${target} ${file})
-    target_link_libraries(examples_fortran_${target} libocca)
+    target_link_libraries(examples_fortran_${target} libocca MPI::MPI_Fortran)
     if (ENABLE_TESTS)
       add_mpi_test_with_modes(examples_fortran_${target})
     endif()


### PR DESCRIPTION
The example directly uses mpi, without the link compilation will fail on the use mpi statement when using a non-mpi-wrapper compiler

Fixes issue #529 