### PR TITLE
Feature ocl device functions

### DIFF
--- a/examples/cpp/30_device_function/CMakeLists.txt
+++ b/examples/cpp/30_device_function/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(EXAMPLE_NAME "device_function")
+compile_cpp_example_with_modes(${EXAMPLE_NAME} main.cpp)
+
+add_custom_target(cpp_example_${EXAMPLE_NAME}_okl ALL COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/addVectors.okl addVectors.okl)
+add_dependencies(examples_cpp_${EXAMPLE_NAME} cpp_example_${EXAMPLE_NAME}_okl)

--- a/examples/cpp/30_device_function/Makefile
+++ b/examples/cpp/30_device_function/Makefile
@@ -1,0 +1,30 @@
+
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifndef OCCA_DIR
+  include $(PROJ_DIR)/../../../scripts/build/Makefile
+else
+  include ${OCCA_DIR}/scripts/build/Makefile
+endif
+
+#---[ COMPILATION ]-------------------------------
+headers = $(wildcard $(incPath)/*.hpp) $(wildcard $(incPath)/*.tpp)
+sources = $(wildcard $(srcPath)/*.cpp)
+
+objects  = $(subst $(srcPath)/,$(objPath)/,$(sources:.cpp=.o))
+
+executables: ${PROJ_DIR}/main
+
+${PROJ_DIR}/main: $(objects) $(headers) ${PROJ_DIR}/main.cpp
+	$(compiler) $(compilerFlags) -o ${PROJ_DIR}/main $(flags) $(objects) ${PROJ_DIR}/main.cpp $(paths) $(linkerFlags)
+	@if which install_name_tool > /dev/null 2>&1; then \
+		install_name_tool -add_rpath "${OCCA_DIR}/lib" ${PROJ_DIR}/main; \
+	fi
+
+$(objPath)/%.o:$(srcPath)/%.cpp $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(srcPath)/,$(incPath)/,$(<:.cpp=.tpp)))
+	$(compiler) $(compilerFlags) -o $@ $(flags) -c $(paths) $<
+
+clean:
+	rm -f $(objPath)/*;
+	rm -f ${PROJ_DIR}/main;
+#=================================================

--- a/examples/cpp/30_device_function/README.md
+++ b/examples/cpp/30_device_function/README.md
@@ -1,0 +1,28 @@
+# Example: Add Vectors
+
+A 'Hello World' example showing the basics
+
+- Creating an OCCA device
+- Allocating and setting memory
+- Building a kernel (function that runs on the device)
+
+# Compiling the Example
+
+```bash
+make
+```
+
+## Usage
+
+```
+> ./main --help
+
+Usage: ./main [OPTIONS]
+
+Example adding two vectors
+
+Options:
+  -d, --device     Device properties (default: "{mode: 'Serial'}")
+  -h, --help       Print usage
+  -v, --verbose    Compile kernels in verbose mode
+```

--- a/examples/cpp/30_device_function/addVectors.okl
+++ b/examples/cpp/30_device_function/addVectors.okl
@@ -1,0 +1,28 @@
+float add(const float* a,
+          int i,
+          const float* b,
+          int j) {
+  return a[i] + b[j];
+}
+
+#define BLOCK_SIZE 4
+
+@kernel 
+void addVectors(const int N,
+                const float* a,
+                const float* b,
+                float *ab) {
+
+  @outer
+  for(int i=0; i < N; i+=BLOCK_SIZE) {
+    @shared float s_b[BLOCK_SIZE];
+    const float* g_a = a;
+    @inner
+    for(int j=0; j < BLOCK_SIZE; ++j) {
+      s_b[j] = b[i+j];
+      @barrier;
+
+      ab[i+j] = add(g_a,i+j,s_b,j);
+    }
+  }
+}

--- a/examples/cpp/30_device_function/main.cpp
+++ b/examples/cpp/30_device_function/main.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <vector>
+#include <occa.hpp>
+
+//---[ Internal Tools ]-----------------
+// Note: These headers are not officially supported
+//       Please don't rely on it outside of the occa examples
+#include <occa/internal/utils/cli.hpp>
+#include <occa/internal/utils/testing.hpp>
+//======================================
+
+occa::json parseArgs(int argc, const char **argv);
+
+int main(int argc, const char **argv) {
+  occa::json args = parseArgs(argc, argv);
+
+  int entries = 12;
+
+  std::vector<float> a(entries);
+  std::vector<float> b(entries);
+  std::vector<float> ab(entries);
+
+  for (int i = 0; i < entries; ++i) {
+    a[i]  = i;
+    b[i]  = 1 - i;
+    ab[i] = 0;
+  }
+
+  occa::device device(args["options/device"].toString());
+
+  auto o_a = device.malloc<float>(entries);
+  auto o_b = device.malloc<float>(entries);
+  auto o_ab = device.malloc<float>(entries);
+
+  o_a.copyFrom(a.data());
+  o_b.copyFrom(b.data());
+
+  auto addVectors = device.buildKernel("addVectors.okl","addVectors");
+  addVectors(entries, o_a, o_b, o_ab);
+  o_ab.copyTo(ab.data());
+
+  for (int i = 0; i < entries; ++i) {
+    std::cout << i << ": " << ab[i] << '\n';
+  }
+  for (int i = 0; i < entries; ++i) {
+    if (!occa::areBitwiseEqual(ab[i], a[i] + b[i])) {
+      throw 1;
+    }
+  }
+
+  return 0;
+}
+
+occa::json parseArgs(int argc, const char **argv) {
+  occa::cli::parser parser;
+  parser
+    .withDescription(
+      "Example adding two vectors"
+    )
+    .addOption(
+      occa::cli::option('d', "device",
+                        "Device properties (default: \"{mode: 'Serial'}\")")
+      .withArg()
+      .withDefaultValue("{mode: 'Serial'}")
+    )
+    .addOption(
+      occa::cli::option('v', "verbose",
+                        "Compile kernels in verbose mode")
+    );
+
+  occa::json args = parser.parseArgs(argc, argv);
+  occa::settings()["kernel/verbose"] = args["options/verbose"];
+
+  return args;
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(14_cuda_interop)
 
 add_subdirectory(18_nonblocking_streams)
 add_subdirectory(20_native_dpcpp_kernel)
+add_subdirectory(30_device_function)
 
 # Don't force-compile OpenGL examples
 # add_subdirectory(16_finite_difference)

--- a/src/occa/internal/lang/modes/opencl.hpp
+++ b/src/occa/internal/lang/modes/opencl.hpp
@@ -11,8 +11,7 @@ namespace occa {
         qualifier_t constant;
         qualifier_t kernel;
         qualifier_t local;
-        // Hack until code-transformation API is done
-        static qualifier_t global;
+        qualifier_t global;
 
         openclParser(const occa::json &settings_ = occa::json());
 
@@ -34,16 +33,11 @@ namespace occa {
         void updateConstToConstant();
 
         void setLocalQualifiers();
-        static bool sharedVariableMatcher(exprNode &expr);
 
         void setGlobalQualifiers();
-        static void updateGlobalVariables(statement_t *smnt);
-        static void addGlobalToFunctionArgs(function_t &func);
-        static void addGlobalToVariable(variable_t &var);
 
-        static void updateScopeStructVariables(statement_t *smnt);
-        static void addStructToVariable(variable_t &var);
-        static void addStructToFunctionArgs(function_t &func);
+        void addStructToVariable(variable_t &var);
+        void addStructToFunctionArgs(function_t &func);
 
         void addBarriers();
 

--- a/src/occa/internal/modes/opencl/device.cpp
+++ b/src/occa/internal/modes/opencl/device.cpp
@@ -48,6 +48,12 @@ namespace occa {
         compilerFlags = (std::string) kernelProps["compiler_flags"];
       }
 
+      std::string ocl_c_ver = "2.0";
+      if (env::var("OCCA_OPENCL_C_VERSION").size()) {
+        ocl_c_ver = env::var("OCCA_OPENCL_C_VERSION");
+      }
+      compilerFlags += " -cl-std=CL" + ocl_c_ver;
+
       kernelProps["compiler_flags"] = compilerFlags;
     }
 


### PR DESCRIPTION
## Description

Closes #166 
Closes #241

- Default to OpenCL C v2.0 to use generic address space
- Add environment variable `OCCA_OPENCL_C_VERSION` to override this option:
   - E.g., `OCCA_OPENCL_C_VERSION="3.0"` would cause the compiler flag `-cl-std=CL3.0` to be added