### PR TITLE
Updates internal API to resolve clang compiler warnings.

### DIFF
--- a/src/occa/internal/core/launchedDevice.hpp
+++ b/src/occa/internal/core/launchedDevice.hpp
@@ -22,10 +22,10 @@ namespace occa {
                    lang::sourceMetadata_t &launcherMetadata,
                    lang::sourceMetadata_t &deviceMetadata);
 
-    virtual modeKernel_t* buildKernel(const std::string &filename,
-                                      const std::string &kernelName,
-                                      const hash_t kernelHash,
-                                      const occa::json &kernelProps);
+    modeKernel_t* buildKernel(const std::string &filename,
+                              const std::string &kernelName,
+                              const hash_t kernelHash,
+                              const occa::json &kernelProps) override;
 
     modeKernel_t* buildKernel(const std::string &filename,
                               const std::string &kernelName,

--- a/src/occa/internal/core/launchedKernel.hpp
+++ b/src/occa/internal/core/launchedKernel.hpp
@@ -19,11 +19,11 @@ namespace occa {
                          const std::string &sourceFilename_,
                          const occa::json &properties_);
 
-    ~launchedModeKernel_t();
+    virtual ~launchedModeKernel_t();
 
-    const lang::kernelMetadata_t& getMetadata() const;
+    const lang::kernelMetadata_t& getMetadata() const override;
 
-    void run() const;
+    void run() const override;
     void launcherRun() const;
 
     //---[ Virtual Methods ]------------

--- a/src/occa/internal/core/memoryPool.hpp
+++ b/src/occa/internal/core/memoryPool.hpp
@@ -32,7 +32,7 @@ namespace occa {
 
     modeMemoryPool_t(modeDevice_t *modeDevice_,
                      const occa::json &json_);
-    ~modeMemoryPool_t();
+    virtual ~modeMemoryPool_t();
 
     udim_t numReservations() const;
 

--- a/src/occa/internal/core/stream.hpp
+++ b/src/occa/internal/core/stream.hpp
@@ -16,6 +16,7 @@ namespace occa {
 
     modeStream_t(modeDevice_t *modeDevice_,
                  const occa::json &json_);
+    virtual ~modeStream_t();
 
     void dontUseRefs();
     void addStreamRef(stream *s);
@@ -23,7 +24,6 @@ namespace occa {
     bool needsFree() const;
 
     //---[ Virtual Methods ]------------
-    virtual ~modeStream_t() = 0;
     virtual void finish() = 0;
     //==================================
   };

--- a/src/occa/internal/modes/cuda/buffer.hpp
+++ b/src/occa/internal/modes/cuda/buffer.hpp
@@ -20,7 +20,7 @@ namespace occa {
       buffer(modeDevice_t *modeDevice_,
              udim_t size_,
              const occa::json &properties_ = occa::json());
-      ~buffer();
+      virtual ~buffer();
 
       void malloc(udim_t bytes) override;
 

--- a/src/occa/internal/modes/cuda/device.hpp
+++ b/src/occa/internal/modes/cuda/device.hpp
@@ -30,26 +30,26 @@ namespace occa {
       device(const occa::json &properties_);
       virtual ~device();
 
-      virtual bool hasSeparateMemorySpace() const;
+      bool hasSeparateMemorySpace() const override;
 
-      virtual hash_t hash() const;
+      hash_t hash() const override;
 
-      virtual hash_t kernelHash(const occa::json &props) const;
+      hash_t kernelHash(const occa::json &props) const override;
 
-      virtual lang::okl::withLauncher* createParser(const occa::json &props) const;
+      lang::okl::withLauncher* createParser(const occa::json &props) const override;
 
       void* getNullPtr();
 
       void setCudaContext();
 
       //---[ Stream ]-------------------
-      virtual modeStream_t* createStream(const occa::json &props);
-      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props);
+      modeStream_t* createStream(const occa::json &props) override;
+      modeStream_t* wrapStream(void* ptr, const occa::json &props) override;
 
-      virtual streamTag tagStream();
-      virtual void waitFor(streamTag tag);
-      virtual double timeBetween(const streamTag &startTag,
-                                 const streamTag &endTag);
+      streamTag tagStream() override;
+      void waitFor(streamTag tag) override;
+      double timeBetween(const streamTag &startTag,
+                         const streamTag &endTag) override;
 
       CUstream& getCuStream() const;
       //================================
@@ -63,7 +63,7 @@ namespace occa {
                                                    const bool usingOkl,
                                                    lang::sourceMetadata_t &launcherMetadata,
                                                    lang::sourceMetadata_t &deviceMetadata,
-                                                   const occa::json &kernelProps);
+                                                   const occa::json &kernelProps) override;
 
       void setArchCompilerFlags(const occa::json &kernelProps,
                                 std::string &compilerFlags);
@@ -81,25 +81,25 @@ namespace occa {
                                              const std::string &binaryFilename,
                                              lang::sourceMetadata_t &launcherMetadata,
                                              lang::sourceMetadata_t &deviceMetadata,
-                                             const occa::json &kernelProps);
+                                             const occa::json &kernelProps) override;
 
-      virtual modeKernel_t* buildKernelFromBinary(const std::string &filename,
-                                                  const std::string &kernelName,
-                                                  const occa::json &props);
+      modeKernel_t* buildKernelFromBinary(const std::string &filename,
+                                          const std::string &kernelName,
+                                          const occa::json &props) override;
       //================================
 
       //---[ Memory ]-------------------
-      virtual modeMemory_t* malloc(const udim_t bytes,
-                                   const void *src,
-                                   const occa::json &props);
+      modeMemory_t* malloc(const udim_t bytes,
+                           const void *src,
+                           const occa::json &props) override;
 
       modeMemory_t* wrapMemory(const void *ptr,
                                const udim_t bytes,
-                               const occa::json &props);
+                               const occa::json &props) override;
 
-      modeMemoryPool_t* createMemoryPool(const occa::json &props);
+      modeMemoryPool_t* createMemoryPool(const occa::json &props) override;
 
-      virtual udim_t memorySize() const;
+      udim_t memorySize() const override;
       //================================
     };
   }

--- a/src/occa/internal/modes/cuda/kernel.hpp
+++ b/src/occa/internal/modes/cuda/kernel.hpp
@@ -39,15 +39,15 @@ namespace occa {
              CUfunction cuFunction_,
              const occa::json &properties_);
 
-      ~kernel();
+      virtual ~kernel();
 
       CUstream& getCuStream() const;
 
-      int maxDims() const;
-      dim maxOuterDims() const;
-      dim maxInnerDims() const;
+      int maxDims() const override;
+      dim maxOuterDims() const override;
+      dim maxInnerDims() const override;
 
-      void deviceRun() const;
+      void deviceRun() const override;
     };
   }
 }

--- a/src/occa/internal/modes/cuda/memory.hpp
+++ b/src/occa/internal/modes/cuda/memory.hpp
@@ -22,29 +22,29 @@ namespace occa {
              udim_t size_, dim_t offset_);
       memory(memoryPool *memPool,
              udim_t size_, dim_t offset_);
-      ~memory();
+      virtual ~memory();
 
       CUstream& getCuStream() const;
 
-      void* getKernelArgPtr() const;
+      void* getKernelArgPtr() const override;
 
-      void* getPtr() const;
+      void* getPtr() const override;
 
       void copyTo(void *dest,
                   const udim_t bytes,
                   const udim_t destOffset = 0,
-                  const occa::json &props = occa::json()) const;
+                  const occa::json &props = occa::json()) const override;
 
       void copyFrom(const void *src,
                     const udim_t bytes,
                     const udim_t offset = 0,
-                    const occa::json &props = occa::json());
+                    const occa::json &props = occa::json()) override;
 
       void copyFrom(const modeMemory_t *src,
                     const udim_t bytes,
                     const udim_t destOffset = 0,
                     const udim_t srcOffset = 0,
-                    const occa::json &props = occa::json());
+                    const occa::json &props = occa::json()) override;
     };
   }
 }

--- a/src/occa/internal/modes/dpcpp/buffer.hpp
+++ b/src/occa/internal/modes/dpcpp/buffer.hpp
@@ -12,7 +12,7 @@ namespace occa {
       buffer(modeDevice_t *modeDevice_,
              udim_t size_,
              const occa::json &properties_ = occa::json());
-      ~buffer();
+      virtual ~buffer();
 
       void malloc(udim_t bytes) override;
 

--- a/src/occa/internal/modes/dpcpp/device.hpp
+++ b/src/occa/internal/modes/dpcpp/device.hpp
@@ -25,26 +25,26 @@ namespace occa
       device(const occa::json &properties_);
       virtual ~device() = default;
 
-      virtual inline bool hasSeparateMemorySpace() const override { return true; }
+      inline bool hasSeparateMemorySpace() const override { return true; }
 
-      virtual hash_t hash() const override;
+      hash_t hash() const override;
 
-      virtual hash_t kernelHash(const occa::json &props) const override;
+      hash_t kernelHash(const occa::json &props) const override;
 
-      virtual lang::okl::withLauncher *createParser(const occa::json &props) const override;
+      lang::okl::withLauncher *createParser(const occa::json &props) const override;
 
       //---[ Stream ]-------------------
-      virtual modeStream_t *createStream(const occa::json &props) override;
-      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props) override;
+      modeStream_t *createStream(const occa::json &props) override;
+      modeStream_t* wrapStream(void* ptr, const occa::json &props) override;
 
-      virtual occa::streamTag tagStream() override;
-      virtual void waitFor(occa::streamTag tag) override;
-      virtual double timeBetween(const occa::streamTag &startTag,
+      occa::streamTag tagStream() override;
+      void waitFor(occa::streamTag tag) override;
+      double timeBetween(const occa::streamTag &startTag,
                                  const occa::streamTag &endTag) override;
       //================================
 
       //---[ Kernel ]-------------------
-      virtual modeKernel_t *buildKernelFromProcessedSource(const hash_t kernelHash,
+      modeKernel_t *buildKernelFromProcessedSource(const hash_t kernelHash,
                                                    const std::string &hashDir,
                                                    const std::string &kernelName,
                                                    const std::string &sourceFilename,
@@ -62,7 +62,7 @@ namespace occa
                          const std::string &binaryFilename,
                          const occa::json &kernelProps);
 
-      virtual modeKernel_t *buildOKLKernelFromBinary(const hash_t kernelHash,
+      modeKernel_t *buildOKLKernelFromBinary(const hash_t kernelHash,
                                              const std::string &hashDir,
                                              const std::string &kernelName,
                                              const std::string &sourceFilename,
@@ -71,7 +71,7 @@ namespace occa
                                              lang::sourceMetadata_t &deviceMetadata,
                                              const occa::json &kernelProps) override;
 
-      virtual modeKernel_t *buildKernelFromBinary(const std::string &filename,
+      modeKernel_t *buildKernelFromBinary(const std::string &filename,
                                                   const std::string &kernelName,
                                                   const occa::json &props) override;
 
@@ -82,17 +82,17 @@ namespace occa
       //================================
 
       //---[ Memory ]-------------------
-      virtual modeMemory_t *malloc(const udim_t bytes,
-                                   const void *src,
-                                   const occa::json &props) override;
+      modeMemory_t *malloc(const udim_t bytes,
+                           const void *src,
+                           const occa::json &props) override;
 
-      virtual modeMemory_t *wrapMemory(const void *ptr,
+      modeMemory_t *wrapMemory(const void *ptr,
                                const udim_t bytes,
                                const occa::json &props) override;
 
-      virtual modeMemoryPool_t* createMemoryPool(const occa::json &props) override;
+      modeMemoryPool_t* createMemoryPool(const occa::json &props) override;
 
-      virtual udim_t memorySize() const override;
+      udim_t memorySize() const override;
       //================================
     };
   } // namespace dpcpp

--- a/src/occa/internal/modes/dpcpp/kernel.hpp
+++ b/src/occa/internal/modes/dpcpp/kernel.hpp
@@ -42,12 +42,12 @@ namespace occa
 
       virtual ~kernel();
 
-      virtual int maxDims() const override;
-      virtual dim maxOuterDims() const override;
-      virtual dim maxInnerDims() const override;
+      int maxDims() const override;
+      dim maxOuterDims() const override;
+      dim maxInnerDims() const override;
       udim_t maxInnerSize() const;
 
-      virtual void deviceRun() const override;
+      void deviceRun() const override;
     };
   } // namespace dpcpp
 } // namespace occa

--- a/src/occa/internal/modes/dpcpp/memory.hpp
+++ b/src/occa/internal/modes/dpcpp/memory.hpp
@@ -22,19 +22,19 @@ namespace occa
 
       virtual ~memory();
 
-      virtual void *getKernelArgPtr() const override;
+      void *getKernelArgPtr() const override;
 
-      virtual void copyTo(void *dest,
+      void copyTo(void *dest,
                   const udim_t bytes,
                   const udim_t destOffset = 0,
                   const occa::json &props = occa::json()) const override;
 
-      virtual void copyFrom(const void *src,
+      void copyFrom(const void *src,
                     const udim_t bytes,
                     const udim_t offset = 0,
                     const occa::json &props = occa::json()) override;
 
-      virtual void copyFrom(const modeMemory_t *src,
+      void copyFrom(const modeMemory_t *src,
                     const udim_t bytes,
                     const udim_t destOffset = 0,
                     const udim_t srcOffset = 0,

--- a/src/occa/internal/modes/hip/buffer.hpp
+++ b/src/occa/internal/modes/hip/buffer.hpp
@@ -20,7 +20,7 @@ namespace occa {
       buffer(modeDevice_t *modeDevice_,
              udim_t size_,
              const occa::json &properties_ = occa::json());
-      ~buffer();
+      virtual ~buffer();
 
       void malloc(udim_t bytes) override;
 

--- a/src/occa/internal/modes/hip/device.hpp
+++ b/src/occa/internal/modes/hip/device.hpp
@@ -25,22 +25,22 @@ namespace occa {
       device(const occa::json &properties_);
       virtual ~device();
 
-      virtual bool hasSeparateMemorySpace() const;
+      bool hasSeparateMemorySpace() const override;
 
-      virtual hash_t hash() const;
+      hash_t hash() const override;
 
-      virtual hash_t kernelHash(const occa::json &props) const;
+      hash_t kernelHash(const occa::json &props) const override;
 
-      virtual lang::okl::withLauncher* createParser(const occa::json &props) const;
+      lang::okl::withLauncher* createParser(const occa::json &props) const override;
 
       //---[ Stream ]-------------------
-      virtual modeStream_t* createStream(const occa::json &props);
-      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props);
+      modeStream_t* createStream(const occa::json &props) override;
+      modeStream_t* wrapStream(void* ptr, const occa::json &props) override;
 
-      virtual streamTag tagStream();
-      virtual void waitFor(streamTag tag);
-      virtual double timeBetween(const streamTag &startTag,
-                                 const streamTag &endTag);
+      streamTag tagStream() override;
+      void waitFor(streamTag tag) override;
+      double timeBetween(const streamTag &startTag,
+                         const streamTag &endTag) override;
 
       hipStream_t& getHipStream() const;
       //================================
@@ -54,7 +54,7 @@ namespace occa {
                                                    const bool usingOkl,
                                                    lang::sourceMetadata_t &launcherMetadata,
                                                    lang::sourceMetadata_t &deviceMetadata,
-                                                   const occa::json &kernelProps);
+                                                   const occa::json &kernelProps) override;
 
       void setArchCompilerFlags(occa::json &kernelProps);
 
@@ -71,25 +71,25 @@ namespace occa {
                                              const std::string &binaryFilename,
                                              lang::sourceMetadata_t &launcherMetadata,
                                              lang::sourceMetadata_t &deviceMetadata,
-                                             const occa::json &kernelProps);
+                                             const occa::json &kernelProps) override;
 
-      virtual modeKernel_t* buildKernelFromBinary(const std::string &filename,
-                                                  const std::string &kernelName,
-                                                  const occa::json &props);
+      modeKernel_t* buildKernelFromBinary(const std::string &filename,
+                                          const std::string &kernelName,
+                                          const occa::json &props) override;
       //================================
 
       //---[ Memory ]-------------------
-      virtual modeMemory_t* malloc(const udim_t bytes,
-                                   const void *src,
-                                   const occa::json &props);
+      modeMemory_t* malloc(const udim_t bytes,
+                           const void *src,
+                           const occa::json &props) override;
 
       modeMemory_t* wrapMemory(const void *ptr,
                                const udim_t bytes,
-                               const occa::json &props);
+                               const occa::json &props) override;
 
-      modeMemoryPool_t* createMemoryPool(const occa::json &props);
+      modeMemoryPool_t* createMemoryPool(const occa::json &props) override;
 
-      virtual udim_t memorySize() const;
+      udim_t memorySize() const override;
       //================================
     };
   }

--- a/src/occa/internal/modes/hip/kernel.hpp
+++ b/src/occa/internal/modes/hip/kernel.hpp
@@ -37,15 +37,15 @@ namespace occa {
              hipFunction_t hipFunction_,
              const occa::json &properties_);
 
-      ~kernel();
+      virtual ~kernel();
 
       hipStream_t& getHipStream() const;
 
-      int maxDims() const;
-      dim maxOuterDims() const;
-      dim maxInnerDims() const;
+      int maxDims() const override;
+      dim maxOuterDims() const override;
+      dim maxInnerDims() const override;
 
-      void deviceRun() const;
+      void deviceRun() const override;
     };
   }
 }

--- a/src/occa/internal/modes/hip/memory.hpp
+++ b/src/occa/internal/modes/hip/memory.hpp
@@ -19,29 +19,29 @@ namespace occa {
              udim_t size_, dim_t offset_);
       memory(memoryPool *memPool,
              udim_t size_, dim_t offset_);
-      ~memory();
+      virtual ~memory();
 
       hipStream_t& getHipStream() const;
 
-      void* getKernelArgPtr() const;
+      void* getKernelArgPtr() const override;
 
-      void* getPtr() const;
+      void* getPtr() const override;
 
       void copyTo(void *dest,
                   const udim_t bytes,
                   const udim_t destOffset = 0,
-                  const occa::json &props = occa::json()) const;
+                  const occa::json &props = occa::json()) const override;
 
       void copyFrom(const void *src,
                     const udim_t bytes,
                     const udim_t offset = 0,
-                    const occa::json &props = occa::json());
+                    const occa::json &props = occa::json()) override;
 
       void copyFrom(const modeMemory_t *src,
                     const udim_t bytes,
                     const udim_t destOffset = 0,
                     const udim_t srcOffset = 0,
-                    const occa::json &props = occa::json());
+                    const occa::json &props = occa::json()) override;
     };
   }
 }

--- a/src/occa/internal/modes/metal/buffer.hpp
+++ b/src/occa/internal/modes/metal/buffer.hpp
@@ -18,7 +18,7 @@ namespace occa {
       buffer(modeDevice_t *modeDevice_,
              udim_t size_,
              const occa::json &properties_ = occa::json());
-      ~buffer();
+      virtual ~buffer();
 
       void malloc(udim_t bytes) override;
 

--- a/src/occa/internal/modes/metal/device.hpp
+++ b/src/occa/internal/modes/metal/device.hpp
@@ -22,22 +22,22 @@ namespace occa {
       device(const occa::json &properties_);
       virtual ~device();
 
-      virtual bool hasSeparateMemorySpace() const;
+      bool hasSeparateMemorySpace() const override;
 
-      virtual hash_t hash() const;
+      hash_t hash() const override;
 
-      virtual hash_t kernelHash(const occa::json &props) const;
+      hash_t kernelHash(const occa::json &props) const override;
 
-      virtual lang::okl::withLauncher* createParser(const occa::json &props) const;
+      lang::okl::withLauncher* createParser(const occa::json &props) const override;
 
       //---[ Stream ]-------------------
-      virtual modeStream_t* createStream(const occa::json &props);
-      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props);
+      modeStream_t* createStream(const occa::json &props) override;
+      modeStream_t* wrapStream(void* ptr, const occa::json &props) override;
 
-      virtual streamTag tagStream();
-      virtual void waitFor(streamTag tag);
-      virtual double timeBetween(const streamTag &startTag,
-                                 const streamTag &endTag);
+      streamTag tagStream() override;
+      void waitFor(streamTag tag) override;
+      double timeBetween(const streamTag &startTag,
+                         const streamTag &endTag) override;
       //================================
 
       //---[ Kernel ]-------------------
@@ -49,7 +49,7 @@ namespace occa {
                                                    const bool usingOkl,
                                                    lang::sourceMetadata_t &launcherMetadata,
                                                    lang::sourceMetadata_t &deviceMetadata,
-                                                   const occa::json &kernelProps);
+                                                   const occa::json &kernelProps) override;
 
       void compileKernel(const std::string &hashDir,
                          const std::string &kernelName,
@@ -64,25 +64,25 @@ namespace occa {
                                              const std::string &binaryFilename,
                                              lang::sourceMetadata_t &launcherMetadata,
                                              lang::sourceMetadata_t &deviceMetadata,
-                                             const occa::json &kernelProps);
+                                             const occa::json &kernelProps) override;
 
-      virtual modeKernel_t* buildKernelFromBinary(const std::string &filename,
-                                                  const std::string &kernelName,
-                                                  const occa::json &kernelProps);
+      modeKernel_t* buildKernelFromBinary(const std::string &filename,
+                                          const std::string &kernelName,
+                                          const occa::json &kernelProps) override;
       //================================
 
       //---[ Memory ]-------------------
-      virtual modeMemory_t* malloc(const udim_t bytes,
-                                   const void *src,
-                                   const occa::json &props);
+      modeMemory_t* malloc(const udim_t bytes,
+                           const void *src,
+                           const occa::json &props) override;
 
       modeMemory_t* wrapMemory(const void *ptr,
                                const udim_t bytes,
-                               const occa::json &props);
+                               const occa::json &props) override;
 
-      modeMemoryPool_t* createMemoryPool(const occa::json &props);
+      modeMemoryPool_t* createMemoryPool(const occa::json &props) override;
 
-      virtual udim_t memorySize() const;
+      udim_t memorySize() const override;
       //================================
     };
   }

--- a/src/occa/internal/modes/metal/kernel.hpp
+++ b/src/occa/internal/modes/metal/kernel.hpp
@@ -28,13 +28,13 @@ namespace occa {
              api::metal::function_t metalFunction_,
              const occa::json &properties_);
 
-      ~kernel();
+      virtual ~kernel();
 
-      int maxDims() const;
-      dim maxOuterDims() const;
-      dim maxInnerDims() const;
+      int maxDims() const override;
+      dim maxOuterDims() const override;
+      dim maxInnerDims() const override;
 
-      void deviceRun() const;
+      void deviceRun() const override;
     };
   }
 }

--- a/src/occa/internal/modes/metal/memory.hpp
+++ b/src/occa/internal/modes/metal/memory.hpp
@@ -18,31 +18,31 @@ namespace occa {
              udim_t size_, dim_t offset_);
       memory(memoryPool *memPool,
              udim_t size_, dim_t offset_);
-      ~memory();
+      virtual ~memory();
 
-      void* getKernelArgPtr() const;
+      void* getKernelArgPtr() const override;
 
       const api::metal::buffer_t& getMetalBuffer();
 
-      void* getPtr() const;
+      void* getPtr() const override;
 
       udim_t getOffset() const;
 
       void copyTo(void *dest,
                   const udim_t bytes,
                   const udim_t destOffset = 0,
-                  const occa::json &props = occa::json()) const;
+                  const occa::json &props = occa::json()) const override;
 
       void copyFrom(const void *src,
                     const udim_t bytes,
                     const udim_t offset = 0,
-                    const occa::json &props = occa::json());
+                    const occa::json &props = occa::json()) override;
 
       void copyFrom(const modeMemory_t *src,
                     const udim_t bytes,
                     const udim_t destOffset = 0,
                     const udim_t srcOffset = 0,
-                    const occa::json &props = occa::json());
+                    const occa::json &props = occa::json()) override;
     };
   }
 }

--- a/src/occa/internal/modes/opencl/buffer.hpp
+++ b/src/occa/internal/modes/opencl/buffer.hpp
@@ -18,7 +18,7 @@ namespace occa {
       buffer(modeDevice_t *modeDevice_,
              udim_t size_,
              const occa::json &properties_ = occa::json());
-      ~buffer();
+      virtual ~buffer();
 
       void malloc(udim_t bytes) override;
 

--- a/src/occa/internal/modes/opencl/device.hpp
+++ b/src/occa/internal/modes/opencl/device.hpp
@@ -23,22 +23,22 @@ namespace occa {
       device(const occa::json &properties_);
       virtual ~device();
 
-      virtual bool hasSeparateMemorySpace() const;
+      bool hasSeparateMemorySpace() const override;
 
-      virtual hash_t hash() const;
+      hash_t hash() const override;
 
-      virtual hash_t kernelHash(const occa::json &props) const;
+      hash_t kernelHash(const occa::json &props) const override;
 
-      virtual lang::okl::withLauncher* createParser(const occa::json &props) const;
+      lang::okl::withLauncher* createParser(const occa::json &props) const override;
 
       //---[ Stream ]-------------------
-      virtual modeStream_t* createStream(const occa::json &props);
-      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props);
+      modeStream_t* createStream(const occa::json &props) override;
+      modeStream_t* wrapStream(void* ptr, const occa::json &props) override;
 
-      virtual streamTag tagStream();
-      virtual void waitFor(streamTag tag);
-      virtual double timeBetween(const streamTag &startTag,
-                                 const streamTag &endTag);
+      streamTag tagStream() override;
+      void waitFor(streamTag tag) override;
+      double timeBetween(const streamTag &startTag,
+                         const streamTag &endTag) override;
 
       cl_command_queue& getCommandQueue() const;
       //================================
@@ -52,7 +52,7 @@ namespace occa {
                                                    const bool usingOkl,
                                                    lang::sourceMetadata_t &launcherMetadata,
                                                    lang::sourceMetadata_t &deviceMetadata,
-                                                   const occa::json &kernelProps);
+                                                   const occa::json &kernelProps) override;
 
       modeKernel_t* buildOKLKernelFromBinary(const hash_t kernelHash,
                                              const std::string &hashDir,
@@ -61,7 +61,7 @@ namespace occa {
                                              const std::string &binaryFilename,
                                              lang::sourceMetadata_t &launcherMetadata,
                                              lang::sourceMetadata_t &deviceMetadata,
-                                             const occa::json &kernelProps);
+                                             const occa::json &kernelProps) override;
 
 
       modeKernel_t* buildOKLKernelFromBinary(info_t &clInfo,
@@ -74,23 +74,23 @@ namespace occa {
                                              lang::sourceMetadata_t &deviceMetadata,
                                              const occa::json &kernelProps);
 
-      virtual modeKernel_t* buildKernelFromBinary(const std::string &filename,
-                                                  const std::string &kernelName,
-                                                  const occa::json &kernelProps);
+      modeKernel_t* buildKernelFromBinary(const std::string &filename,
+                                          const std::string &kernelName,
+                                          const occa::json &kernelProps) override;
       //================================
 
       //---[ Memory ]-------------------
-      virtual modeMemory_t* malloc(const udim_t bytes,
-                                   const void *src,
-                                   const occa::json &props);
+      modeMemory_t* malloc(const udim_t bytes,
+                           const void *src,
+                           const occa::json &props) override;
 
       modeMemory_t* wrapMemory(const void *ptr,
                                const udim_t bytes,
-                               const occa::json &props);
+                               const occa::json &props) override;
 
-      modeMemoryPool_t* createMemoryPool(const occa::json &props);
+      modeMemoryPool_t* createMemoryPool(const occa::json &props) override;
 
-      virtual udim_t memorySize() const;
+      udim_t memorySize() const override;
       //================================
     };
   }

--- a/src/occa/internal/modes/opencl/kernel.hpp
+++ b/src/occa/internal/modes/opencl/kernel.hpp
@@ -30,15 +30,15 @@ namespace occa {
              cl_kernel clKernel_,
              const occa::json &properties_);
 
-      ~kernel();
+      virtual ~kernel();
 
       cl_command_queue& getCommandQueue() const;
 
-      int maxDims() const;
-      dim maxOuterDims() const;
-      dim maxInnerDims() const;
+      int maxDims() const override;
+      dim maxOuterDims() const override;
+      dim maxInnerDims() const override;
 
-      void deviceRun() const;
+      void deviceRun() const override;
     };
   }
 }

--- a/src/occa/internal/modes/opencl/memory.hpp
+++ b/src/occa/internal/modes/opencl/memory.hpp
@@ -22,29 +22,29 @@ namespace occa {
              udim_t size_, dim_t offset_);
       memory(memoryPool *memPool,
              udim_t size_, dim_t offset_);
-      ~memory();
+      virtual ~memory();
 
       cl_command_queue& getCommandQueue() const;
 
-      void* getKernelArgPtr() const;
+      void* getKernelArgPtr() const override;
 
-      void* getPtr() const;
+      void* getPtr() const override;
 
       void copyTo(void *dest,
                   const udim_t bytes,
                   const udim_t destOffset = 0,
-                  const occa::json &props = occa::json()) const;
+                  const occa::json &props = occa::json()) const override;
 
       void copyFrom(const void *src,
                     const udim_t bytes,
                     const udim_t offset = 0,
-                    const occa::json &props = occa::json());
+                    const occa::json &props = occa::json()) override;
 
       void copyFrom(const modeMemory_t *src,
                     const udim_t bytes,
                     const udim_t destOffset = 0,
                     const udim_t srcOffset = 0,
-                    const occa::json &props = occa::json());
+                    const occa::json &props = occa::json()) override;
     };
   }
 }

--- a/src/occa/internal/modes/openmp/device.hpp
+++ b/src/occa/internal/modes/openmp/device.hpp
@@ -14,20 +14,21 @@ namespace occa {
 
     public:
       device(const occa::json &properties_);
+      virtual ~device() = default;
 
-      virtual hash_t hash() const;
+      hash_t hash() const override;
 
-      virtual hash_t kernelHash(const occa::json &props) const;
+      hash_t kernelHash(const occa::json &props) const override;
 
-      virtual bool parseFile(const std::string &filename,
-                             const std::string &outputFile,
-                             const occa::json &kernelProps,
-                             lang::sourceMetadata_t &metadata);
+      bool parseFile(const std::string &filename,
+                     const std::string &outputFile,
+                     const occa::json &kernelProps,
+                     lang::sourceMetadata_t &metadata) override;
 
-      virtual modeKernel_t* buildKernel(const std::string &filename,
-                                        const std::string &kernelName,
-                                        const hash_t kernelHash,
-                                        const occa::json &kernelProps);
+      modeKernel_t* buildKernel(const std::string &filename,
+                                const std::string &kernelName,
+                                const hash_t kernelHash,
+                                const occa::json &kernelProps) override;
     };
   }
 }

--- a/src/occa/internal/modes/serial/buffer.hpp
+++ b/src/occa/internal/modes/serial/buffer.hpp
@@ -12,7 +12,7 @@ namespace occa {
       buffer(modeDevice_t *modeDevice_,
              udim_t size_,
              const occa::json &properties_ = occa::json());
-      ~buffer();
+      virtual ~buffer();
 
       void malloc(udim_t bytes) override;
 

--- a/src/occa/internal/modes/serial/device.cpp
+++ b/src/occa/internal/modes/serial/device.cpp
@@ -16,8 +16,6 @@ namespace occa {
     device::device(const occa::json &properties_) :
       occa::modeDevice_t(properties_) {}
 
-    device::~device() {}
-
     bool device::hasSeparateMemorySpace() const {
       return false;
     }

--- a/src/occa/internal/modes/serial/device.hpp
+++ b/src/occa/internal/modes/serial/device.hpp
@@ -11,22 +11,22 @@ namespace occa {
 
     public:
       device(const occa::json &properties_);
-      virtual ~device();
+      virtual ~device() = default;
 
-      virtual bool hasSeparateMemorySpace() const;
+      bool hasSeparateMemorySpace() const override;
 
-      virtual hash_t hash() const;
+      hash_t hash() const override;
 
-      virtual hash_t kernelHash(const occa::json &props) const;
+      hash_t kernelHash(const occa::json &props) const override;
 
       //---[ Stream ]-------------------
-      virtual modeStream_t* createStream(const occa::json &props);
-      virtual modeStream_t* wrapStream(void* ptr, const occa::json &props);
+      modeStream_t* createStream(const occa::json &props) override;
+      modeStream_t* wrapStream(void* ptr, const occa::json &props) override;
 
-      virtual streamTag tagStream();
-      virtual void waitFor(streamTag tag);
-      virtual double timeBetween(const streamTag &startTag,
-                                 const streamTag &endTag);
+      streamTag tagStream() override;
+      void waitFor(streamTag tag) override;
+      double timeBetween(const streamTag &startTag,
+                         const streamTag &endTag) override;
       //================================
 
       //---[ Kernel ]-------------------
@@ -35,10 +35,10 @@ namespace occa {
                              const occa::json &kernelProps,
                              lang::sourceMetadata_t &metadata);
 
-      virtual modeKernel_t* buildKernel(const std::string &filename,
-                                        const std::string &kernelName,
-                                        const hash_t kernelHash,
-                                        const occa::json &kernelProps);
+      modeKernel_t* buildKernel(const std::string &filename,
+                                const std::string &kernelName,
+                                const hash_t kernelHash,
+                                const occa::json &kernelProps) override;
 
       modeKernel_t* buildLauncherKernel(const std::string &filename,
                                         const std::string &kernelName,
@@ -48,11 +48,11 @@ namespace occa {
                                 const std::string &kernelName,
                                 const hash_t kernelHash,
                                 const occa::json &kernelProps,
-                                const bool isLauncerKernel);
+                                const bool isLauncherKernel);
 
-      virtual modeKernel_t* buildKernelFromBinary(const std::string &filename,
-                                                  const std::string &kernelName,
-                                                  const occa::json &kernelProps);
+      modeKernel_t* buildKernelFromBinary(const std::string &filename,
+                                          const std::string &kernelName,
+                                          const occa::json &kernelProps) override;
 
       virtual modeKernel_t* buildKernelFromBinary(const std::string &filename,
                                                   const std::string &kernelName,
@@ -61,17 +61,17 @@ namespace occa {
       //================================
 
       //---[ Memory ]-------------------
-      virtual modeMemory_t* malloc(const udim_t bytes,
-                                   const void *src,
-                                   const occa::json &props);
+      modeMemory_t* malloc(const udim_t bytes,
+                           const void *src,
+                           const occa::json &props) override;
 
       modeMemory_t* wrapMemory(const void *ptr,
                                const udim_t bytes,
-                               const occa::json &props);
+                               const occa::json &props) override;
 
-      modeMemoryPool_t* createMemoryPool(const occa::json &props);
+      modeMemoryPool_t* createMemoryPool(const occa::json &props) override;
 
-      virtual udim_t memorySize() const;
+      udim_t memorySize() const override;
       //================================
     };
   }

--- a/src/occa/internal/modes/serial/kernel.hpp
+++ b/src/occa/internal/modes/serial/kernel.hpp
@@ -24,15 +24,15 @@ namespace occa {
              const std::string &name_,
              const std::string &sourceFilename_,
              const occa::json &properties_);
-      ~kernel();
+      virtual ~kernel();
 
-      int maxDims() const;
-      dim maxOuterDims() const;
-      dim maxInnerDims() const;
+      int maxDims() const override;
+      dim maxOuterDims() const override;
+      dim maxInnerDims() const override;
 
-      const lang::kernelMetadata_t& getMetadata() const;
+      const lang::kernelMetadata_t& getMetadata() const override;
 
-      void run() const;
+      void run() const override;
 
       friend class device;
     };

--- a/src/occa/internal/modes/serial/memory.hpp
+++ b/src/occa/internal/modes/serial/memory.hpp
@@ -14,25 +14,25 @@ namespace occa {
              udim_t size_, dim_t offset_);
       memory(memoryPool *memPool,
              udim_t size_, dim_t offset_);
-      ~memory();
+      virtual ~memory();
 
-      void* getKernelArgPtr() const;
+      void* getKernelArgPtr() const override;
 
       void copyTo(void *dest,
                   const udim_t bytes,
                   const udim_t destOffset,
-                  const occa::json &props) const;
+                  const occa::json &props) const override;
 
       void copyFrom(const void *src,
                     const udim_t bytes,
                     const udim_t offset,
-                    const occa::json &props);
+                    const occa::json &props) override;
 
       void copyFrom(const modeMemory_t *src,
                     const udim_t bytes,
                     const udim_t destOffset,
                     const udim_t srcOffset,
-                    const occa::json &props);
+                    const occa::json &props) override;
     };
   }
 }

--- a/src/occa/internal/modes/serial/streamTag.cpp
+++ b/src/occa/internal/modes/serial/streamTag.cpp
@@ -8,7 +8,5 @@ namespace occa {
                          double time_) :
       modeStreamTag_t(modeDevice_),
       time(time_) {}
-
-    streamTag::~streamTag() {}
   }
 }

--- a/src/occa/internal/modes/serial/streamTag.hpp
+++ b/src/occa/internal/modes/serial/streamTag.hpp
@@ -14,7 +14,7 @@ namespace occa {
       streamTag(modeDevice_t *modeDevice_,
                 double time_);
 
-      virtual ~streamTag();
+      virtual ~streamTag() = default;
     };
   }
 }


### PR DESCRIPTION
## Details

- Adds `override` to the mode implementations of core OCCA data types.
- Only updates internal API&mdash;does not affect user code
