### PR TITLE
[SYS] Fix frequency units

### DIFF
--- a/src/occa/internal/utils/sys.cpp
+++ b/src/occa/internal/utils/sys.cpp
@@ -545,7 +545,7 @@ namespace occa {
       const float frequency = parseFloat(
         getSystemInfoField(systemInfo, "CPU max MHz")
       );
-      return (udim_t) (frequency * 1e3);
+      return (udim_t) (frequency * 1e6);
 
 #elif (OCCA_OS == OCCA_MACOS_OS)
       const float frequency = parseFloat(


### PR DESCRIPTION
## Description

CPU frequency displays the wrong units in `occa info`. The frequency is parsed from `lscpu` in MHz was converting to KHz, but the `stringifyFrequency` routine assumes it is in Hz. 



<!-- Thank you for contributing! -->
