### PR TITLE
[CUDA][HIP][DPC++] Fix an issue with double frees when OKL has multip…

### DIFF
--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -348,6 +348,7 @@ namespace occa {
       kernel &k = *(new kernel(this,
                                kernelName,
                                sourceFilename,
+                               cuModule,
                                kernelProps));
 
       k.launcherKernel = buildLauncherKernel(kernelHash,
@@ -377,7 +378,6 @@ namespace occa {
         kernel *cuKernel = new kernel(this,
                                       metadata.name,
                                       sourceFilename,
-                                      cuModule,
                                       cuFunction,
                                       kernelProps);
         cuKernel->metadata = metadata;

--- a/src/occa/internal/modes/cuda/kernel.cpp
+++ b/src/occa/internal/modes/cuda/kernel.cpp
@@ -10,10 +10,20 @@ namespace occa {
     kernel::kernel(modeDevice_t *modeDevice_,
                    const std::string &name_,
                    const std::string &sourceFilename_,
+                   CUmodule cuModule_,
+                   const occa::json &properties_) :
+      occa::launchedModeKernel_t(modeDevice_, name_, sourceFilename_, properties_),
+      cuModule(cuModule_),
+      cuFunction(NULL) {}
+
+    kernel::kernel(modeDevice_t *modeDevice_,
+                   const std::string &name_,
+                   const std::string &sourceFilename_,
+                   CUfunction cuFunction_,
                    const occa::json &properties_) :
       occa::launchedModeKernel_t(modeDevice_, name_, sourceFilename_, properties_),
       cuModule(NULL),
-      cuFunction(NULL) {}
+      cuFunction(cuFunction_) {}
 
     kernel::kernel(modeDevice_t *modeDevice_,
                    const std::string &name_,

--- a/src/occa/internal/modes/cuda/kernel.hpp
+++ b/src/occa/internal/modes/cuda/kernel.hpp
@@ -23,6 +23,13 @@ namespace occa {
       kernel(modeDevice_t *modeDevice_,
              const std::string &name_,
              const std::string &sourceFilename_,
+             CUmodule cuModule_,
+             const occa::json &properties_);
+
+      kernel(modeDevice_t *modeDevice_,
+             const std::string &name_,
+             const std::string &sourceFilename_,
+             CUfunction cuFunction_,
              const occa::json &properties_);
 
       kernel(modeDevice_t *modeDevice_,

--- a/src/occa/internal/modes/dpcpp/device.cpp
+++ b/src/occa/internal/modes/dpcpp/device.cpp
@@ -246,9 +246,12 @@ namespace occa
                                                    lang::sourceMetadata_t &deviceMetadata,
                                                    const occa::json &kernelProps)
     {
+      void *dl_handle = sys::dlopen(binaryFilename);
+
       dpcpp::kernel &k = *(new dpcpp::kernel(this,
                                              kernelName,
                                              sourceFilename,
+                                             dl_handle,
                                              kernelProps));
 
       k.launcherKernel = buildLauncherKernel(kernelHash,
@@ -259,8 +262,6 @@ namespace occa
       orderedKernelMetadata launchedKernelsMetadata = getLaunchedKernelsMetadata(
           kernelName,
           deviceMetadata);
-
-      void *dl_handle = sys::dlopen(binaryFilename);
 
       const int launchedKernelsCount = (int)launchedKernelsMetadata.size();
       for (int i = 0; i < launchedKernelsCount; ++i)
@@ -279,7 +280,6 @@ namespace occa
         kernel *dpcppKernel = new dpcpp::kernel(this,
                                metadata.name,
                                sourceFilename,
-                               dl_handle,
                                kernel_function,
                                kernelProps);
 

--- a/src/occa/internal/modes/dpcpp/kernel.cpp
+++ b/src/occa/internal/modes/dpcpp/kernel.cpp
@@ -14,10 +14,22 @@ namespace occa
     kernel::kernel(modeDevice_t *modeDevice_,
                    const std::string &name_,
                    const std::string &sourceFilename_,
+                   void *dlHandle_,
                    const occa::json &properties_)
         : occa::launchedModeKernel_t(modeDevice_, name_, sourceFilename_, properties_),
-          dlHandle{nullptr},
+          dlHandle{dlHandle_},
           function{nullptr}
+    {
+    }
+
+    kernel::kernel(modeDevice_t *modeDevice_,
+                   const std::string &name_,
+                   const std::string &sourceFilename_,
+                   functionPtr_t function_,
+                   const occa::json &properties_)
+        : occa::launchedModeKernel_t(modeDevice_, name_, sourceFilename_, properties_),
+          dlHandle(nullptr),
+          function(function_)
     {
     }
 

--- a/src/occa/internal/modes/dpcpp/kernel.hpp
+++ b/src/occa/internal/modes/dpcpp/kernel.hpp
@@ -24,6 +24,13 @@ namespace occa
       kernel(modeDevice_t *modeDevice_,
              const std::string &name_,
              const std::string &sourceFilename_,
+             void* dlHandle_,
+             const occa::json &properties_);
+
+      kernel(modeDevice_t *modeDevice_,
+             const std::string &name_,
+             const std::string &sourceFilename_,
+             functionPtr_t function_,
              const occa::json &properties_);
 
       kernel(modeDevice_t *modeDevice_,

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -333,6 +333,7 @@ namespace occa {
       kernel &k = *(new kernel(this,
                                kernelName,
                                sourceFilename,
+                               hipModule,
                                kernelProps));
 
       k.launcherKernel = buildLauncherKernel(kernelHash,
@@ -360,7 +361,6 @@ namespace occa {
         kernel *hipKernel = new kernel(this,
                                        metadata.name,
                                        sourceFilename,
-                                       hipModule,
                                        hipFunction,
                                        kernelProps);
         hipKernel->metadata = metadata;

--- a/src/occa/internal/modes/hip/kernel.cpp
+++ b/src/occa/internal/modes/hip/kernel.cpp
@@ -10,10 +10,20 @@ namespace occa {
     kernel::kernel(modeDevice_t *modeDevice_,
                    const std::string &name_,
                    const std::string &sourceFilename_,
+                   hipModule_t hipModule_,
+                   const occa::json &properties_) :
+      occa::launchedModeKernel_t(modeDevice_, name_, sourceFilename_, properties_),
+      hipModule(hipModule_),
+      hipFunction(NULL) {}
+
+    kernel::kernel(modeDevice_t *modeDevice_,
+                   const std::string &name_,
+                   const std::string &sourceFilename_,
+                   hipFunction_t hipFunction_,
                    const occa::json &properties_) :
       occa::launchedModeKernel_t(modeDevice_, name_, sourceFilename_, properties_),
       hipModule(NULL),
-      hipFunction(NULL) {}
+      hipFunction(hipFunction_) {}
 
     kernel::kernel(modeDevice_t *modeDevice_,
                    const std::string &name_,

--- a/src/occa/internal/modes/hip/kernel.hpp
+++ b/src/occa/internal/modes/hip/kernel.hpp
@@ -21,6 +21,13 @@ namespace occa {
       kernel(modeDevice_t *modeDevice_,
              const std::string &name_,
              const std::string &sourceFilename_,
+             hipModule_t   hipModule_,
+             const occa::json &properties_);
+
+      kernel(modeDevice_t *modeDevice_,
+             const std::string &name_,
+             const std::string &sourceFilename_,
+             hipFunction_t hipFunction_,
              const occa::json &properties_);
 
       kernel(modeDevice_t *modeDevice_,


### PR DESCRIPTION
## Description

Fix an issue where a seg fault is encountered when destroying an occa::kernel that was created via a multi-kernel OKL file in CUDA, HIP, or DPC++ modes. 

A multi-kernel OKL file is one that has multiple distinct outer-loop blocks. 

<!-- Thank you for contributing! -->
