### PR TITLE
Fix dpcpp warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
     - name: Run CTests
       if: ${{ matrix.useCMake && !matrix.useoneAPI }}
       run: |
-        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp"
+        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp|examples_cpp_nonblocking_streams-dpcpp"
         
 
     - name: Run CTests
@@ -176,7 +176,7 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh
         export SYCL_DEVICE_FILTER=opencl.cpu
-        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp"
+        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp|examples_cpp_nonblocking_streams-dpcpp"
 
     - name: Upload code coverage
       if: ${{ matrix.OCCA_COVERAGE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
     - name: Run CTests
       if: ${{ matrix.useCMake && !matrix.useoneAPI }}
       run: |
-        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_nonblocking_streams-opencl|examples_cpp_shared_memory-dpcpp|examples_cpp_nonblocking_streams-dpcpp|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp"
+        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp"
         
 
     - name: Run CTests
@@ -176,7 +176,7 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh
         export SYCL_DEVICE_FILTER=opencl.cpu
-        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_nonblocking_streams-opencl|examples_cpp_shared_memory-dpcpp|examples_cpp_nonblocking_streams-dpcpp|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp"
+        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp"
 
     - name: Upload code coverage
       if: ${{ matrix.OCCA_COVERAGE }}

--- a/src/occa/internal/lang/expr/dpcppAtomicNode.cpp
+++ b/src/occa/internal/lang/expr/dpcppAtomicNode.cpp
@@ -32,13 +32,13 @@ namespace occa
     void dpcppAtomicNode::print(printer &pout) const
     {
 
-      pout << "sycl::ext::oneapi::atomic_ref<";
+      pout << "sycl::atomic_ref<";
 
       // Currently CUDA only supports atomics on fundamental types:
       // assume that we can safefuly ignore the pointer types for now
       // and simply print the typename.
       pout << atomic_type.name() << ",";
-      pout << "sycl::ext::oneapi::memory_order::relaxed,";
+      pout << "sycl::memory_order::relaxed,";
 
       //  The SYCL standard states,
       // 
@@ -49,15 +49,15 @@ namespace occa
       //  Currently OCCA does not address system-wide atomics;
       //  therefore, assume for now that we can always safely
       //  use `memory_scope::device`.
-      pout << "sycl::ext::oneapi::memory_scope::device,";
+      pout << "sycl::memory_scope::device,";
 
       if(atomic_type.hasAttribute("shared"))
       {
-        pout << "sycl::access::address_space::global_space";
+        pout << "sycl::access::address_space::local_space";
       }
       else
       {
-        pout << "sycl::access::address_space::local_space";
+        pout << "sycl::access::address_space::global_space";
       }
 
       pout << ">(";

--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -132,20 +132,18 @@ namespace occa
         // }
       }
 
-      // @note: As of SYCL 2020 this will need to change to `group_barrier(it.group())`
       void dpcppParser::addBarriers()
       {
         statementArray::from(root)
             .flatFilterByStatementType(statementType::empty, "barrier")
             .forEach([&](statement_t *smnt)
                      {
-                       // TODO 1.1: Implement proper barriers
                        emptyStatement &emptySmnt = (emptyStatement &)*smnt;
 
                        statement_t &barrierSmnt = (*(new sourceCodeStatement(
                            emptySmnt.up,
                            emptySmnt.source,
-                           "item_.barrier(sycl::access::fence_space::local_space);")));
+                           "group_barrier(item_.get_group());")));
 
                        emptySmnt.replaceWith(barrierSmnt);
 


### PR DESCRIPTION
## Description

- Updates the namespace of DPC++ features accepted into the SYCL 2020 spec
- Corrects address space of atomic references
- Replaces deprecated barrier calls with `group_barrier`
- Reintroduces some DPC++ tests into the CI pipeline
