### PR TITLE
[CMake] Remove redundant flags and properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,19 +259,9 @@ file(
   GLOB_RECURSE OCCA_SRC_cpp
   RELATIVE ${OCCA_SOURCE_DIR} "src/*.cpp")
 
-if(OCCA_OPENMP_ENABLED)
-  set_source_files_properties(${OCCA_SRC_cpp} PROPERTIES
-    COMPILE_FLAGS ${OpenMP_CXX_FLAGS})
-endif()
-
 if(ENABLE_FORTRAN)
   file(GLOB_RECURSE OCCA_SRC_f90
     RELATIVE ${OCCA_SOURCE_DIR} "src/*.f90")
-
-  if(OCCA_OPENMP_ENABLED)
-    set_source_files_properties(${OCCA_SRC_f90} PROPERTIES
-      COMPILE_FLAGS ${OpenMP_Fortran_FLAGS})
-  endif()
 
   install(CODE
     "file(GLOB public-modules ${CMAKE_Fortran_MODULE_DIRECTORY}/*.mod)\n

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ function(add_occa_test test_source)
     $<BUILD_INTERFACE:${OCCA_SOURCE_DIR}/src>)
 
   if (${test_source} MATCHES "typedefs.f90")
-    target_link_libraries(${cmake_test_target} libtypedefs_helper libocca ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+    target_link_libraries(${cmake_test_target} libtypedefs_helper)
   endif()
 
   add_test(


### PR DESCRIPTION
## Description

Small cleanup: I think these are redundant after https://github.com/libocca/occa/pull/533.