### PR TITLE
[Tests] Fix wrong directory in run_examples script

### DIFF
--- a/tests/run_examples
+++ b/tests/run_examples
@@ -37,7 +37,7 @@ if [[ $C_EXAMPLES -eq 1 ]]; then
   examples+=(
     c/01_add_vectors
     c/02_background_device
-    c/03_generic_inline_okl
+    c/03_generic_inline_kernel
     c/04_reduction
   )
 fi


### PR DESCRIPTION
## Description

While looking at the CI for another pull request I noticed 

```
./tests/run_examples: line 132: cd: /home/runner/work/occa/occa/examples/c/03_generic_inline_okl: No such file or directory
---[ (OpenMP) c/03_generic_inline_okl ]-----------------------------------------
rm -f /home/runner/work/occa/occa/examples/c/02_background_device/obj/*;
rm -f /home/runner/work/occa/occa/examples/c/02_background_device/main
clang-11  -O3 -march=native -D __extern_always_inline=inline -Wno-variadic-macros -o /home/runner/work/occa/occa/examples/c/02_background_device/main  -fopenmp  /home/runner/work/occa/occa/examples/c/02_background_device/main.c -I/home/runner/work/occa/occa/include -I/home/runner/work/occa/occa/src -L/home/runner/work/occa/occa/lib    -locca -lm -lrt -ldl
Loading cached [addVectors] from [/home/runner/work/occa/occa/examples/c/02_background_device/addVectors.okl] in [/home/runner/.occa/cache/dbe3cfe6e3600364/binary]
0 = 1.000000
1 = 1.000000
2 = 1.000000
3 = 1.000000
4 = 1.000000
```

This PR has the quick fix of fixing the path in the list of paths, but the worrying part is that the test doesn't fail, it just doesn't change directory and runs the `02` test again. I normally don't use the Make-based scripts so I don't want to touch this any more, but I would recommend some more error checking.