### PR TITLE
Updates `actions/checkout` to version 3.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
       FORTRAN_EXAMPLES: ${{ matrix.OCCA_FORTRAN_ENABLED }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: add oneAPI to apt
       if: ${{ matrix.useoneAPI }}


### PR DESCRIPTION
Older versions of `actions/checkout` used node12, which is now deprecated on GitHub. Version 3 onward use node16.

## Description




<!-- Thank you for contributing! -->
