### PR TITLE
[MemPool] Fix a bug in reservation tracking in memory pools

### DIFF
--- a/src/occa/internal/core/memoryPool.hpp
+++ b/src/occa/internal/core/memoryPool.hpp
@@ -12,8 +12,9 @@ namespace occa {
    public:
     struct compare {
       bool operator()(const modeMemory_t* a, const modeMemory_t* b) const {
-        return (a->offset  < b->offset) ||
-               (a->offset == b->offset &&  a->size < b->size);
+        if (a->offset != b->offset) return (a->offset < b->offset);
+        if (a->size != b->size)     return (a->size < b->size);
+        return (a < b);
       };
     };
     typedef std::set<modeMemory_t*, compare> reservationSet;


### PR DESCRIPTION
## Description

Testing adding memoryPools into a larger application and hit this issue. 

The comparison function used for the std::set which tracks reservation in memoryPools wasn't strong enough to distinguish between modeMemorys with the same size and location in the memoryPool's allocation. 


<!-- Thank you for contributing! -->
