### PR TITLE
[OKL][Feature] `@max_inner_dims` attribute

### DIFF
--- a/src/occa/internal/lang/builtins/attributes.hpp
+++ b/src/occa/internal/lang/builtins/attributes.hpp
@@ -9,6 +9,7 @@
 #include <occa/internal/lang/builtins/attributes/implicitArg.hpp>
 #include <occa/internal/lang/builtins/attributes/inner.hpp>
 #include <occa/internal/lang/builtins/attributes/kernel.hpp>
+#include <occa/internal/lang/builtins/attributes/maxInnerDims.hpp>
 #include <occa/internal/lang/builtins/attributes/outer.hpp>
 #include <occa/internal/lang/builtins/attributes/restrict.hpp>
 #include <occa/internal/lang/builtins/attributes/shared.hpp>

--- a/src/occa/internal/lang/builtins/attributes/maxInnerDims.cpp
+++ b/src/occa/internal/lang/builtins/attributes/maxInnerDims.cpp
@@ -14,16 +14,10 @@ namespace occa {
         return name_;
       }
 
-      bool maxInnerDims::forFunction() const {
-        return true;
-      }
-
       bool maxInnerDims::forStatementType(const int sType) const {
-        return (sType 
-          & (statementType::function | statementType::functionDecl)
-          );
+        return (sType & statementType::for_);
       }
-
+      
       bool maxInnerDims::isValid(const attributeToken_t &attr) const {
         if (attr.kwargs.size()) {
           attr.printError("[@max_inner_dims] does not take kwargs");

--- a/src/occa/internal/lang/builtins/attributes/maxInnerDims.cpp
+++ b/src/occa/internal/lang/builtins/attributes/maxInnerDims.cpp
@@ -1,0 +1,62 @@
+#include <occa/internal/lang/expr.hpp>
+#include <occa/internal/lang/parser.hpp>
+#include <occa/internal/lang/statement.hpp>
+#include <occa/internal/lang/variable.hpp>
+#include <occa/internal/lang/builtins/attributes/maxInnerDims.hpp>
+
+namespace occa {
+  namespace lang {
+    namespace attributes {
+      maxInnerDims::maxInnerDims() {}
+
+      const std::string& maxInnerDims::name() const {
+        static const std::string name_{"max_inner_dims"};
+        return name_;
+      }
+
+      bool maxInnerDims::forFunction() const {
+        return true;
+      }
+
+      bool maxInnerDims::forStatementType(const int sType) const {
+        return (sType 
+          & (statementType::function | statementType::functionDecl)
+          );
+      }
+
+      bool maxInnerDims::isValid(const attributeToken_t &attr) const {
+        if (attr.kwargs.size()) {
+          attr.printError("[@max_inner_dims] does not take kwargs");
+          return false;
+        }
+        const auto argCount{attr.args.size()};
+        if (1 > argCount) {
+          attr.printError("[@max_inner_dims] expects at least one argument");
+          return false;
+        }
+        if(3 < argCount) {
+          attr.printError("[@max_inner_dims] takes at most 3 arguments");
+          return false;
+        }
+
+        for(auto&& arg : attr.args) {
+          exprNode *expr = arg.expr;
+          bool error = !(expr && expr->canEvaluate());
+          if(!error){
+            primitive value = expr->evaluate();
+            error = !value.isInteger();
+            if(!error) {
+              int intValue = value;
+              error = (intValue < 0);
+            }
+          }
+          if(error) {
+            attr.printError("[@max_inner_dims] arguments must be postive!");
+            return false;
+          }
+        }
+        return true;
+      }
+    }
+  }
+}

--- a/src/occa/internal/lang/builtins/attributes/maxInnerDims.hpp
+++ b/src/occa/internal/lang/builtins/attributes/maxInnerDims.hpp
@@ -12,7 +12,6 @@ namespace occa {
 
         virtual const std::string& name() const;
 
-        virtual bool forFunction() const;
         virtual bool forStatementType(const int sType) const;
 
         virtual bool isValid(const attributeToken_t &attr) const;

--- a/src/occa/internal/lang/builtins/attributes/maxInnerDims.hpp
+++ b/src/occa/internal/lang/builtins/attributes/maxInnerDims.hpp
@@ -1,0 +1,24 @@
+#ifndef OCCA_INTERNAL_LANG_BUILTINS_ATTRIBUTES_MAX_INNER_DIMS_HEADER
+#define OCCA_INTERNAL_LANG_BUILTINS_ATTRIBUTES_MAX_INNER_DIMS_HEADER
+
+#include <occa/internal/lang/attribute.hpp>
+
+namespace occa {
+  namespace lang {
+    namespace attributes {
+      class maxInnerDims : public attribute_t {
+      public:
+        maxInnerDims();
+
+        virtual const std::string& name() const;
+
+        virtual bool forFunction() const;
+        virtual bool forStatementType(const int sType) const;
+
+        virtual bool isValid(const attributeToken_t &attr) const;
+      };
+    }
+  }
+}
+
+#endif

--- a/src/occa/internal/lang/expr/dpcppAtomicNode.cpp
+++ b/src/occa/internal/lang/expr/dpcppAtomicNode.cpp
@@ -32,13 +32,13 @@ namespace occa
     void dpcppAtomicNode::print(printer &pout) const
     {
 
-      pout << "sycl::ONEAPI::atomic_ref<";
+      pout << "sycl::ext::oneapi::atomic_ref<";
 
       // Currently CUDA only supports atomics on fundamental types:
       // assume that we can safefuly ignore the pointer types for now
       // and simply print the typename.
       pout << atomic_type.name() << ",";
-      pout << "sycl::ONEAPI::memory_order::relaxed,";
+      pout << "sycl::ext::oneapi::memory_order::relaxed,";
 
       //  The SYCL standard states,
       // 
@@ -49,7 +49,7 @@ namespace occa
       //  Currently OCCA does not address system-wide atomics;
       //  therefore, assume for now that we can always safely
       //  use `memory_scope::device`.
-      pout << "sycl::ONEAPI::memory_scope::device,";
+      pout << "sycl::ext::oneapi::memory_scope::device,";
 
       if(atomic_type.hasAttribute("shared"))
       {

--- a/src/occa/internal/lang/modes/cuda.cpp
+++ b/src/occa/internal/lang/modes/cuda.cpp
@@ -147,10 +147,21 @@ namespace occa {
         root.children
           .forEachKernelStatement([&](functionDeclStatement &kernelSmnt) {
             // Set kernel qualifiers
-            vartype_t &vartype = kernelSmnt.function().returnType;
-            vartype.qualifiers.addFirst(vartype.origin(),
+           vartype_t &vartype = kernelSmnt.function().returnType;
+
+           dim kernelInnerDims = innerDims(kernelSmnt);
+           if (!success) return;
+           int kernelInnerDim = kernelInnerDims[0];
+           for(int i=1; i < kernelInnerDims.dims; i++) kernelInnerDim *= kernelInnerDims[i];
+           if(kernelInnerDim) {
+             const std::string s = "__launch_bounds__(" + std::to_string(kernelInnerDim) + ")";
+             qualifier_t *boundQualifier = new qualifier_t(s, qualifierType::custom);
+             vartype.qualifiers.addFirst(vartype.origin(), 
+                                          *boundQualifier);
+           }
+           vartype.qualifiers.addFirst(vartype.origin(),
                                         global);
-            vartype.qualifiers.addFirst(vartype.origin(),
+           vartype.qualifiers.addFirst(vartype.origin(),
                                         externC);
           });
       }

--- a/src/occa/internal/lang/modes/cuda.cpp
+++ b/src/occa/internal/lang/modes/cuda.cpp
@@ -60,6 +60,12 @@ namespace occa {
         return name;
       }
 
+      std::string cudaParser::launchBoundsAttribute(const int innerDims[3]) {
+        const int innerTotal{innerDims[0]*innerDims[1]*innerDims[2]};
+        const std::string lbAttr = "__launch_bounds__(" + std::to_string(innerTotal) + ")";
+        return lbAttr;
+      }
+
       void cudaParser::updateConstToConstant() {
         root.children
           .forEachDeclaration([&](variableDeclaration &decl) {
@@ -149,16 +155,6 @@ namespace occa {
             // Set kernel qualifiers
            vartype_t &vartype = kernelSmnt.function().returnType;
 
-           dim kernelInnerDims = innerDims(kernelSmnt);
-           if (!success) return;
-           int kernelInnerDim = kernelInnerDims[0];
-           for(int i=1; i < kernelInnerDims.dims; i++) kernelInnerDim *= kernelInnerDims[i];
-           if(kernelInnerDim) {
-             const std::string s = "__launch_bounds__(" + std::to_string(kernelInnerDim) + ")";
-             qualifier_t *boundQualifier = new qualifier_t(s, qualifierType::custom);
-             vartype.qualifiers.addFirst(vartype.origin(), 
-                                          *boundQualifier);
-           }
            vartype.qualifiers.addFirst(vartype.origin(),
                                         global);
            vartype.qualifiers.addFirst(vartype.origin(),

--- a/src/occa/internal/lang/modes/cuda.hpp
+++ b/src/occa/internal/lang/modes/cuda.hpp
@@ -15,17 +15,17 @@ namespace occa {
 
         cudaParser(const occa::json &settings_ = occa::json());
 
-        virtual void onClear();
+        virtual void onClear() override;
 
-        virtual void beforePreprocessing();
+        virtual void beforePreprocessing() override;
 
-        virtual void beforeKernelSplit();
+        virtual void beforeKernelSplit() override;
 
-        virtual void afterKernelSplit();
+        virtual void afterKernelSplit() override;
 
-        virtual std::string getOuterIterator(const int loopIndex);
+        virtual std::string getOuterIterator(const int loopIndex) override;
 
-        virtual std::string getInnerIterator(const int loopIndex);
+        virtual std::string getInnerIterator(const int loopIndex) override;
 
         virtual std::string launchBoundsAttribute(const int innerDims[3]) override;
 

--- a/src/occa/internal/lang/modes/cuda.hpp
+++ b/src/occa/internal/lang/modes/cuda.hpp
@@ -27,6 +27,8 @@ namespace occa {
 
         virtual std::string getInnerIterator(const int loopIndex);
 
+        virtual std::string launchBoundsAttribute(const int innerDims[3]) override;
+
         void updateConstToConstant();
 
         void setFunctionQualifiers();

--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -5,6 +5,7 @@
 #include <occa/internal/lang/builtins/attributes.hpp>
 #include <occa/internal/lang/builtins/types.hpp>
 #include <occa/internal/lang/expr.hpp>
+// #include <stringstream>
 
 namespace occa
 {
@@ -74,6 +75,19 @@ namespace occa
       std::string dpcppParser::getInnerIterator(const int loopIndex)
       {
         return "item_.get_local_id(" + occa::toString(dpcppDimensionOrder(loopIndex)) + ")";
+      }
+
+      std::string dpcppParser::launchBoundsAttribute(const int innerDims[3])
+      {
+        std::stringstream ss; 
+        ss << "[[reqd_work_group_size("
+           << innerDims[2]
+           << ","
+           << innerDims[1]
+           << ","
+           << innerDims[0]
+           << ")]]\n";
+        return ss.str();
       }
 
       // @note: As of SYCL 2020 this will need to change from `CL/sycl.hpp` to `sycl.hpp`

--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -246,7 +246,6 @@ namespace occa
                      {
                        functionDeclStatement &funcDeclSmnt = (functionDeclStatement &)*smnt;
 
-                       // Only add __device__ to non-kernel functions
                        if (funcDeclSmnt.hasAttribute("kernel"))
                        {
                          return;

--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -80,7 +80,7 @@ namespace occa
       std::string dpcppParser::launchBoundsAttribute(const int innerDims[3])
       {
         std::stringstream ss; 
-        ss << "[[reqd_work_group_size("
+        ss << "[[sycl::reqd_work_group_size("
            << innerDims[2]
            << ","
            << innerDims[1]

--- a/src/occa/internal/lang/modes/dpcpp.hpp
+++ b/src/occa/internal/lang/modes/dpcpp.hpp
@@ -31,6 +31,7 @@ namespace occa
 
         virtual std::string getOuterIterator(const int loopIndex) override;
         virtual std::string getInnerIterator(const int loopIndex) override;
+        virtual std::string launchBoundsAttribute(const int innerDims[3]) override;
 
         void addExtensions();
         void addBarriers();
@@ -41,10 +42,11 @@ namespace occa
         void setSharedQualifiers();
         void setKernelQualifiers(function_t &function);
         void migrateLocalDecls(functionDeclStatement &kernelSmnt);
+        void setLaunchBounds();
 
-      void setupAtomics();
-      static bool transformAtomicBlockStatement(blockStatement &blockSmnt);
-      static bool transformAtomicBasicExpressionStatement(expressionStatement &exprSmnt);
+        void setupAtomics();
+        static bool transformAtomicBlockStatement(blockStatement &blockSmnt);
+        static bool transformAtomicBasicExpressionStatement(expressionStatement &exprSmnt);
 
       private:
         inline int dpcppDimensionOrder(const int index) { return 2 - index; }

--- a/src/occa/internal/lang/modes/metal.cpp
+++ b/src/occa/internal/lang/modes/metal.cpp
@@ -54,8 +54,9 @@ namespace occa {
         return name;
       }
 
+      // Needs to be implemented: do nothing for now.
       std::string metalParser::launchBoundsAttribute(const int innerDims[3]) {
-        return "Not implemented yet!!";
+        return "";
       }
 
       void metalParser::setSharedQualifiers() {

--- a/src/occa/internal/lang/modes/metal.cpp
+++ b/src/occa/internal/lang/modes/metal.cpp
@@ -54,6 +54,10 @@ namespace occa {
         return name;
       }
 
+      std::string metalParser::launchBoundsAttribute(const int innerDims[3]) {
+        return "Not implemented yet!!";
+      }
+
       void metalParser::setSharedQualifiers() {
         statementArray::from(root)
             .nestedForEachDeclaration([&](variableDeclaration &decl) {

--- a/src/occa/internal/lang/modes/metal.hpp
+++ b/src/occa/internal/lang/modes/metal.hpp
@@ -15,16 +15,16 @@ namespace occa {
 
         metalParser(const occa::json &settings_ = occa::json());
 
-        virtual void onClear();
-        virtual void beforePreprocessing();
+        virtual void onClear() override;
+        virtual void beforePreprocessing() override;
 
-        virtual void beforeKernelSplit();
+        virtual void beforeKernelSplit() override;
 
-        virtual void afterKernelSplit();
+        virtual void afterKernelSplit() override;
 
-        virtual std::string getOuterIterator(const int loopIndex);
+        virtual std::string getOuterIterator(const int loopIndex) override;
 
-        virtual std::string getInnerIterator(const int loopIndex);
+        virtual std::string getInnerIterator(const int loopIndex) override;
 
         virtual std::string launchBoundsAttribute(const int innerDims[3]) override;
 

--- a/src/occa/internal/lang/modes/metal.hpp
+++ b/src/occa/internal/lang/modes/metal.hpp
@@ -26,6 +26,8 @@ namespace occa {
 
         virtual std::string getInnerIterator(const int loopIndex);
 
+        virtual std::string launchBoundsAttribute(const int innerDims[3]) override;
+
         void setSharedQualifiers();
 
         void addBarriers();

--- a/src/occa/internal/lang/modes/okl.cpp
+++ b/src/occa/internal/lang/modes/okl.cpp
@@ -390,6 +390,7 @@ namespace occa {
         parser.addAttribute<attributes::kernel>();
         parser.addAttribute<attributes::outer>();
         parser.addAttribute<attributes::shared>();
+        parser.addAttribute<attributes::maxInnerDims>();
       }
 
       void setOklLoopIndices(functionDeclStatement &kernelSmnt) {

--- a/src/occa/internal/lang/modes/opencl.cpp
+++ b/src/occa/internal/lang/modes/opencl.cpp
@@ -281,7 +281,6 @@ namespace occa {
                   if (!success) return;
 
                   dim kernelInnerDims = innerDims((functionDeclStatement&) *smnt);
-                  std::cout << "here" << kernelInnerDims[0] << std::endl;
                   if (!success) return;
 
                   int kernelInnerDim = kernelInnerDims[0];

--- a/src/occa/internal/lang/modes/opencl.cpp
+++ b/src/occa/internal/lang/modes/opencl.cpp
@@ -74,6 +74,18 @@ namespace occa {
         return name;
       }
 
+      std::string openclParser::launchBoundsAttribute(const int innerDims[3]) {
+        std::stringstream ss; 
+        ss << "__attribute__((reqd_work_group_size("
+           << innerDims[0]
+           << ","
+           << innerDims[1]
+           << ","
+           << innerDims[2]
+           << ")))\n";
+        return ss.str();
+      }
+
       void openclParser::addExtensions() {
         if (!settings.has("extensions")) {
           return;
@@ -279,23 +291,6 @@ namespace occa {
 
                   migrateLocalDecls((functionDeclStatement&) *smnt);
                   if (!success) return;
-
-                  dim kernelInnerDims = innerDims((functionDeclStatement&) *smnt);
-                  if (!success) return;
-
-                  int kernelInnerDim = kernelInnerDims[0];
-                  for(int i=1; i < kernelInnerDims.dims; i++) kernelInnerDim *= kernelInnerDims[i];
-                  if(kernelInnerDim) {
-                    std::string s = "__attribute__((work_group_size_hint(";
-                    s += std::to_string(kernelInnerDims[0]);
-                    for(int i=1; i < 3; i++) {
-                      s += ", " + std::to_string(std::max((int)kernelInnerDims[i],1));
-                    }
-                    s += ")))";
-                    qualifier_t *boundQualifier = new qualifier_t(s, qualifierType::custom);
-                    function->returnType.add(0, *boundQualifier);
-                  }
-
                 } else {
                   function = &(((functionStatement*) smnt)->function());
                 }

--- a/src/occa/internal/lang/modes/opencl.cpp
+++ b/src/occa/internal/lang/modes/opencl.cpp
@@ -279,6 +279,24 @@ namespace occa {
 
                   migrateLocalDecls((functionDeclStatement&) *smnt);
                   if (!success) return;
+
+                  dim kernelInnerDims = innerDims((functionDeclStatement&) *smnt);
+                  std::cout << "here" << kernelInnerDims[0] << std::endl;
+                  if (!success) return;
+
+                  int kernelInnerDim = kernelInnerDims[0];
+                  for(int i=1; i < kernelInnerDims.dims; i++) kernelInnerDim *= kernelInnerDims[i];
+                  if(kernelInnerDim) {
+                    std::string s = "__attribute__((work_group_size_hint(";
+                    s += std::to_string(kernelInnerDims[0]);
+                    for(int i=1; i < 3; i++) {
+                      s += ", " + std::to_string(std::max((int)kernelInnerDims[i],1));
+                    }
+                    s += ")))";
+                    qualifier_t *boundQualifier = new qualifier_t(s, qualifierType::custom);
+                    function->returnType.add(0, *boundQualifier);
+                  }
+
                 } else {
                   function = &(((functionStatement*) smnt)->function());
                 }
@@ -299,6 +317,7 @@ namespace occa {
       }
 
       void openclParser::setKernelQualifiers(function_t &function) {
+
         function.returnType.add(0, kernel);
 
         const int argCount = (int) function.args.size();

--- a/src/occa/internal/lang/modes/opencl.hpp
+++ b/src/occa/internal/lang/modes/opencl.hpp
@@ -16,16 +16,16 @@ namespace occa {
 
         openclParser(const occa::json &settings_ = occa::json());
 
-        virtual void onClear();
-        virtual void beforePreprocessing();
+        virtual void onClear() override;
+        virtual void beforePreprocessing() override;
 
-        virtual void beforeKernelSplit();
+        virtual void beforeKernelSplit() override;
 
-        virtual void afterKernelSplit();
+        virtual void afterKernelSplit() override;
 
-        virtual std::string getOuterIterator(const int loopIndex);
+        virtual std::string getOuterIterator(const int loopIndex) override;
 
-        virtual std::string getInnerIterator(const int loopIndex);
+        virtual std::string getInnerIterator(const int loopIndex) override;
 
         virtual std::string launchBoundsAttribute(const int innerDims[3]) override;
 

--- a/src/occa/internal/lang/modes/opencl.hpp
+++ b/src/occa/internal/lang/modes/opencl.hpp
@@ -27,6 +27,8 @@ namespace occa {
 
         virtual std::string getInnerIterator(const int loopIndex);
 
+        virtual std::string launchBoundsAttribute(const int innerDims[3]) override;
+
         void addExtensions();
 
         void updateConstToConstant();

--- a/src/occa/internal/lang/modes/withLauncher.cpp
+++ b/src/occa/internal/lang/modes/withLauncher.cpp
@@ -184,6 +184,7 @@ namespace occa {
              dims[1] = 0;
              dims[2] = 0;
              int innerCount = 0;
+             int innerIndex;
              const int pathCount = (int) path.length();
              for (int i = 0; i < pathCount; ++i) {
                forStatement &pathSmnt = *((forStatement*) path[i]);
@@ -191,12 +192,16 @@ namespace occa {
 
                if(pathSmnt.hasAttribute("inner")) {
                  innerCount++;
+                 innerIndex = oklForSmnt.oklLoopIndex();
                  std::string s = oklForSmnt.getIterationCount()->toString();
                  if(oklForSmnt.getIterationCount()->canEvaluate()) {
-                   dims[i-1] = (int) oklForSmnt.getIterationCount()->evaluate();
+                   dims[innerIndex] = (int) oklForSmnt.getIterationCount()->evaluate();
                  } else { // loop bounds are unknown at compile time or there is tiled loop
-                   if(s.find("_occa_tiled_") != std::string::npos)
-                     dims[i-1] = std::stoi(s.substr(s.find_first_of("0123456789")));
+                    if(s.find("_occa_tiled_") != std::string::npos) {
+                      size_t tile_size = s.find_first_of("0123456789");
+                      OCCA_ERROR("@tile size is undefined!",tile_size != std::string::npos);
+                      dims[innerIndex] = std::stoi(s.substr(tile_size));
+                    }
                  }
                }
              }

--- a/src/occa/internal/lang/modes/withLauncher.cpp
+++ b/src/occa/internal/lang/modes/withLauncher.cpp
@@ -51,10 +51,10 @@ namespace occa {
         splitKernels();
 
         if (!success) return;
-        setupKernels();
+        afterKernelSplit();
 
         if (!success) return;
-        afterKernelSplit();
+        setupKernels();
       }
 
       void withLauncher::beforeKernelSplit() {}
@@ -166,6 +166,43 @@ namespace occa {
           }
         }
         return false;
+      }
+
+      dim withLauncher::innerDims(functionDeclStatement &smnt) {
+        dim dims;
+        functionDeclStatement &kernelSmnt = (functionDeclStatement&) smnt.clone();
+
+        statementArray::from(kernelSmnt)
+          .flatFilterByAttribute("outer")
+          .filterByStatementType(statementType::for_)
+          .forEach([&](statement_t *forSmnt) {
+
+             forStatement *innerSmnt = getInnerMostInnerLoop((forStatement&) *forSmnt);
+             statementArray path = oklForStatement::getOklLoopPath(*innerSmnt);
+
+             dims[0] = 0;
+             dims[1] = 0;
+             dims[2] = 0;
+             int innerCount = 0;
+             const int pathCount = (int) path.length();
+             for (int i = 0; i < pathCount; ++i) {
+               forStatement &pathSmnt = *((forStatement*) path[i]);
+               oklForStatement oklForSmnt(pathSmnt);
+
+               if(pathSmnt.hasAttribute("inner")) {
+                 innerCount++;
+                 std::string s = oklForSmnt.getIterationCount()->toString();
+                 if(oklForSmnt.getIterationCount()->canEvaluate()) {
+                   dims[i-1] = (int) oklForSmnt.getIterationCount()->evaluate();
+                 } else { // loop bounds are unknown at compile time or there is tiled loop
+                   if(s.find("_occa_tiled_") != std::string::npos)
+                     dims[i-1] = std::stoi(s.substr(s.find_first_of("0123456789")));
+                 }
+               }
+             }
+             dims.dims = innerCount;
+          });
+        return dims; 
       }
 
       void withLauncher::setKernelLaunch(functionDeclStatement &kernelSmnt,

--- a/src/occa/internal/lang/modes/withLauncher.cpp
+++ b/src/occa/internal/lang/modes/withLauncher.cpp
@@ -168,48 +168,6 @@ namespace occa {
         return false;
       }
 
-      dim withLauncher::innerDims(functionDeclStatement &smnt) {
-        dim dims;
-        functionDeclStatement &kernelSmnt = (functionDeclStatement&) smnt.clone();
-
-        statementArray::from(kernelSmnt)
-          .flatFilterByAttribute("outer")
-          .filterByStatementType(statementType::for_)
-          .forEach([&](statement_t *forSmnt) {
-
-             forStatement *innerSmnt = getInnerMostInnerLoop((forStatement&) *forSmnt);
-             statementArray path = oklForStatement::getOklLoopPath(*innerSmnt);
-
-             dims[0] = 0;
-             dims[1] = 0;
-             dims[2] = 0;
-             int innerCount = 0;
-             int innerIndex;
-             const int pathCount = (int) path.length();
-             for (int i = 0; i < pathCount; ++i) {
-               forStatement &pathSmnt = *((forStatement*) path[i]);
-               oklForStatement oklForSmnt(pathSmnt);
-
-               if(pathSmnt.hasAttribute("inner")) {
-                 innerCount++;
-                 innerIndex = oklForSmnt.oklLoopIndex();
-                 std::string s = oklForSmnt.getIterationCount()->toString();
-                 if(oklForSmnt.getIterationCount()->canEvaluate()) {
-                   dims[innerIndex] = (uint_t) oklForSmnt.getIterationCount()->evaluate();
-                 } else { // loop bounds are unknown at compile time or there is tiled loop
-                    if(s.find("_occa_tiled_") != std::string::npos) {
-                      size_t tile_size = s.find_first_of("0123456789");
-                      OCCA_ERROR("@tile size is undefined!",tile_size != std::string::npos);
-                      dims[innerIndex] = std::stoi(s.substr(tile_size));
-                    }
-                 }
-               }
-             }
-             dims.dims = innerCount;
-          });
-        return dims; 
-      }
-
       void withLauncher::setKernelLaunch(functionDeclStatement &kernelSmnt,
                                          forStatement &forSmnt,
                                          const int kernelIndex) {
@@ -470,22 +428,54 @@ namespace occa {
         forStatement &newForSmnt = (forStatement&) forSmnt.clone();
         newKernelSmnt.set(newForSmnt);
 
+        bool addLaunchBoundsAttribute{true};
+        int kernelInnerDims[3] = {1,1,1};
         if (newForSmnt.hasAttribute("max_inner_dims")) {
-                attributeToken_t& attr = newForSmnt.attributes["max_inner_dims"];
-                
-                int kernelInnerDims[3] = {1,1,1};
-                for(size_t i=0; i < attr.args.size(); ++i) {
+          attributeToken_t& attr = newForSmnt.attributes["max_inner_dims"];      
 
-                  exprNode* expr = attr.args[i].expr;
-                  primitive value = expr->evaluate();
-                  kernelInnerDims[i] = value; 
+          for(size_t i=0; i < attr.args.size(); ++i) {
+            exprNode* expr = attr.args[i].expr;
+            primitive value = expr->evaluate();
+            kernelInnerDims[i] = value; 
+          } 
+        } else {
+          //Programmer hasn't specified launch bounds.
+          //If they are known at compile time, set them.
+          forStatement *innerSmnt = getInnerMostInnerLoop(newForSmnt);
+          statementArray path = oklForStatement::getOklLoopPath(*innerSmnt);
+
+          int innerIndex;
+          const int pathCount = (int) path.length();
+          for (int i = 0; i < pathCount; ++i) {
+            forStatement &pathSmnt = *((forStatement*) path[i]);
+            oklForStatement oklForSmnt(pathSmnt);
+
+            if(pathSmnt.hasAttribute("inner")) {
+              innerIndex = oklForSmnt.oklLoopIndex();
+              if(oklForSmnt.getIterationCount()->canEvaluate()) {
+                kernelInnerDims[innerIndex] = (int) oklForSmnt.getIterationCount()->evaluate();
+              } else { 
+                std::string s = oklForSmnt.getIterationCount()->toString();
+                if(s.find("_occa_tiled_") != std::string::npos) {
+                  size_t tile_size = s.find_first_of("0123456789");
+                  OCCA_ERROR("@tile size is undefined!",tile_size != std::string::npos);
+                  kernelInnerDims[innerIndex] = std::stoi(s.substr(tile_size));
+                } else {
+                  //loop bounds are unknown at compile time
+                  addLaunchBoundsAttribute=false;
+                  break;
                 }
-                 
-                std::string lbAttr = launchBoundsAttribute(kernelInnerDims);
-                qualifier_t& boundQualifier = *(new qualifier_t(lbAttr,qualifierType::custom));
-                function_t& function = newKernelSmnt.function();
-                function.returnType.add(1, boundQualifier);
-              } 
+              }
+            }
+          }
+        }
+
+        if(addLaunchBoundsAttribute) {
+          std::string lbAttr = launchBoundsAttribute(kernelInnerDims);
+          qualifier_t& boundQualifier = *(new qualifier_t(lbAttr,qualifierType::custom));
+          function_t& function = newKernelSmnt.function();
+          function.returnType.add(1, boundQualifier);
+        }
 
         const int argc = (int) newFunction.args.size();
         for (int i = 0; i < argc; ++i) {

--- a/src/occa/internal/lang/modes/withLauncher.cpp
+++ b/src/occa/internal/lang/modes/withLauncher.cpp
@@ -457,7 +457,7 @@ namespace occa {
               } else { 
                 std::string s = oklForSmnt.getIterationCount()->toString();
                 if(s.find("_occa_tiled_") != std::string::npos) {
-                  size_t tile_size = s.find_first_of("0123456789");
+                  size_t tile_size = s.find_first_of("123456789");
                   OCCA_ERROR("@tile size is undefined!",tile_size != std::string::npos);
                   kernelInnerDims[innerIndex] = std::stoi(s.substr(tile_size));
                 } else {

--- a/src/occa/internal/lang/modes/withLauncher.hpp
+++ b/src/occa/internal/lang/modes/withLauncher.hpp
@@ -46,6 +46,8 @@ namespace occa {
 
         bool isInsideLoop(forStatement &forSmnt);
 
+        dim innerDims(functionDeclStatement &kernelSmnt);
+
         void setKernelLaunch(functionDeclStatement &kernelSmnt,
                              forStatement &forSmnt,
                              const int kernelIndex);

--- a/src/occa/internal/lang/modes/withLauncher.hpp
+++ b/src/occa/internal/lang/modes/withLauncher.hpp
@@ -86,6 +86,7 @@ namespace occa {
 
         virtual std::string getOuterIterator(const int loopIndex) = 0;
         virtual std::string getInnerIterator(const int loopIndex) = 0;
+        virtual std::string launchBoundsAttribute(const int innerDims[3]) = 0;
       };
     }
   }

--- a/src/occa/internal/lang/modes/withLauncher.hpp
+++ b/src/occa/internal/lang/modes/withLauncher.hpp
@@ -46,8 +46,6 @@ namespace occa {
 
         bool isInsideLoop(forStatement &forSmnt);
 
-        dim innerDims(functionDeclStatement &kernelSmnt);
-
         void setKernelLaunch(functionDeclStatement &kernelSmnt,
                              forStatement &forSmnt,
                              const int kernelIndex);

--- a/tests/src/internal/lang/modes/okl.cpp
+++ b/tests/src/internal/lang/modes/okl.cpp
@@ -23,6 +23,7 @@ int main(const int argc, const char **argv) {
   parser.addAttribute<attributes::inner>();
   parser.addAttribute<attributes::shared>();
   parser.addAttribute<attributes::exclusive>();
+  parser.addAttribute<attributes::maxInnerDims>();
 
   testKernel();
   testLoops();

--- a/tests/src/internal/lang/parser/utils.hpp
+++ b/tests/src/internal/lang/parser/utils.hpp
@@ -7,4 +7,5 @@ void setupParser() {
   parser.addAttribute<attributes::inner>();
   parser.addAttribute<attributes::shared>();
   parser.addAttribute<attributes::exclusive>();
+  parser.addAttribute<attributes::maxInnerDims>();
 }


### PR DESCRIPTION
## Description
Closes #307

Introduces a new loop attribute `@max_inner_dims(X, Y, Z)`, where `X`, `Y`, and `Z` are compile-time constants. 

Example usage:
```
@max_inner_dims(16,32)
for(int ib=0; ib < BLOCK_M; ++ib; @outer) {
  for(int jb=0; jb < BLOCK_N; ++jb; @outer) {
    ...
    for(int it=0; it < 32; ++it; @inner) {
      for(int jt=0; jt < 16; ++jt; @inner) {
      ...
      }
    }
  }
}
```

When the range of the `@inner` loops within an `@outer` block can be determined at compile-time (e.g., because they are constant), this attribute is added automatically.

## Details

If the outermost `@outer`-loop of a for-loop block is decorated with this OKL attribute, the following C++ attributes are added to the resulting backend kernel definitions:

- CUDA/HIP: `__launch_bounds(X*Y*Z)__`
- OpenCL: `__attribute__((reqd_work_group_size(X, Y, Z)))`
- DPC++: `[[sycl::reqd_work_group_size(X,Y,Z)]]`

The number of arguments given should be greater than or equal to the number of `@inner` loops in the block.

In the case where `@max_inner_dims` is specified and the the range of the `@inner` loops can be determined, the former takes precedence&mdash;overriding the kernel launch bounds that would be added automatically.

## Limitations

This attribute only affects the behaviour of the "launched" backends.
Currently CUDA, HIP, OpenCL, and DPC++ are supported: the Metal backend still needs an implementation.