### PR TITLE
Fix segfault when using --verbose flag when running examples with Intel mpiexec

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,9 @@
 macro(add_test_with_mode_and_nranks exe mode device nranks)
   if (${nranks} GREATER 1)
-    add_test(NAME ${exe}-${mode} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${nranks} ./${exe} --verbose --device "${device}")
+    # Passing the --verbose flag to our executable has a bad interaction with the mpiexec command provided by (at least)
+    # Intel(R) MPI Library for Linux* OS, Version 2021.2 Build 20210302: it causes a segmentation fault in MPI_Init.
+    # None of our MPI tests actually use the flag, so don't pass it.
+    add_test(NAME ${exe}-${mode} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${nranks} ./${exe} --device "${device}")
   else()
     add_test(NAME ${exe}-${mode} COMMAND ./${exe} --verbose --device "${device}")
   endif()


### PR DESCRIPTION
## Description

This is a bit of a weird one...

Since updating to the Intel 2021.2 compiler stack (with Intel MPI), mpi-related tests started failing with a segmentation fault in MPI_Init.

The '--verbose' flag passed to our example executables from CTest seems to have a bad interaction with mpiexec: if we also pass '--verbose' (or '-verbose') to mpiexec the example runs wtihout a crash. Or if we leave out our own '--verbose'.

If we use mpirun instead of mpiexec the problem also goes away, but CMake sets MPIEXEC_EXECUTABLE to mpiexec, so it's better to keep it that way.

Also, something like 

`/apps/EasyBuild/software/impi/2021.2.0-intel-compilers-2021.2.0/mpi/2021.2.0/bin/mpiexec --verbose -n 2 ./examples_fortran_10_mpi --verbose --device "{"mode": "OpenMP"}"` works, but
`bash -c '/apps/EasyBuild/software/impi/2021.2.0-intel-compilers-2021.2.0/mpi/2021.2.0/bin/mpiexec --verbose -n 2 ./examples_fortran_10_mpi --verbose --device "{"mode": "OpenMP"}"'` crashes.

Luckily, none of the mpi-related examples actually parse '--verbose', so we can actually leave it out without any detrimental effects.

If anyone has a more principled fix that would be nice, but this is what I have currently to fix our tests.