### PR TITLE
Show compiler output for kernel if verbose is true

### DIFF
--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -319,6 +319,8 @@ namespace occa {
           << "Output:\n\n"
           << commandOutput << "\n"
         );
+      } else if (verbose) {
+          io::stdout << "Output:\n\n" << commandOutput << "\n";
       }
       //================================
     }

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -310,6 +310,8 @@ namespace occa {
           << "Output:\n\n"
           << commandOutput << "\n"
         );
+      } else if (verbose) {
+          io::stdout << "Output:\n\n" << commandOutput << "\n";
       }
       //================================
     }

--- a/src/occa/internal/modes/metal/device.cpp
+++ b/src/occa/internal/modes/metal/device.cpp
@@ -176,6 +176,8 @@ namespace occa {
               << "Output:\n\n"
               << commandOutput << "\n"
             );
+          } else if (verbose) {
+              io::stdout << "Output:\n\n" << commandOutput << "\n";
           }
 
           return true;
@@ -212,6 +214,8 @@ namespace occa {
           << "Output:\n\n"
           << commandOutput << "\n"
         );
+      } else if (verbose) {
+          io::stdout << "Output:\n\n" << commandOutput << "\n";
       }
       //================================
     }


### PR DESCRIPTION
## Description

This behaviour was changed for CUDA in the v1.3 release, but getting e.g. information about register spilling is very useful.

Also implement similar behaviour for HIP and Metal.