### PR TITLE
Bugfix launch bounds 567

### DIFF
--- a/src/occa/internal/lang/builtins/attributes/maxInnerDims.cpp
+++ b/src/occa/internal/lang/builtins/attributes/maxInnerDims.cpp
@@ -41,7 +41,7 @@ namespace occa {
             error = !value.isInteger();
             if(!error) {
               int intValue = value;
-              error = (intValue < 0);
+              error = !(0 < intValue);
             }
           }
           if(error) {

--- a/tests/src/internal/lang/modes/okl.cpp
+++ b/tests/src/internal/lang/modes/okl.cpp
@@ -42,12 +42,18 @@ void testOKLLoopExists();
 void testProperOKLLoops();
 void testInnerInsideOuter();
 void testSameInnerLoopCount();
+void testEmptyLoops();
+void testInfiniteLoops();
+void testMaxInnerDims();
 
 void testLoops() {
   testOKLLoopExists();
   testProperOKLLoops();
   testInnerInsideOuter();
   testSameInnerLoopCount();
+  testEmptyLoops();
+  testInfiniteLoops();
+  testMaxInnerDims();
 }
 
 void testOKLLoopExists() {
@@ -159,6 +165,66 @@ void testSameInnerLoopCount() {
     "    for (int i = 0; i < 2; ++i; @inner) {\n"
     "      for (int i2 = 0; i2 < 2; ++i2; @inner) {\n"
     "      }\n"
+    "    }\n"
+    "  }\n"
+    "}\n"
+  );
+}
+
+void testEmptyLoops() {
+
+  parseBadOKLSource(
+    "@kernel void foo() {\n"
+    "  for (int o = 0; o < 2; ++o; @outer) {\n"
+    "    for (int i = 10; i < 2; i+=3; @inner) {\n"
+    "        int k = i + j;\n"
+    "    }\n"
+    "  }\n"
+    "}\n"
+  );
+
+  parseBadOKLSource(
+    "@kernel void foo() {\n"
+    "  for (int o = 0; o < 2; ++o; @outer) {\n"
+    "    for (int i = 10; i > 11; i-=3; @inner) {\n"
+    "        int k = i + j;\n"
+    "    }\n"
+    "  }\n"
+    "}\n"
+  );
+}
+
+void testInfiniteLoops() {
+
+  parseBadOKLSource(
+    "@kernel void foo() {\n"
+    "  for (int o = 0; o < 2; ++o; @outer) {\n"
+    "    for (int i = 0; i < 2; i-=5; @inner) {\n"
+    "        int k = i + j;\n"
+    "    }\n"
+    "  }\n"
+    "}\n"
+  );
+
+  parseBadOKLSource(
+    "@kernel void foo() {\n"
+    "  for (int o = 0; o < 2; ++o; @outer) {\n"
+    "    for (int i = 2; i > 2=0; i+=5; @inner) {\n"
+    "        int k = i + j;\n"
+    "    }\n"
+    "  }\n"
+    "}\n"
+  );
+
+}
+
+void testMaxInnerDims() {
+  parseBadOKLSource(
+    "@kernel void foo(const int& N) {\n"
+    "  @max_inner_dims(0)\n"
+    "  for (int o = 0; o < 2; ++o; @outer) {\n"
+    "    for (int i = 0; i < N; ++i; @inner) {\n"
+    "        int k = i + j;\n"
     "    }\n"
     "  }\n"
     "}\n"


### PR DESCRIPTION
## Description

Closes #567.

- Ensure that only positive values are passes to `@max_inner_dims`
- Check for empty and infinite loops during translation of OKL for loops
