### PR TITLE
[Git] Also ignore build dir if it's a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ main
 opt
 
 # CMake
-/build/
+/build
 
 # Bin
 /bin/*


### PR DESCRIPTION
## Description

Build dir is commonly a symlink to a scratch space in my setup, it would be nice to ignore that case as well.
