### PR TITLE
CMake find OpenCL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,9 +129,8 @@ jobs:
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DCMAKE_INSTALL_PREFIX=install \
         -DENABLE_TESTS=ON \
-        -DENABLE_EXAMPLES=ON \
-        -DCMAKE_PREFIX_PATH="/opt/intel/oneapi/compiler/latest/linux;/opt/intel/oneapi/compiler/latest/linux/compiler"
-    
+        -DENABLE_EXAMPLES=ON
+        
     - name: CMake build
       if: ${{ matrix.useCMake && !matrix.useoneAPI}}
       run: |

--- a/cmake/FindOpenCLWrapper.cmake
+++ b/cmake/FindOpenCLWrapper.cmake
@@ -3,31 +3,38 @@
 # This Find module is also distributed alongside the occa package config file!
 ###############################################################################
 
-# Look in some default places for OpenCL and set OpenCL_ROOT if not already set
-if(NOT OpenCL_ROOT)
-  # Search in user specified path first
-  find_path(OpenCL_ROOT
-    NAMES CL/cl.h
+# Try finding OpenCL. The user should set OpenCL_ROOT if needed.
+find_package(OpenCL QUIET)
+if(NOT OpenCL_FOUND)
+  # Otherwise, look for the headers and library in standard locations
+  find_path(OpenCL_INCLUDE_DIR
+    NAMES CL/cl.h OpenCL/cl.h
     PATHS
-    ENV   OpenCL_PATH
-    DOC   "OpenCL root location"
-    NO_DEFAULT_PATH)
+      ENV CUDA_PATH
+      ENV CUDAToolkit_ROOT
+      ENV ROCM_PATH
+      ENV NVHPC_ROOT
+      ENV SYCL_ROOT
+    PATH_SUFFIXES
+      opencl
+      include
+      include/sycl
+  )
 
-  # Now search in default path
-  find_path(OpenCL_ROOT
-    NAMES CL/cl.h
-    PATHS 
-      /usr 
-      /opt/rocm/opencl 
-      /usr/local/cuda 
-      /opt/intel/oneapi/compiler/latest/linux
-    PATH_SUFFIXES sycl
-    DOC   "OpenCL root location")
+  find_library(OpenCL_LIBRARY
+    NAMES OpenCL libOpenCL
+    PATHS
+      ENV CUDA_PATH
+      ENV CUDAToolkit_ROOT
+      ENV ROCM_PATH
+      ENV NVHPC_ROOT
+      ENV SYCL_ROOT
+    PATH_SUFFIXES
+      opencl
+      lib
+      lib64
+  )
 endif()
-
-# Trick CMake's default OpenCL module to look in our directory
-set(ENV{AMDAPPSDKROOT} ${OpenCL_ROOT})
-
 find_package(OpenCL)
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindOpenCLWrapper.cmake
+++ b/cmake/FindOpenCLWrapper.cmake
@@ -3,18 +3,18 @@
 # This Find module is also distributed alongside the occa package config file!
 ###############################################################################
 
-# Look in some default places for OpenCL and set OPENCL_ROOT if not already set
-if(NOT OPENCL_ROOT)
+# Look in some default places for OpenCL and set OpenCL_ROOT if not already set
+if(NOT OpenCL_ROOT)
   # Search in user specified path first
-  find_path(OPENCL_ROOT
+  find_path(OpenCL_ROOT
     NAMES CL/cl.h
     PATHS
-    ENV   OPENCL_PATH
-    DOC   "OPENCL root location"
+    ENV   OpenCL_PATH
+    DOC   "OpenCL root location"
     NO_DEFAULT_PATH)
 
   # Now search in default path
-  find_path(OPENCL_ROOT
+  find_path(OpenCL_ROOT
     NAMES CL/cl.h
     PATHS 
       /usr 
@@ -22,11 +22,11 @@ if(NOT OPENCL_ROOT)
       /usr/local/cuda 
       /opt/intel/oneapi/compiler/latest/linux
     PATH_SUFFIXES sycl
-    DOC   "OPENCL root location")
+    DOC   "OpenCL root location")
 endif()
 
 # Trick CMake's default OpenCL module to look in our directory
-set(ENV{AMDAPPSDKROOT} ${OPENCL_ROOT})
+set(ENV{AMDAPPSDKROOT} ${OpenCL_ROOT})
 
 find_package(OpenCL)
 

--- a/cmake/FindOpenCLWrapper.cmake
+++ b/cmake/FindOpenCLWrapper.cmake
@@ -15,8 +15,10 @@ if(NOT OpenCL_FOUND)
       ENV ROCM_PATH
       ENV NVHPC_ROOT
       ENV SYCL_ROOT
+      /usr/local/cuda
+      /opt/rocm/opencl
+      /opt/intel/oneapi/compiler/latest/linux
     PATH_SUFFIXES
-      opencl
       include
       include/sycl
   )
@@ -29,8 +31,10 @@ if(NOT OpenCL_FOUND)
       ENV ROCM_PATH
       ENV NVHPC_ROOT
       ENV SYCL_ROOT
+      /usr/local/cuda
+      /opt/rocm/opencl
+      /opt/intel/oneapi/compiler/latest/linux
     PATH_SUFFIXES
-      opencl
       lib
       lib64
   )


### PR DESCRIPTION
## Description

Updates CMake logic for finding OpenCL headers and library: it should no longer be necessary to define the environment variable `OpenCL_ROOT` on most platforms which have CUDA, HIP, or SYCL installed.
