### PR TITLE
Feature device synchronization

### DIFF
--- a/include/occa/c/device.h
+++ b/include/occa/c/device.h
@@ -27,6 +27,8 @@ occaUDim_t occaDeviceMemoryAllocated(occaDevice device);
 
 void occaDeviceFinish(occaDevice device);
 
+void occaDeviceFinishAll(occaDevice device);
+
 bool occaDeviceHasSeparateMemorySpace(occaDevice device);
 
 //---[ Stream ]-------------------------

--- a/include/occa/c/stream.h
+++ b/include/occa/c/stream.h
@@ -1,0 +1,14 @@
+
+ifndef OCCA_C_STREAM_HEADER
+#define OCCA_C_STREAM_HEADER
+
+#include <occa/c/defines.h>
+#include <occa/c/types.h>
+
+OCCA_START_EXTERN_C
+
+void occaStreamFinish(occaStream stream);
+
+OCCA_END_EXTERN_C
+
+#endif

--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -349,12 +349,25 @@ namespace occa {
      * @startDoc{finish}
      *
      * Description:
-     *   Finishes any asynchronous operation queued up on the device, such as
-     *   [[async memory allocations|device.malloc]] or [[kernel calls|kernel.operator_parentheses]].
+     *   Waits for all asynchronous operations, such as
+     *   [[async memory allocations|device.malloc]] or [[kernel calls|kernel.operator_parentheses]],
+     *   submitted to the current stream on this device to complete.
      *
      * @endDoc
      */
     void finish();
+
+    /**
+     * @startDoc{finish}
+     *
+     * Description:
+     *   Waits for all asynchronous operations, such as
+     *   [[async memory allocations|device.malloc]] or [[kernel calls|kernel.operator_parentheses]],
+     *   submitted to all streams on this device to complete.
+     *
+     * @endDoc
+     */
+    void finishAll();
 
     /**
      * @startDoc{hasSeparateMemorySpace}

--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -355,7 +355,6 @@ namespace occa {
      *
      * @endDoc
      */
-    [[deprecated("Use `getStream().finish()` instead.")]]
     void finish();
 
     /**

--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -355,6 +355,7 @@ namespace occa {
      *
      * @endDoc
      */
+    [[deprecated("Use `getStream().finish()` instead.")]]
     void finish();
 
     /**

--- a/include/occa/core/stream.hpp
+++ b/include/occa/core/stream.hpp
@@ -136,6 +136,17 @@ namespace occa {
      * @endDoc
      */
     void free();
+
+    /**
+     * @startDoc{finish}
+     *
+     * Description:
+     *   Waits for all asynchronous operations, such as memory allocations
+     *   or kernel calls, submitted to this device to complete.
+     *
+     * @endDoc
+     */
+    void finish();
   };
 
   std::ostream& operator << (std::ostream &out,

--- a/scripts/build/Make.fortran_rules
+++ b/scripts/build/Make.fortran_rules
@@ -8,6 +8,7 @@ $(fObjPath)/occa_device_m.o:        $(fObjPath)/occa_types_m.o
 $(fObjPath)/occa_memory_m.o:        $(fObjPath)/occa_types_m.o
 $(fObjPath)/occa_kernel_m.o:        $(fObjPath)/occa_types_m.o
 $(fObjPath)/occa_kernelBuilder_m.o: $(fObjPath)/occa_types_m.o
+$(fObjPath)/occa_stream_m.o:        $(fObjPath)/occa_types_m.o
 $(fObjPath)/occa_uva_m.o:           $(fObjPath)/occa_types_m.o
 $(fObjPath)/occa_scope_m.o:         $(fObjPath)/occa_types_m.o
 $(fObjPath)/occa_json_m.o:          $(fObjPath)/occa_types_m.o

--- a/scripts/build/Make.fortran_rules
+++ b/scripts/build/Make.fortran_rules
@@ -21,6 +21,7 @@ $(fObjPath)/occa_m.o:               $(fObjPath)/fc_string_m.o \
                                     $(fObjPath)/occa_memory_m.o \
                                     $(fObjPath)/occa_kernel_m.o \
                                     $(fObjPath)/occa_kernelBuilder_m.o \
+                                    $(fObjPath)/occa_stream_m.o \
                                     $(fObjPath)/occa_uva_m.o \
                                     $(fObjPath)/occa_scope_m.o \
                                     $(fObjPath)/occa_json_m.o

--- a/src/c/device.cpp
+++ b/src/c/device.cpp
@@ -70,6 +70,10 @@ void occaDeviceFinish(occaDevice device) {
   occa::c::device(device).finish();
 }
 
+void occaDeviceFinishAll(occaDevice device) {
+  occa::c::device(device).finishAll();
+}
+
 bool occaDeviceHasSeparateMemorySpace(occaDevice device) {
   return (int) occa::c::device(device).hasSeparateMemorySpace();
 }

--- a/src/c/stream.cpp
+++ b/src/c/stream.cpp
@@ -1,0 +1,11 @@
+#include <occa/internal/c/types.hpp>
+#include <occa/c/device.h>
+#include <occa/c/dtype.h>
+
+OCCA_START_EXTERN_C
+
+void occaStreamFinish(occaStream stream) {
+  occa::c::stream(stream).finish();
+}
+
+OCCA_END_EXTERN_C

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -245,6 +245,12 @@ namespace occa {
     }
   }
 
+  void device::finishAll() {
+    if (modeDevice) {
+      modeDevice->finishAll();
+    }
+  }
+
   bool device::hasSeparateMemorySpace() {
     return (modeDevice &&
             modeDevice->hasSeparateMemorySpace());

--- a/src/core/stream.cpp
+++ b/src/core/stream.cpp
@@ -98,6 +98,10 @@ namespace occa {
     modeStream = NULL;
   }
 
+  void stream::finish() {
+    if(modeStream) modeStream->finish();
+  }
+
   std::ostream& operator << (std::ostream &out,
                              const occa::stream &stream) {
     out << stream.properties();

--- a/src/fortran/occa_device_m.f90
+++ b/src/fortran/occa_device_m.f90
@@ -93,6 +93,13 @@ module occa_device_m
       type(occaDevice), value :: device
     end subroutine
 
+    ! void occaDeviceFinishAll(occaDevice device);
+    subroutine occaDeviceFinishAll(device) bind(C, name="occaDeviceFinishAll")
+      import occaDevice
+      implicit none
+      type(occaDevice), value :: device
+    end subroutine
+
     ! bool occaDeviceHasSeparateMemorySpace(occaDevice device);
     logical(kind=C_bool) function occaDeviceHasSeparateMemorySpace(device) &
                                   bind(C, name="occaDeviceHasSeparateMemorySpace")

--- a/src/fortran/occa_m.f90
+++ b/src/fortran/occa_m.f90
@@ -8,6 +8,7 @@ module occa
   use occa_memory_m
   use occa_kernel_m
   use occa_kernelBuilder_m
+  use occa_stream_m
   use occa_scope_m
   use occa_json_m
 

--- a/src/fortran/occa_stream_m.f90
+++ b/src/fortran/occa_stream_m.f90
@@ -1,0 +1,16 @@
+module occa_stream_m
+! occa/c/device.h
+
+use occa_types_m
+implicit none
+
+interface
+  ! void occaStreamFinish(occaStream stream);
+  subroutine occaStreamFinish(stream) bind(C, name="occaStreamFinish")
+    import occaStream
+    implicit none
+    type(occaStream), value :: stream
+  end subroutine
+end interface
+
+end module occa_stream_m

--- a/src/occa/internal/core/device.cpp
+++ b/src/occa/internal/core/device.cpp
@@ -80,8 +80,12 @@ namespace occa {
     streamTagRing.removeRef(streamTag);
   }
 
+  void modeDevice_t::finish() const {
+    currentStream.getModeStream()->finish();
+  }
+
   void modeDevice_t::finishAll() const {
-    for(const auto* stream : streams) {
+    for(auto* stream : streams) {
       if(stream) stream->finish();
     }
   }

--- a/src/occa/internal/core/device.cpp
+++ b/src/occa/internal/core/device.cpp
@@ -80,6 +80,12 @@ namespace occa {
     streamTagRing.removeRef(streamTag);
   }
 
+  void modeDevice_t::finishAll() const {
+    for(const auto* stream : streams) {
+      if(stream) stream->finish();
+    }
+  }
+
   hash_t modeDevice_t::versionedHash() const {
     return (occa::hash(settings()["version"])
             ^ hash());

--- a/src/occa/internal/core/device.hpp
+++ b/src/occa/internal/core/device.hpp
@@ -58,12 +58,11 @@ namespace occa {
     void addStreamTagRef(modeStreamTag_t *streamTag);
     void removeStreamTagRef(modeStreamTag_t *streamTag);
 
+    void finish() const;
     void finishAll() const;
 
     //---[ Virtual Methods ]------------
     virtual ~modeDevice_t() = 0;
-
-    virtual void finish() const = 0;
 
     virtual bool hasSeparateMemorySpace() const = 0;
 

--- a/src/occa/internal/core/device.hpp
+++ b/src/occa/internal/core/device.hpp
@@ -58,6 +58,8 @@ namespace occa {
     void addStreamTagRef(modeStreamTag_t *streamTag);
     void removeStreamTagRef(modeStreamTag_t *streamTag);
 
+    void finishAll() const;
+
     //---[ Virtual Methods ]------------
     virtual ~modeDevice_t() = 0;
 

--- a/src/occa/internal/core/stream.hpp
+++ b/src/occa/internal/core/stream.hpp
@@ -24,6 +24,7 @@ namespace occa {
 
     //---[ Virtual Methods ]------------
     virtual ~modeStream_t() = 0;
+    virtual void finish() = 0;
     //==================================
   };
 }

--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -88,11 +88,6 @@ namespace occa {
       }
     }
 
-    void device::finish() const {
-      OCCA_CUDA_ERROR("Device: Finish",
-                      cuStreamSynchronize(getCuStream()));
-    }
-
     bool device::hasSeparateMemorySpace() const {
       return true;
     }

--- a/src/occa/internal/modes/cuda/device.hpp
+++ b/src/occa/internal/modes/cuda/device.hpp
@@ -30,8 +30,6 @@ namespace occa {
       device(const occa::json &properties_);
       virtual ~device();
 
-      virtual void finish() const;
-
       virtual bool hasSeparateMemorySpace() const;
 
       virtual hash_t hash() const;

--- a/src/occa/internal/modes/cuda/stream.cpp
+++ b/src/occa/internal/modes/cuda/stream.cpp
@@ -18,5 +18,10 @@ namespace occa {
         );
       }
     }
+
+    void stream::finish() {
+      OCCA_CUDA_ERROR("Stream: Finish",
+                      cuStreamSynchronize(cuStream));
+    }
   }
 }

--- a/src/occa/internal/modes/cuda/stream.hpp
+++ b/src/occa/internal/modes/cuda/stream.hpp
@@ -20,6 +20,7 @@ namespace occa {
              bool isWrapped_=false);
 
       virtual ~stream();
+      void finish() override;
     };
   }
 }

--- a/src/occa/internal/modes/dpcpp/device.cpp
+++ b/src/occa/internal/modes/dpcpp/device.cpp
@@ -50,11 +50,6 @@ namespace occa
       setCompilerLinkerOptions(kernelProps);
     }
 
-    void device::finish() const
-    {
-      getDpcppStream(currentStream).finish();
-    }
-
     hash_t device::hash() const
     {
       if (!hash_.initialized)

--- a/src/occa/internal/modes/dpcpp/device.hpp
+++ b/src/occa/internal/modes/dpcpp/device.hpp
@@ -25,8 +25,6 @@ namespace occa
       device(const occa::json &properties_);
       virtual ~device() = default;
 
-      virtual void finish() const override;
-
       virtual inline bool hasSeparateMemorySpace() const override { return true; }
 
       virtual hash_t hash() const override;

--- a/src/occa/internal/modes/dpcpp/stream.hpp
+++ b/src/occa/internal/modes/dpcpp/stream.hpp
@@ -18,7 +18,7 @@ namespace occa {
 
       virtual ~stream()=default;
 
-      void finish();
+      void finish() override;
 
       occa::dpcpp::streamTag memcpy(void *dest, const void *src, occa::udim_t num_bytes);
     };

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -85,11 +85,6 @@ namespace occa {
 
     device::~device() { }
 
-    void device::finish() const {
-      OCCA_HIP_ERROR("Device: Finish",
-                     hipStreamSynchronize(getHipStream()));
-    }
-
     bool device::hasSeparateMemorySpace() const {
       return true;
     }

--- a/src/occa/internal/modes/hip/device.hpp
+++ b/src/occa/internal/modes/hip/device.hpp
@@ -25,8 +25,6 @@ namespace occa {
       device(const occa::json &properties_);
       virtual ~device();
 
-      virtual void finish() const;
-
       virtual bool hasSeparateMemorySpace() const;
 
       virtual hash_t hash() const;

--- a/src/occa/internal/modes/hip/stream.cpp
+++ b/src/occa/internal/modes/hip/stream.cpp
@@ -17,5 +17,10 @@ namespace occa {
                         hipStreamDestroy(hipStream));
       }
     }
+
+    void stream::finish() {
+      OCCA_HIP_ERROR("Stream: Finish",
+                     hipStreamSynchronize(hipStream));
+    }
   }
 }

--- a/src/occa/internal/modes/hip/stream.hpp
+++ b/src/occa/internal/modes/hip/stream.hpp
@@ -18,6 +18,7 @@ namespace occa {
              bool isWrapped_=false);
 
       virtual ~stream();
+      void finish() override;
     };
   }
 }

--- a/src/occa/internal/modes/metal/device.cpp
+++ b/src/occa/internal/modes/metal/device.cpp
@@ -41,13 +41,6 @@ namespace occa {
       metalDevice.free();
     }
 
-    void device::finish() const {
-      metal::stream &stream = (
-        *((metal::stream*) (currentStream.getModeStream()))
-      );
-      stream.metalCommandQueue.finish();
-    }
-
     bool device::hasSeparateMemorySpace() const {
       return true;
     }

--- a/src/occa/internal/modes/metal/device.hpp
+++ b/src/occa/internal/modes/metal/device.hpp
@@ -22,8 +22,6 @@ namespace occa {
       device(const occa::json &properties_);
       virtual ~device();
 
-      virtual void finish() const;
-
       virtual bool hasSeparateMemorySpace() const;
 
       virtual hash_t hash() const;

--- a/src/occa/internal/modes/metal/stream.cpp
+++ b/src/occa/internal/modes/metal/stream.cpp
@@ -15,5 +15,9 @@ namespace occa {
         metalCommandQueue.free();
       }
     }
+
+    void stream::finish() {
+      metalCommandQueue.finish();
+    }
   }
 }

--- a/src/occa/internal/modes/metal/stream.hpp
+++ b/src/occa/internal/modes/metal/stream.hpp
@@ -18,6 +18,7 @@ namespace occa {
              bool isWrapped_=false);
 
       virtual ~stream();
+      void finish() override;
     };
   }
 }

--- a/src/occa/internal/modes/opencl/device.cpp
+++ b/src/occa/internal/modes/opencl/device.cpp
@@ -65,11 +65,6 @@ namespace occa {
       }
     }
 
-    void device::finish() const {
-      OCCA_OPENCL_ERROR("Device: Finish",
-                        clFinish(getCommandQueue()));
-    }
-
     bool device::hasSeparateMemorySpace() const {
       return true;
     }

--- a/src/occa/internal/modes/opencl/device.hpp
+++ b/src/occa/internal/modes/opencl/device.hpp
@@ -23,8 +23,6 @@ namespace occa {
       device(const occa::json &properties_);
       virtual ~device();
 
-      virtual void finish() const;
-
       virtual bool hasSeparateMemorySpace() const;
 
       virtual hash_t hash() const;

--- a/src/occa/internal/modes/opencl/stream.cpp
+++ b/src/occa/internal/modes/opencl/stream.cpp
@@ -13,5 +13,10 @@ namespace occa {
       OCCA_OPENCL_ERROR("Device: Freeing cl_command_queue",
                         clReleaseCommandQueue(commandQueue));
     }
+
+    void stream::finish() {
+      OCCA_OPENCL_ERROR("Stream: finish",
+                        clFinish(getCommandQueue));
+    }
   }
 }

--- a/src/occa/internal/modes/opencl/stream.cpp
+++ b/src/occa/internal/modes/opencl/stream.cpp
@@ -16,7 +16,7 @@ namespace occa {
 
     void stream::finish() {
       OCCA_OPENCL_ERROR("Stream: finish",
-                        clFinish(getCommandQueue));
+                        clFinish(commandQueue));
     }
   }
 }

--- a/src/occa/internal/modes/opencl/stream.hpp
+++ b/src/occa/internal/modes/opencl/stream.hpp
@@ -17,6 +17,7 @@ namespace occa {
              cl_command_queue commandQueue_);
 
       virtual ~stream();
+      void finish() override;
     };
   }
 }

--- a/src/occa/internal/modes/serial/device.cpp
+++ b/src/occa/internal/modes/serial/device.cpp
@@ -17,8 +17,6 @@ namespace occa {
 
     device::~device() {}
 
-    void device::finish() const {}
-
     bool device::hasSeparateMemorySpace() const {
       return false;
     }

--- a/src/occa/internal/modes/serial/device.hpp
+++ b/src/occa/internal/modes/serial/device.hpp
@@ -13,8 +13,6 @@ namespace occa {
       device(const occa::json &properties_);
       virtual ~device();
 
-      virtual void finish() const;
-
       virtual bool hasSeparateMemorySpace() const;
 
       virtual hash_t hash() const;

--- a/src/occa/internal/modes/serial/stream.cpp
+++ b/src/occa/internal/modes/serial/stream.cpp
@@ -7,5 +7,6 @@ namespace occa {
       modeStream_t(modeDevice_, properties_) {}
 
     stream::~stream() {}
+    void stream::finish() {}
   }
 }

--- a/src/occa/internal/modes/serial/stream.hpp
+++ b/src/occa/internal/modes/serial/stream.hpp
@@ -12,6 +12,7 @@ namespace occa {
              const occa::json &properties_);
 
       virtual ~stream();
+      void finish() override;
     };
   }
 }


### PR DESCRIPTION
## Description

Closes #598.

This could be split into 2 separate PRs: the first implementing `stream::finish()` and a subsequent one implementing `device::finishAll()`; however, the need for `stream::finish` is less clear outside of the current context.


<!-- Thank you for contributing! -->
