### PR TITLE
[bugfix] OKL for loop init statement

### DIFF
--- a/src/occa/internal/lang/modes/oklForStatement.cpp
+++ b/src/occa/internal/lang/modes/oklForStatement.cpp
@@ -108,7 +108,7 @@ namespace occa {
         iterator  = &decl.variable();
         if(!(iterator->isNamed())) {
           if(printErrors)
-            iterator->printError(sourceStr() 
+            declSmnt.printError(sourceStr() 
               + "OKL for loop variable does not have a name.");
           return false;
         }

--- a/src/occa/internal/lang/variable.cpp
+++ b/src/occa/internal/lang/variable.cpp
@@ -49,7 +49,7 @@ namespace occa {
     }
 
     bool variable_t::isNamed() const {
-      return source->value.size();
+      return !(this->name().empty());
     }
 
     std::string& variable_t::name() {

--- a/tests/src/internal/lang/modes/okl.cpp
+++ b/tests/src/internal/lang/modes/okl.cpp
@@ -97,6 +97,9 @@ void testProperOKLLoops() {
   parseBadOKLSource(oStart + "for (int o = 0; o < 2;; @outer) {" + oMid + "}" + oEnd);
   parseBadOKLSource(oStart + "for (int o = 0; o < 2; o *= 2; @outer) {" + oMid + "}" + oEnd);
   parseBadOKLSource(oStart + "for (int o = 0; o < 2; ++j; @outer) {" + oMid + "}" + oEnd);
+  parseBadOKLSource(oStart + "for (int o; o < 2; ++o; @outer) {" + oMid + "}" + oEnd);
+  parseBadOKLSource(oStart + "for (int; o < 2; ++o; @outer) {" + oMid + "}" + oEnd);
+  parseBadOKLSource(oStart + "for ( ; o < 2; ++o; @outer) {" + oMid + "}" + oEnd);
 
   parseBadOKLSource(iStart + "for (i = 0;;; @inner) {}" + iEnd);
   parseBadOKLSource(iStart + "for (float i = 0;;; @inner) {}" + iEnd);
@@ -107,6 +110,9 @@ void testProperOKLLoops() {
   parseBadOKLSource(iStart + "for (int i = 0; i < 2;; @inner) {}" + iEnd);
   parseBadOKLSource(iStart + "for (int i = 0; i < 2; i *= 2; @inner) {}" + iEnd);
   parseBadOKLSource(iStart + "for (int i = 0; i < 2; ++j; @inner) {}" + iEnd);
+  parseBadOKLSource(iStart + "for (int i; i < 2; ++i; @inner) {}" + iEnd);
+  parseBadOKLSource(iStart + "for (int; i < 2; ++i; @inner) {}" + iEnd);
+  parseBadOKLSource(iStart + "for ( ; i < 2; ++i; @inner) {}" + iEnd);
 
   // No double @outer + @inner
   parseBadOKLSource(


### PR DESCRIPTION
## Description

Closes #610

- Ensures that an OKL for loop counter variable is initialized.
- Provides descriptive error messages related to OKL for loop init statements
 
