### PR TITLE
Add C API to get CUDA/HIP arch version from device

### DIFF
--- a/include/occa/c/base.h
+++ b/include/occa/c/base.h
@@ -25,6 +25,10 @@ occaJson occaDeviceProperties();
 
 void occaFinish();
 
+void occaGetDeviceArchVersion(occaDevice device,
+                              int *archMajorVersion,
+                              int *archMinorVersion);
+
 occaStream occaCreateStream(occaJson props);
 
 occaStream occaGetStream();

--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -281,6 +281,19 @@ namespace occa {
      */
     const occa::json& properties() const;
 
+    /**
+     * @startDoc{getDeviceArchVersion}
+     *
+     * Description:
+     *   Returns the architecture version of a CUDA or HIP device.
+     *
+     * Returns:
+     *   The architecture version of a CUDA or HIP device.
+     *
+     * @endDoc
+     */
+    void getDeviceArchVersion(int *archMajorVersion, int *archMinorVersion);
+
     const occa::json& kernelProperties() const;
     occa::json kernelProperties(const occa::json &additionalProps) const;
 

--- a/src/c/base.cpp
+++ b/src/c/base.cpp
@@ -44,6 +44,12 @@ void occaFinish() {
   occa::finish();
 }
 
+void occaGetDeviceArchVersion(occaDevice device,
+                              int *archMajorVersion,
+                              int *archMinorVersion) {
+  (occa::c::device(device)).getDeviceArchVersion(archMajorVersion, archMinorVersion);
+}
+
 occaStream occaCreateStream(occaJson props) {
   occa::stream stream;
   if (occa::c::isDefault(props)) {

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -175,6 +175,19 @@ namespace occa {
     return modeDevice->properties;
   }
 
+  void device::getDeviceArchVersion(int *archMajorVersion, int *archMinorVersion) {
+    assertInitialized();
+    *archMajorVersion = 0;
+    *archMinorVersion = 0;
+    if (modeDevice->mode == "CUDA" || modeDevice->mode == "HIP") {
+      *archMajorVersion = (((occa::cuda::device*)modeDevice)->archMajorVersion);
+      *archMinorVersion = (((occa::cuda::device*)modeDevice)->archMinorVersion);
+    } else {
+      std::cout << "getDeviceArchVersion called with device mode = " <<
+          modeDevice->mode << "!\nOnly CUDA/HIP device mode is supported currently.\n";
+    }
+  }
+
   const occa::json& device::kernelProperties() const {
     assertInitialized();
     return (const occa::json&) modeDevice->properties["kernel"];

--- a/src/occa/internal/io/cache.cpp
+++ b/src/occa/internal/io/cache.cpp
@@ -79,9 +79,15 @@ namespace occa {
         std::stringstream ss;
         ss << header << '\n'
            << io::read(expFilename);
-        io::write(sourceFile, ss.str());
+        io::stageFile(
+          sourceFile,
+          true,
+          [&](const std::string &tempFilename) -> bool {
+            io::write(tempFilename, ss.str());
+            return true;
+          }
+        );
       }
-
       return sourceFile;
     }
 

--- a/src/occa/internal/lang/modes/withLauncher.cpp
+++ b/src/occa/internal/lang/modes/withLauncher.cpp
@@ -24,7 +24,14 @@ namespace occa {
       }
 
       void withLauncher::writeLauncherSourceToFile(const std::string &filename) const {
-        launcherParser.writeToFile(filename);
+        io::stageFile(
+          filename,
+          true,
+          [&](const std::string &tempFilename) -> bool {
+            launcherParser.writeToFile(tempFilename);
+            return true;
+          }
+        );
       }
       //================================
 


### PR DESCRIPTION
## Description

As discussed in the overtime of https://github.com/libocca/occa-taf/blob/main/meeting-notes/2022-06-29.md, this is an example of the kind of information that we would like to be available.
It punches through abstractions rather inelegantly so I'm not expecting this to be accepted as-is and I'll keep it as a draft to be used as input for future development?