### PR TITLE
[OKL] Extend allowed loop index types

### DIFF
--- a/src/occa/internal/lang/modes/oklForStatement.cpp
+++ b/src/occa/internal/lang/modes/oklForStatement.cpp
@@ -96,15 +96,17 @@ namespace occa {
         variableDeclaration &decl = declSmnt.declarations[0];
         iterator  = &decl.variable();
         initValue = decl.value;
-        // Valid types: {char, short, int, long}
+        // Valid types: {char, short, int, long, ptrdiff_t, size_t}
         const type_t *type = iterator->vartype.flatten().type;
         if (!type ||
             ((*type != char_)  &&
              (*type != short_) &&
-             (*type != int_))) {
+             (*type != int_) &&
+             (*type != ptrdiff_t_) &&
+             (*type != size_t_))) {
           if (printErrors) {
             iterator->printError(sourceStr() + "Iterator variable needs to be of type"
-                                 " [char, short, int, long]");
+                                 " [char, short, int, long, ptrdiff_t, size_t]");
           }
           return false;
         }

--- a/tests/src/loops/forLoop.cpp
+++ b/tests/src/loops/forLoop.cpp
@@ -52,7 +52,7 @@ void testOuterForLoops(occa::device device) {
     .outer(length)
     .run(OCCA_FUNCTION(scope, [=](const int outerIndex) -> void {
       OKL("@inner");
-      for (int i = 0; i < 2; ++i) {
+      for (long i = 0; i < 2; ++i) {
         const int globalIndex = i + (2 * outerIndex);
         output[globalIndex] = globalIndex;
       }
@@ -86,7 +86,7 @@ void testOuterForLoops(occa::device device) {
     .outer(length, occa::range(length), indexArray)
     .run(OCCA_FUNCTION(scope, [=](const int3 outerIndex) -> void {
       OKL("@inner");
-      for (int i = 0; i < 2; ++i) {
+      for (size_t i = 0; i < 2; ++i) {
         const int globalIndex = (
           i + (2 * (outerIndex.z + length * (outerIndex.y + length * outerIndex.x)))
         );


### PR DESCRIPTION
## Description

OKL is rather opinionated about what (integer) types are allowed as loop indices. This PR loosens these restrictions somewhat: The code now allows `size_t` and `ptrdiff_t` as types for loop variables.
