### PR TITLE
Fix prepending of qualifiers (addFirst)

### DIFF
--- a/src/occa/internal/lang/qualifier.cpp
+++ b/src/occa/internal/lang/qualifier.cpp
@@ -273,8 +273,8 @@ namespace occa {
       }
 
       qualifiers.push_back(qualifiers[count - 1]);
-      for (int i = 0; i < (count - 1); ++i) {
-        qualifiers[i + 1] = qualifiers[i];
+      for (int i = (count - 1); i > 0; --i) {
+        qualifiers[i] = qualifiers[i - 1];
       }
       qualifiers[0] = qualifier;
       return *this;


### PR DESCRIPTION
## Description

The existing qualifiers were shuffled around incorrectly:

For example (original situation, forward loop):

```
inline const long
inline const long long          # qualifiers.push_back(qualifiers[count - 1]);
inline inline long long         # qualifiers[1] = qualifiers[0];
inline inline inline long       # qualifiers[2] = qualifiers[1];
__device__ inline inline long   # qualifiers[0] = qualifier;
```

Should be (new situation, backward loop):

```
inline const long
inline const long long          # qualifiers.push_back(qualifiers[count - 1]);
inline const const long         # qualifiers[2] = qualifiers[1];
inline inline const long        # qualifiers[1] = qualifiers[0];
__device__ inline const long    # qualifiers[0] = qualifier;
```