### PR TITLE
Fix cache write races when transformking OKL + Serial/OpenMP kernels

### DIFF
--- a/src/occa/internal/io/cache.cpp
+++ b/src/occa/internal/io/cache.cpp
@@ -79,9 +79,15 @@ namespace occa {
         std::stringstream ss;
         ss << header << '\n'
            << io::read(expFilename);
-        io::write(sourceFile, ss.str());
+        io::stageFile(
+          sourceFile,
+          true,
+          [&](const std::string &tempFilename) -> bool {
+            io::write(tempFilename, ss.str());
+            return true;
+          }
+        );
       }
-
       return sourceFile;
     }
 

--- a/src/occa/internal/lang/modes/withLauncher.cpp
+++ b/src/occa/internal/lang/modes/withLauncher.cpp
@@ -24,7 +24,14 @@ namespace occa {
       }
 
       void withLauncher::writeLauncherSourceToFile(const std::string &filename) const {
-        launcherParser.writeToFile(filename);
+        io::stageFile(
+          filename,
+          true,
+          [&](const std::string &tempFilename) -> bool {
+            launcherParser.writeToFile(tempFilename);
+            return true;
+          }
+        );
       }
       //================================
 


### PR DESCRIPTION
## Description

When using OKL + OpenMP code in an MPI-enabled application I started seeing intermittent "Unable to transform OKL kernel" errors, with some indication that some ranks were trying to read incomplete/corrupted intermediate files.

In particular, this piece of code in `src/occa/internal/modes/serial/device.cpp` seemed suspect:

```
[...]
        // Cache raw origin
        sourceFilename = (
          io::cacheFile(filename,
                        rawSourceFile,
                        kernelHash,
                        assembleKernelHeader(kernelProps))
        );

        if (compilingOkl) {
          const std::string outputFile = hashDir + kc::sourceFile;
          bool valid = parseFile(sourceFilename,
                                 outputFile,
                                 kernelProps,
                                 metadata);
[...]
```

The first commit adds a `stageFile` wrapper around the file write inside `io::cacheFile`, which fixes the issue for me.
The second commit is an earlier attempt at finding similar issues and it seems safer to have that wrapped as well (but I don't think I needed it to fix the issue).

Open question: personally I find that the function name `cacheFile` does not communicate well that it is actually potentially writing a file, especially since it returns a string. Do you think the name could be made more clear?

EDIT: I think the issue for me is that I keep reading `cache` in `cacheFile` as part of a noun, instead of a verb. So e.g. `parseFile` feels more clear to me, but maybe that's all in my head.