### PR TITLE
[OpenMP] Fix cancelling kernel hash

### DIFF
--- a/src/occa/internal/modes/openmp/device.cpp
+++ b/src/occa/internal/modes/openmp/device.cpp
@@ -14,14 +14,14 @@ namespace occa {
     hash_t device::hash() const {
       return (
         serial::device::hash()
-        ^ occa::hash("openmp")
+        ^ occa::hash("openmp device::hash")
       );
     }
 
     hash_t device::kernelHash(const occa::json &props) const {
       return (
         serial::device::kernelHash(props)
-        ^ occa::hash("openmp")
+        ^ occa::hash("openmp device::kernelHash")
       );
     }
 


### PR DESCRIPTION
## Description

Fixes a bug where both the openmp device::hash() and device::kernelHash were identical to the serial device hashes, with an additional ^ occa::hash("openmp"). This extra hash term would cancel out later (since they're identical) in device::setupKernelInfo, leading to the serial and openmp kernels having the same hash in the cache. 


<!-- Thank you for contributing! -->
