### PR TITLE
Improve compilation output

### DIFF
--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -315,7 +315,7 @@ namespace occa {
       if (commandExitCode) {
         OCCA_FORCE_ERROR(
           "Error compiling [" << kernelName << "],"
-          " Command: [" << sCommand << ']'
+          " Command: [" << sCommand << "] exited with code " << commandExitCode << "\n"
           << "Output:\n\n"
           << commandOutput << "\n"
         );

--- a/src/occa/internal/modes/dpcpp/device.cpp
+++ b/src/occa/internal/modes/dpcpp/device.cpp
@@ -225,7 +225,7 @@ namespace occa
       if (compileError)
       {
         OCCA_FORCE_ERROR("Error compiling [" << kernelName << "],"
-                          << " Command: ["<< sCommand << ']');
+                          << " Command: ["<< sCommand << "] exited with code " << compileError << "\n");
       }
     }
 

--- a/src/occa/internal/modes/dpcpp/device.cpp
+++ b/src/occa/internal/modes/dpcpp/device.cpp
@@ -215,17 +215,25 @@ namespace occa
       }
 
       const std::string &sCommand = command.str();
-      if (verbose)
-      {
-        io::stdout << sCommand << '\n';
+      if (verbose) {
+        io::stdout << "Compiling [" << kernelName << "]\n" << sCommand << "\n";
       }
 
-      const int compileError = system(sCommand.c_str());
+      std::string commandOutput;
+      const int commandExitCode = sys::call(
+        sCommand.c_str(),
+        commandOutput
+      );
 
-      if (compileError)
-      {
-        OCCA_FORCE_ERROR("Error compiling [" << kernelName << "],"
-                          << " Command: ["<< sCommand << "] exited with code " << compileError << "\n");
+      if (commandExitCode) {
+        OCCA_FORCE_ERROR(
+          "Error compiling [" << kernelName << "],"
+          " Command: [" << sCommand << "] exited with code " << commandExitCode << "\n\n"
+          << "Output:\n\n"
+          << commandOutput << "\n"
+        );
+      } else if (verbose) {
+        io::stdout << "Output:\n\n" << commandOutput << "\n";
       }
     }
 

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -306,7 +306,7 @@ namespace occa {
       if (commandExitCode) {
         OCCA_FORCE_ERROR(
           "Error compiling [" << kernelName << "],"
-          " Command: [" << sCommand << "]\n"
+          " Command: [" << sCommand << "] exited with code " << commandExitCode << "\n\n"
           << "Output:\n\n"
           << commandOutput << "\n"
         );

--- a/src/occa/internal/modes/metal/device.cpp
+++ b/src/occa/internal/modes/metal/device.cpp
@@ -172,7 +172,7 @@ namespace occa {
           if (commandExitCode) {
             OCCA_FORCE_ERROR(
               "Error compiling [" << kernelName << "],"
-              " Command: [" << airCommand << ']'
+              " Command: [" << airCommand << "] exited with code " << commandExitCode << "\n\n"
               << "Output:\n\n"
               << commandOutput << "\n"
             );
@@ -210,7 +210,7 @@ namespace occa {
       if (commandExitCode) {
         OCCA_FORCE_ERROR(
           "Error compiling [" << kernelName << "],"
-          " Command: [" << metallibCommand << ']'
+          " Command: [" << metallibCommand << "] exited with code " << commandExitCode << "\n\n"
           << "Output:\n\n"
           << commandOutput << "\n"
         );

--- a/src/occa/internal/modes/metal/device.cpp
+++ b/src/occa/internal/modes/metal/device.cpp
@@ -160,7 +160,7 @@ namespace occa {
 
           const std::string airCommand = command.str();
           if (verbose) {
-            io::stdout << "Compiling [" << kernelName << "]\n" << airCommand << "\n";
+            io::stdout << "Compiling Air Binary [" << kernelName << "]\n" << airCommand << "\n";
           }
 
           std::string commandOutput;
@@ -198,7 +198,7 @@ namespace occa {
 
       const std::string metallibCommand = command.str();
       if (verbose) {
-        io::stdout << metallibCommand << '\n';
+        io::stdout << "Compiling Metallib [" << kernelName << "]\n" << metallibCommand << "\n";
       }
 
       std::string commandOutput;

--- a/src/occa/internal/utils/sys.cpp
+++ b/src/occa/internal/utils/sys.cpp
@@ -179,9 +179,11 @@ namespace occa {
     int call(const std::string &cmdline) {
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
       FILE *fp = popen(cmdline.c_str(), "r");
+      if (!fp) return errno;
       return pclose(fp);
 #else
       FILE *fp = _popen(cmdline.c_str(), "r");
+      if (!fp) return errno;
       return _pclose(fp);
 #endif
     }
@@ -193,8 +195,13 @@ namespace occa {
       FILE *fp = _popen(cmdline.c_str(), "r");
 #endif
 
-      size_t lineBytes = 512;
-      char lineBuffer[512];
+      if (!fp) {
+          output = "Failed to launch process";
+          return errno;
+      }
+
+      const size_t lineBytes = 512;
+      char lineBuffer[lineBytes];
 
       output = "";
       while (fgets(lineBuffer, lineBytes, fp)) {


### PR DESCRIPTION
## Description

Sometimes the (nvcc) compiler invocations fail without any actual error messages from the compiler itself.
This PR doesn't solve that problem, but it provides some more information about the failure, which might point to a solution in the future.

It also tries to bring the code for various modes closer together in that regard.

The CUDA changes have been tested, but the DPCPP and Metal changes are 'blind' fixes, so some extra eyes from people who can actually run that part of the code would be good to have (in addition to letting the CI run on this PR).
