### PR TITLE
Enable math functions

### DIFF
--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -96,7 +96,7 @@ namespace occa
         root.addFirst(
             *(new directiveStatement(
                 &root,
-                directiveToken(root.source->origin, "include <CL/sycl.hpp>"))));
+                directiveToken(root.source->origin, "include <CL/sycl.hpp>\n using namespace sycl;\n"))));
       }
 
       void dpcppParser::addExtensions()

--- a/tests/src/math/fpMath.cpp
+++ b/tests/src/math/fpMath.cpp
@@ -1,0 +1,123 @@
+#include <iostream>
+#include <vector>
+
+#include "occa.hpp"
+
+std::vector<std::string> arg_types = {"float","double"};
+
+std::string unary_args = "x";
+std::string binary_args = "x,y";
+std::string ternary_args = "x,y,z";
+
+std::vector<std::string> unary_functions = {
+  "fabs",
+  "sqrt",
+  "cbrt",
+  "cos",
+  "sin",
+  "tan",
+  "acos",
+  "asin",
+  "atan",
+  "cosh",
+  "sinh",
+  "tanh",
+  "acosh",
+  "asinh",
+  "atanh",
+  "exp",
+  "exp2",
+  "exp10",
+  "log",
+  "log2",
+  "log10"
+};
+
+std::vector<std::string> binary_functions = {
+  "fmax",
+  "fmin",
+  "hypot",
+  "pow"
+};
+
+std::vector<std::string> ternary_functions = {"fma"};
+
+std::string kernel_front_half =
+"@kernel\n"
+"void f() {\n"
+"  @outer\n"
+"  for (int b=0; b<1; ++b) {\n"
+"    @inner\n"
+"    for (int t=0; t<1; ++t) {\n"
+;
+
+std::string kernel_back_half =
+"    }\n"
+"  }\n"
+"}\n"
+;
+
+void testUnaryFunctions(const occa::device& d) {
+  for (auto fp_type : arg_types) {
+    std::string arg_decl = 
+      "        " + fp_type + " " + unary_args + ";\n";
+    for(auto func : unary_functions) {
+      std::string function_call = 
+        "        " + func + "(" + unary_args + ");\n";
+      std::string kernel_src = 
+        kernel_front_half + arg_decl + function_call +kernel_back_half;
+
+      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+    }
+  }
+}
+
+void testBinaryFunctions(const occa::device& d) {
+  for (auto fp_type : arg_types) {
+    std::string arg_decl = 
+      "        " + fp_type + " " + binary_args + ";\n";
+    for(auto func : binary_functions) {
+      std::string function_call = 
+        "        " + func + "(" + binary_args + ");\n";
+      std::string kernel_src = 
+        kernel_front_half + arg_decl + function_call +kernel_back_half;
+
+      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+    }
+  }
+}
+
+void testTernaryFunctions(const occa::device& d) {
+  for (auto fp_type : arg_types) {
+    std::string arg_decl = 
+      "        " + fp_type + " " + ternary_args + ";\n";
+    for(auto func : ternary_functions) {
+      std::string function_call = 
+        "        " + func + "(" + ternary_args + ");\n";
+      std::string kernel_src = 
+        kernel_front_half + arg_decl + function_call +kernel_back_half;
+
+      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+    }
+  }
+}
+
+int main() {
+  std::vector<occa::device> devices = {
+    occa::device({{"mode", "Serial"}}),
+    occa::device({{"mode", "OpenMP"}}),
+    occa::device({{"mode", "CUDA"},{"device_id", 0}}),
+    occa::device({{"mode", "HIP"},{"device_id", 0}}),
+    occa::device({{"mode", "OpenCL"},{"platform_id",0},{"device_id", 0}}),
+    occa::device({{"mode", "dpcpp"},{"platform_id",0},{"device_id", 0}})
+  };
+
+  for(auto &d : devices) {
+    std::cout << "Testing mode: " << d.mode() << "\n";
+    testUnaryFunctions(d);
+    testBinaryFunctions(d);
+    testTernaryFunctions(d);
+  }
+
+  return 0;
+}

--- a/tests/src/math/fpMath.cpp
+++ b/tests/src/math/fpMath.cpp
@@ -39,18 +39,18 @@ std::vector<std::string> binary_functions = {
 std::vector<std::string> ternary_functions = {"fma"};
 
 std::string kernel_front_half =
-"@kernel\n"
-"void f() {\n"
-"  @outer\n"
-"  for (int b=0; b<1; ++b) {\n"
-"    @inner\n"
-"    for (int t=0; t<1; ++t) {\n"
+"@kernel \n"
+"void f(const int dummy_arg) { \n"
+"  @outer \n"
+"  for (int b=0; b<1; ++b) { \n"
+"    @inner \n"
+"    for (int t=0; t<1; ++t) { \n"
 ;
 
 std::string kernel_back_half =
-"    }\n"
-"  }\n"
-"}\n"
+"    } \n"
+"  } \n"
+"} \n"
 ;
 
 void testUnaryFunctions(const occa::device& d) {

--- a/tests/src/math/fpMath.cpp
+++ b/tests/src/math/fpMath.cpp
@@ -26,11 +26,7 @@ std::vector<std::string> unary_functions = {
   "asinh",
   "atanh",
   "exp",
-  "exp2",
-  "exp10",
-  "log",
-  "log2",
-  "log10"
+  "log"
 };
 
 std::vector<std::string> binary_functions = {
@@ -63,7 +59,7 @@ void testUnaryFunctions(const occa::device& d) {
       "        " + fp_type + " " + unary_args + ";\n";
     for(auto func : unary_functions) {
       std::string function_call = 
-        "        " + func + "(" + unary_args + ");\n";
+        "        " + fp_type + " w = " + func + "(" + unary_args + ");\n";
       std::string kernel_src = 
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
@@ -78,7 +74,7 @@ void testBinaryFunctions(const occa::device& d) {
       "        " + fp_type + " " + binary_args + ";\n";
     for(auto func : binary_functions) {
       std::string function_call = 
-        "        " + func + "(" + binary_args + ");\n";
+        "        " + fp_type + " w = " + func + "(" + binary_args + ");\n";
       std::string kernel_src = 
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
@@ -93,7 +89,7 @@ void testTernaryFunctions(const occa::device& d) {
       "        " + fp_type + " " + ternary_args + ";\n";
     for(auto func : ternary_functions) {
       std::string function_call = 
-        "        " + func + "(" + ternary_args + ");\n";
+        "        " + fp_type + " w = " + func + "(" + ternary_args + ");\n";
       std::string kernel_src = 
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 

--- a/tests/src/math/intMath.cpp
+++ b/tests/src/math/intMath.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <vector>
+
+#include "occa.hpp"
+
+std::vector<std::string> arg_types = {"int"};
+
+std::string unary_args = "x";
+std::string binary_args = "x,y";
+
+std::vector<std::string> unary_functions = {"abs"};
+
+std::vector<std::string> binary_functions = {"max","min"};
+
+std::string kernel_front_half =
+"@kernel\n"
+"void f() {\n"
+"  @outer\n"
+"  for (int b=0; b<1; ++b) {\n"
+"    @inner\n"
+"    for (int t=0; t<1; ++t) {\n"
+;
+
+std::string kernel_back_half =
+"    }\n"
+"  }\n"
+"}\n"
+;
+
+void testUnaryFunctions(const occa::device& d) {
+  for (auto fp_type : arg_types) {
+    std::string arg_decl = 
+      "        " + fp_type + " " + unary_args + ";\n";
+    for(auto func : unary_functions) {
+      std::string function_call = 
+        "        " + func + "(" + unary_args + ");\n";
+      std::string kernel_src = 
+        kernel_front_half + arg_decl + function_call +kernel_back_half;
+
+      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+    }
+  }
+}
+
+void testBinaryFunctions(const occa::device& d) {
+  for (auto fp_type : arg_types) {
+    std::string arg_decl = 
+      "        " + fp_type + " " + binary_args + ";\n";
+    for(auto func : binary_functions) {
+      std::string function_call = 
+        "        " + func + "(" + binary_args + ");\n";
+      std::string kernel_src = 
+        kernel_front_half + arg_decl + function_call +kernel_back_half;
+
+      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+    }
+  }
+}
+
+int main() {
+  std::vector<occa::device> devices = {
+    occa::device({{"mode", "Serial"}}),
+    occa::device({{"mode", "OpenMP"}}),
+    occa::device({{"mode", "CUDA"},{"device_id", 0}}),
+    occa::device({{"mode", "HIP"},{"device_id", 0}}),
+    occa::device({{"mode", "OpenCL"},{"platform_id",0},{"device_id", 0}}),
+    occa::device({{"mode", "dpcpp"},{"platform_id",0},{"device_id", 0}})
+  };
+
+  for(auto &d : devices) {
+    std::cout << "Testing mode: " << d.mode() << "\n";
+    testUnaryFunctions(d);
+    testBinaryFunctions(d);
+  }
+
+  return 0;
+}

--- a/tests/src/math/intMath.cpp
+++ b/tests/src/math/intMath.cpp
@@ -13,28 +13,28 @@ std::vector<std::string> unary_functions = {"abs"};
 std::vector<std::string> binary_functions = {"max","min"};
 
 std::string kernel_front_half =
-"@kernel\n"
-"void f() {\n"
-"  @outer\n"
-"  for (int b=0; b<1; ++b) {\n"
-"    @inner\n"
-"    for (int t=0; t<1; ++t) {\n"
+"@kernel \n"
+"void f(const int dummy_arg) { \n"
+"  @outer \n"
+"  for (int b=0; b<1; ++b) { \n"
+"    @inner \n"
+"    for (int t=0; t<1; ++t) { \n"
 ;
 
 std::string kernel_back_half =
-"    }\n"
-"  }\n"
-"}\n"
+"    } \n"
+"  } \n"
+"} \n"
 ;
 
 void testUnaryFunctions(const occa::device& d) {
-  for (auto int_type : arg_types) {
-    std::string arg_decl = 
-      "        " + int_type + " " + unary_args + ";\n";
-    for(auto func : unary_functions) {
-      std::string function_call = 
-        "        " + int_type + " w = " + func + "(" + unary_args + ");\n";
-      std::string kernel_src = 
+  for (auto&& int_type : arg_types) {
+    const std::string arg_decl = 
+      "        " + int_type + " " + unary_args + "; \n";
+    for (auto&& func : unary_functions) {
+      const std::string function_call = 
+        "        " + int_type + " w = " + func + "(" + unary_args + "); \n";
+      const std::string kernel_src = 
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
       occa::kernel k = d.buildKernelFromString(kernel_src,"f");
@@ -43,13 +43,13 @@ void testUnaryFunctions(const occa::device& d) {
 }
 
 void testBinaryFunctions(const occa::device& d) {
-  for (auto int_type : arg_types) {
-    std::string arg_decl = 
-      "        " + int_type + " " + binary_args + ";\n";
-    for(auto func : binary_functions) {
-      std::string function_call = 
-        "        " + int_type + " w = " + func + "(" + binary_args + ");\n";
-      std::string kernel_src = 
+  for (auto&& int_type : arg_types) {
+    const std::string arg_decl = 
+      "        " + int_type + " " + binary_args + "; \n";
+    for (auto&& func : binary_functions) {
+      const std::string function_call = 
+        "        " + int_type + " w = " + func + "(" + binary_args + "); \n";
+      const std::string kernel_src = 
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
       occa::kernel k = d.buildKernelFromString(kernel_src,"f");

--- a/tests/src/math/intMath.cpp
+++ b/tests/src/math/intMath.cpp
@@ -28,12 +28,12 @@ std::string kernel_back_half =
 ;
 
 void testUnaryFunctions(const occa::device& d) {
-  for (auto fp_type : arg_types) {
+  for (auto int_type : arg_types) {
     std::string arg_decl = 
-      "        " + fp_type + " " + unary_args + ";\n";
+      "        " + int_type + " " + unary_args + ";\n";
     for(auto func : unary_functions) {
       std::string function_call = 
-        "        " + func + "(" + unary_args + ");\n";
+        "        " + int_type + " w = " + func + "(" + unary_args + ");\n";
       std::string kernel_src = 
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
@@ -43,12 +43,12 @@ void testUnaryFunctions(const occa::device& d) {
 }
 
 void testBinaryFunctions(const occa::device& d) {
-  for (auto fp_type : arg_types) {
+  for (auto int_type : arg_types) {
     std::string arg_decl = 
-      "        " + fp_type + " " + binary_args + ";\n";
+      "        " + int_type + " " + binary_args + ";\n";
     for(auto func : binary_functions) {
       std::string function_call = 
-        "        " + func + "(" + binary_args + ");\n";
+        "        " + int_type + " w = " + func + "(" + binary_args + ");\n";
       std::string kernel_src = 
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 


### PR DESCRIPTION
## Description

Closes #115

- Add tests for common math functions
- Include `using namespace sycl;` when translating OKL kernels with dpcpp mode

### Todo

- [x] Test CUDA mode
- [x] Test HIP mode

