### PR TITLE
[JSON] Fix a json constructor not setting the type

### DIFF
--- a/src/types/json.cpp
+++ b/src/types/json.cpp
@@ -10,6 +10,7 @@ namespace occa {
 
   json::json(const std::string &name,
              const primitive &value) {
+    type = object_;
     (*this)[name] = value;
   }
 


### PR DESCRIPTION
## Description

Fix an occa::json constructor not setting the type member. 

This bug would cause the following line to fail:
```cpp
occa::json props("name", value);
```
to fail, while the alternative code path: 
```cpp
occa::json props;
props["name"] = value;
```
works as intended. 

<!-- Thank you for contributing! -->
