### PR TITLE
Add kernel/require_occa property to control including and linking occa into kernels

### DIFF
--- a/examples/cpp/18_nonblocking_streams/main.cpp
+++ b/examples/cpp/18_nonblocking_streams/main.cpp
@@ -27,6 +27,7 @@ int main(int argc, const char **argv) {
   occa::json kernelProps({
     {"defines/block", block},
     {"defines/group", group},
+    {"serial/include_std", true},
   });
   occa::kernel powerOfPi = occa::buildKernel("powerOfPi.okl",
                                              "powerOfPi",

--- a/src/loops/typelessForLoop.cpp
+++ b/src/loops/typelessForLoop.cpp
@@ -34,6 +34,8 @@ namespace occa {
       loopScope.device = device;
     }
 
+    loopScope.props["kernel/include_occa"] = true;
+
     const int outerIterationCount = (int) outerIterations.size();
     const int innerIterationCount = (int) innerIterations.size();
 

--- a/src/occa/internal/lang/modes/serial.cpp
+++ b/src/occa/internal/lang/modes/serial.cpp
@@ -33,11 +33,11 @@ namespace occa {
 
       void serialParser::setupHeaders() {
         strVector headers;
-        const bool includeOcca = settings.get("kernel/include_occa", true);
+        const bool includeOcca = settings.get("kernel/include_occa", false);
         if (includeOcca) {
           headers.push_back("include <occa.hpp>\n");
         }
-        const bool includingStd = settings.get("serial/include_std", true);
+        const bool includingStd = settings.get("serial/include_std", false);
         if (includingStd) {
           headers.push_back("include <stdint.h>");
           headers.push_back("include <cstdlib>");

--- a/src/occa/internal/lang/modes/serial.cpp
+++ b/src/occa/internal/lang/modes/serial.cpp
@@ -33,8 +33,11 @@ namespace occa {
 
       void serialParser::setupHeaders() {
         strVector headers;
+        const bool includeOcca = settings.get("kernel/include_occa", true);
+        if (includeOcca) {
+          headers.push_back("include <occa.hpp>\n");
+        }
         const bool includingStd = settings.get("serial/include_std", true);
-        headers.push_back("include <occa.hpp>\n");
         if (includingStd) {
           headers.push_back("include <stdint.h>");
           headers.push_back("include <cstdlib>");
@@ -50,7 +53,9 @@ namespace occa {
             if (includingStd) {
               header += "\nusing namespace std;";
             }
-            header += "\nusing namespace occa;";
+            if (includeOcca) {
+              header += "\nusing namespace occa;";
+            }
           }
           directiveToken token(root.source->origin,
                                header);

--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -111,6 +111,8 @@ namespace occa {
       return (
         occa::hash(props["compiler"])
         ^ props["compiler_flags"]
+        ^ props["kernel/include_occa"]
+        ^ props["kernel/link_occa"]
       );
     }
 
@@ -290,6 +292,9 @@ namespace occa {
         sys::addCompilerLibraryFlags(compilerFlags);
       }
 
+      const bool includeOcca = kernelProps.get("kernel/include_occa", true);
+      const bool linkOcca = kernelProps.get("kernel/link_occa", false);
+
       //---[ Compiling Command ]--------
       std::stringstream command;
       command << allProps["compiler"]
@@ -298,10 +303,15 @@ namespace occa {
 #if (OCCA_OS == OCCA_WINDOWS_OS)
               << " -D OCCA_OS=OCCA_WINDOWS_OS -D _MSC_VER=1800"
 #endif
-              << " -I"        << env::OCCA_DIR << "include"
-              << " -I"        << env::OCCA_INSTALL_DIR << "include"
-              << " -L"        << env::OCCA_INSTALL_DIR << "lib -locca"
-              << " -x cu " << sourceFilename
+          ;
+      if (includeOcca) {
+        command << " -I"        << env::OCCA_DIR << "include"
+                << " -I"        << env::OCCA_INSTALL_DIR << "include";
+      }
+      if (linkOcca) {
+        command << " -L"        << env::OCCA_INSTALL_DIR << "lib -locca";
+      }
+      command << " -x cu " << sourceFilename
               << " -o "    << binaryFilename
               << " 2>&1";
 

--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -111,7 +111,6 @@ namespace occa {
       return (
         occa::hash(props["compiler"])
         ^ props["compiler_flags"]
-        ^ props["compiler_env_script"]
       );
     }
 

--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -292,7 +292,7 @@ namespace occa {
         sys::addCompilerLibraryFlags(compilerFlags);
       }
 
-      const bool includeOcca = kernelProps.get("kernel/include_occa", true);
+      const bool includeOcca = kernelProps.get("kernel/include_occa", false);
       const bool linkOcca = kernelProps.get("kernel/link_occa", false);
 
       //---[ Compiling Command ]--------

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -110,6 +110,8 @@ namespace occa {
         ^ props["compiler_flags"]
         ^ props["compiler_env_script"]
         ^ props["hipcc_compiler_flags"]
+        ^ props["kernel/include_occa"]
+        ^ props["kernel/link_occa"]
       );
     }
 
@@ -287,14 +289,20 @@ namespace occa {
 #else
               << " -f=\\\"" << compilerFlags << "\\\""
 #endif
-              << ' ' << hipccCompilerFlags
+              << ' ' << hipccCompilerFlags;
 #if defined(__HIP_PLATFORM_NVCC___) || (HIP_VERSION >= 305)
-              << " -I"        << env::OCCA_DIR << "include"
-              << " -I"        << env::OCCA_INSTALL_DIR << "include"
+      const bool includeOcca = kernelProps.get("kernel/include_occa", true);
+      const bool linkOcca = kernelProps.get("kernel/link_occa", false);
+      if (includeOcca) {
+        command << " -I"        << env::OCCA_DIR << "include"
+                << " -I"        << env::OCCA_INSTALL_DIR << "include";
+      }
+      if (linkOcca) {
+            /* NC: hipcc doesn't seem to like linking a library in */
+              //<< " -L"        << env::OCCA_INSTALL_DIR << "lib -locca";
+      }
 #endif
-              /* NC: hipcc doesn't seem to like linking a library in */
-              //<< " -L"        << env::OCCA_INSTALL_DIR << "lib -locca"
-              << ' '    << sourceFilename
+      command << ' '    << sourceFilename
               << " -o " << binaryFilename
               << " 2>&1";
 

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -109,6 +109,7 @@ namespace occa {
         occa::hash(props["compiler"])
         ^ props["compiler_flags"]
         ^ props["compiler_env_script"]
+        ^ props["hipcc_compiler_flags"]
       );
     }
 

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -291,7 +291,7 @@ namespace occa {
 #endif
               << ' ' << hipccCompilerFlags;
 #if defined(__HIP_PLATFORM_NVCC___) || (HIP_VERSION >= 305)
-      const bool includeOcca = kernelProps.get("kernel/include_occa", true);
+      const bool includeOcca = kernelProps.get("kernel/include_occa", false);
       const bool linkOcca = kernelProps.get("kernel/link_occa", false);
       if (includeOcca) {
         command << " -I"        << env::OCCA_DIR << "include"

--- a/src/occa/internal/modes/serial/device.cpp
+++ b/src/occa/internal/modes/serial/device.cpp
@@ -39,6 +39,8 @@ namespace occa {
         ^ props["compiler_language"]
         ^ props["compiler_linker_flags"]
         ^ props["compiler_shared_flags"]
+        ^ props["include_occa"]
+        ^ props["link_occa"]
       );
     }
 
@@ -318,6 +320,9 @@ namespace occa {
         sys::addCompilerLibraryFlags(compilerFlags);
       }
 
+      const bool includeOcca = kernelProps.get("kernel/include_occa", true);
+      const bool linkOcca = kernelProps.get("kernel/link_occa", false);
+
       io::stageFile(
         binaryFilename,
         true,
@@ -326,11 +331,15 @@ namespace occa {
           command << compiler
                   << ' '    << compilerFlags
                   << ' '    << sourceFilename
-                  << " -o " << tempFilename
-                  << " -I"  << env::OCCA_DIR << "include"
-                  << " -I"  << env::OCCA_INSTALL_DIR << "include"
-                  << " -L"  << env::OCCA_INSTALL_DIR << "lib -locca"
-                  << ' '    << compilerLinkerFlags
+                  << " -o " << tempFilename;
+          if (includeOcca) {
+            command << " -I"  << env::OCCA_DIR << "include"
+                    << " -I"  << env::OCCA_INSTALL_DIR << "include";
+          }
+          if (linkOcca) {
+            command << " -L"  << env::OCCA_INSTALL_DIR << "lib -locca";
+          }
+          command << ' '    << compilerLinkerFlags
                   << " 2>&1"
                   << std::endl;
 #else
@@ -340,11 +349,13 @@ namespace occa {
                   << " /EHsc"
                   << " /wd4244 /wd4800 /wd4804 /wd4018"
                   << ' '       << compilerFlags
-                  << " /I"     << env::OCCA_DIR << "include"
-                  << " /I"     << env::OCCA_INSTALL_DIR << "include"
-                  << ' '       << sourceFilename
-                  << " /link " << env::OCCA_INSTALL_DIR << "lib/libocca.lib",
-                  << ' '       << compilerLinkerFlags
+          if (requireOcca) {
+            command << " /I"     << env::OCCA_DIR << "include"
+                    << " /I"     << env::OCCA_INSTALL_DIR << "include"
+                    << ' '       << sourceFilename
+                    << " /link " << env::OCCA_INSTALL_DIR << "lib/libocca.lib";
+          }
+          command << ' '       << compilerLinkerFlags
                   << " /OUT:"  << tempFilename
                   << std::endl;
 #endif

--- a/src/occa/internal/modes/serial/device.cpp
+++ b/src/occa/internal/modes/serial/device.cpp
@@ -320,8 +320,8 @@ namespace occa {
         sys::addCompilerLibraryFlags(compilerFlags);
       }
 
-      const bool includeOcca = kernelProps.get("kernel/include_occa", true);
-      const bool linkOcca = kernelProps.get("kernel/link_occa", false);
+      const bool includeOcca = kernelProps.get("kernel/include_occa", isLauncherKernel);
+      const bool linkOcca = kernelProps.get("kernel/link_occa", isLauncherKernel);
 
       io::stageFile(
         binaryFilename,

--- a/tests/src/c/kernel.cpp
+++ b/tests/src/c/kernel.cpp
@@ -87,7 +87,7 @@ void testRun() {
     occa::env::OCCA_DIR + "tests/files/argKernel.okl"
   );
   occaJson kernelProps = occaJsonParse(
-    "{type_validation: false}"
+    "{type_validation: false, serial: {include_std: true}}"
   );
   occaKernel argKernel = (
     occaBuildKernel(argKernelFile.c_str(),

--- a/tests/src/core/kernel.cpp
+++ b/tests/src/core/kernel.cpp
@@ -154,7 +154,8 @@ void testRun() {
   );
   occa::kernel argKernel = occa::buildKernel(argKernelFile,
                                              "argKernel",
-                                             {{"type_validation", false}});
+                                             {{"type_validation", false},
+                                              {"serial/include_std", true}});
 
   argKernel.setRunDims(occa::dim(1, 1, 1),
                        occa::dim(1, 1, 1));

--- a/tests/src/math/fpMath.cpp
+++ b/tests/src/math/fpMath.cpp
@@ -55,45 +55,48 @@ std::string kernel_back_half =
 
 void testUnaryFunctions(const occa::device& d) {
   for (auto fp_type : arg_types) {
-    std::string arg_decl = 
+    std::string arg_decl =
       "        " + fp_type + " " + unary_args + ";\n";
     for(auto func : unary_functions) {
-      std::string function_call = 
+      std::string function_call =
         "        " + fp_type + " w = " + func + "(" + unary_args + ");\n";
-      std::string kernel_src = 
+      std::string kernel_src =
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
-      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+      occa::kernel k = d.buildKernelFromString(kernel_src, "f",
+                                               {{"serial/include_std", true}});
     }
   }
 }
 
 void testBinaryFunctions(const occa::device& d) {
   for (auto fp_type : arg_types) {
-    std::string arg_decl = 
+    std::string arg_decl =
       "        " + fp_type + " " + binary_args + ";\n";
     for(auto func : binary_functions) {
-      std::string function_call = 
+      std::string function_call =
         "        " + fp_type + " w = " + func + "(" + binary_args + ");\n";
-      std::string kernel_src = 
+      std::string kernel_src =
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
-      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+      occa::kernel k = d.buildKernelFromString(kernel_src, "f",
+                                               {{"serial/include_std", true}});
     }
   }
 }
 
 void testTernaryFunctions(const occa::device& d) {
   for (auto fp_type : arg_types) {
-    std::string arg_decl = 
+    std::string arg_decl =
       "        " + fp_type + " " + ternary_args + ";\n";
     for(auto func : ternary_functions) {
-      std::string function_call = 
+      std::string function_call =
         "        " + fp_type + " w = " + func + "(" + ternary_args + ");\n";
-      std::string kernel_src = 
+      std::string kernel_src =
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
-      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+      occa::kernel k = d.buildKernelFromString(kernel_src, "f",
+                                               {{"serial/include_std", true}});
     }
   }
 }

--- a/tests/src/math/intMath.cpp
+++ b/tests/src/math/intMath.cpp
@@ -29,30 +29,33 @@ std::string kernel_back_half =
 
 void testUnaryFunctions(const occa::device& d) {
   for (auto&& int_type : arg_types) {
-    const std::string arg_decl = 
+    const std::string arg_decl =
       "        " + int_type + " " + unary_args + "; \n";
     for (auto&& func : unary_functions) {
-      const std::string function_call = 
+      const std::string function_call =
         "        " + int_type + " w = " + func + "(" + unary_args + "); \n";
-      const std::string kernel_src = 
+      const std::string kernel_src =
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
-      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+      occa::kernel k = d.buildKernelFromString(kernel_src, "f",
+                                               {{"serial/include_std", true}});
     }
   }
 }
 
 void testBinaryFunctions(const occa::device& d) {
   for (auto&& int_type : arg_types) {
-    const std::string arg_decl = 
+    const std::string arg_decl =
       "        " + int_type + " " + binary_args + "; \n";
     for (auto&& func : binary_functions) {
-      const std::string function_call = 
+      const std::string function_call =
         "        " + int_type + " w = " + func + "(" + binary_args + "); \n";
-      const std::string kernel_src = 
+      const std::string kernel_src =
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
-      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+      occa::kernel k = d.buildKernelFromString(kernel_src, "f",
+                                               {{"serial/include_std", true},
+                                                {"kernel/include_occa", true}}); // For min/max
     }
   }
 }


### PR DESCRIPTION
## Description

Recently I have been debugging a segmentation fault in our code that seems to have been caused by transitive dependencies of occa. During this process I noticed that all kernels get linked to libocca and occa headers are `#include`d at the top of the kernel code. However, none of our kernels require anything from inside occa, so I think it would be nice to be able to control this. Not linking in occa speeds things up a little bit and potentially prevents unexpected behaviour.

This PR keeps the default behaviour as-is, but makes linking to occa, and `#include`(i)ng the occa headers and namespace opt-out per kernel. This seems to work well in our code at this moment. Is this something that seems generally useful enough to include?

Open questions: should we do some bikeshedding on the flag name and where should this new option be documented? And I'm not quite sure if the markdown files in `docs` should just be edited directly or if there is some kind of automation for that?
Remark: I have not been able to test with HIP, but the change looks straightforward enough (famous last words).

I also noticed some inconsistencies in how the kernelHash is calculated, based on what goes into the compiler invocation so this is a separate fix commit. It could be taken out of this PR if requested.
