### PR TITLE
[CMake] Add MPIEXEC_PREFLAGS and MPIEXEC_POSTFLAGS to examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(add_test_with_mode_and_nranks exe mode device nranks)
   if (${nranks} GREATER 1)
-    add_test(NAME ${exe}-${mode} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${nranks} ./${exe} --verbose --device "${device}")
+    add_test(NAME ${exe}-${mode} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${nranks} ${MPIEXEC_PREFLAGS} ./${exe} ${MPIEXEC_POSTFLAGS} --verbose --device "${device}")
   else()
     add_test(NAME ${exe}-${mode} COMMAND ./${exe} --verbose --device "${device}")
   endif()


### PR DESCRIPTION
## Description

This is recommended by CMake (https://cmake.org/cmake/help/latest/module/FindMPI.html#usage-of-mpiexec)
and allows some extra control for different MPI setups.

