### PR TITLE
Add the `@nobarrier` attribute to stop barriers from being added automatically to `@inner` loop blocks.

### DIFF
--- a/src/occa/internal/lang/builtins/attributes.hpp
+++ b/src/occa/internal/lang/builtins/attributes.hpp
@@ -10,6 +10,7 @@
 #include <occa/internal/lang/builtins/attributes/inner.hpp>
 #include <occa/internal/lang/builtins/attributes/kernel.hpp>
 #include <occa/internal/lang/builtins/attributes/maxInnerDims.hpp>
+#include <occa/internal/lang/builtins/attributes/noBarrier.hpp>
 #include <occa/internal/lang/builtins/attributes/outer.hpp>
 #include <occa/internal/lang/builtins/attributes/restrict.hpp>
 #include <occa/internal/lang/builtins/attributes/shared.hpp>

--- a/src/occa/internal/lang/builtins/attributes/noBarrier.cpp
+++ b/src/occa/internal/lang/builtins/attributes/noBarrier.cpp
@@ -1,0 +1,34 @@
+#include <occa/internal/lang/expr.hpp>
+#include <occa/internal/lang/statement.hpp>
+#include <occa/internal/lang/builtins/attributes/noBarrier.hpp>
+
+namespace occa {
+  namespace lang {
+    namespace attributes {
+      //---[ @nobarrier ]-----------------------
+      noBarrier::noBarrier() {}
+
+      const std::string& noBarrier::name() const {
+        static std::string name_ = "nobarrier";
+        return name_;
+      }
+
+      bool noBarrier::forStatementType(const int sType) const {
+        return (sType & statementType::for_);
+      }
+
+      bool noBarrier::isValid(const attributeToken_t &attr) const {
+        if (attr.kwargs.size()) {
+          attr.printError("[@nobarrier] does not take kwargs");
+          return false;
+        }
+        if (attr.args.size()) {
+          attr.printError("[@nobarrier] does not take arguments");
+          return false;
+        }
+        return true;
+      }
+      //==================================
+    }
+  }
+}

--- a/src/occa/internal/lang/builtins/attributes/noBarrier.hpp
+++ b/src/occa/internal/lang/builtins/attributes/noBarrier.hpp
@@ -1,0 +1,25 @@
+#ifndef OCCA_INTERNAL_LANG_BUILTINS_ATTRIBUTES_NOBARRIER_HEADER
+#define OCCA_INTERNAL_LANG_BUILTINS_ATTRIBUTES_NOBARRIER_HEADER
+
+#include <occa/internal/lang/attribute.hpp>
+
+namespace occa {
+  namespace lang {
+    namespace attributes {
+      //---[ @nobarrier ]---------------
+      class noBarrier : public attribute_t {
+      public:
+        noBarrier();
+
+        virtual const std::string& name() const;
+
+        virtual bool forStatementType(const int sType) const;
+
+        virtual bool isValid(const attributeToken_t &attr) const;
+      };
+      //================================
+    }
+  }
+}
+
+#endif

--- a/src/occa/internal/lang/modes/okl.cpp
+++ b/src/occa/internal/lang/modes/okl.cpp
@@ -391,6 +391,7 @@ namespace occa {
         parser.addAttribute<attributes::outer>();
         parser.addAttribute<attributes::shared>();
         parser.addAttribute<attributes::maxInnerDims>();
+        parser.addAttribute<attributes::noBarrier>();
       }
 
       void setOklLoopIndices(functionDeclStatement &kernelSmnt) {

--- a/src/occa/internal/lang/modes/withLauncher.cpp
+++ b/src/occa/internal/lang/modes/withLauncher.cpp
@@ -513,8 +513,9 @@ namespace occa {
 
               //Only apply barriers when needed in the last inner-loop
               if (isOuterMostInnerLoop(innerSmnt)
-                  && (!isLastInnerLoop(innerSmnt) || isInsideLoop(innerSmnt)))
-                addBarriersAfterInnerLoop(innerSmnt);
+                  && (!isLastInnerLoop(innerSmnt) || isInsideLoop(innerSmnt))
+                  && !(innerSmnt.hasAttribute("nobarrier"))
+                 ) addBarriersAfterInnerLoop(innerSmnt);
             });
         }
 


### PR DESCRIPTION
## Description

Closes #484 

Introduces an attribute `@nobarrier` to disable the automatic addition of barriers after `@inner` loop blocks that write to shared memory.

## Usage

```
@kernel void f(int N) 
{  
  @outer
  for(int i=0; i < N; ++i) {
    @shared double x[3];

    @inner @nobarrier
    for(int j=0; j < N; ++j) {
      x[j] = 1.0;
    }

    @inner
    for(int j=0; j < N; ++j) {
      x[j] = 1.0;
    }
  }
}
```
