### PR TITLE
[#553] Fix broken caching for "output" file

### DIFF
--- a/src/occa/internal/io/cache.cpp
+++ b/src/occa/internal/io/cache.cpp
@@ -88,7 +88,6 @@ namespace occa {
     bool cachedFileIsComplete(const std::string &hashDir,
                               const std::string &filename) {
       std::string successFile = hashDir;
-      successFile += ".success/";
       successFile += filename;
 
       return io::exists(successFile);


### PR DESCRIPTION
Fix cached file path of "output" to match with the actual file created when checking for its existence.

