### PR TITLE
Adds option to control barrier insertion via kernel properties.

### DIFF
--- a/src/occa/internal/lang/modes/withLauncher.cpp
+++ b/src/occa/internal/lang/modes/withLauncher.cpp
@@ -16,6 +16,7 @@ namespace occa {
         parser_t(settings_),
         launcherParser(settings["launcher"]) {
         launcherParser.settings["okl/validate"] = false;
+        add_barriers = settings.get("okl/add_barriers", true);
       }
 
       //---[ Public ]-------------------
@@ -622,7 +623,7 @@ namespace occa {
       }
 
       bool withLauncher::usesBarriers() {
-        return true;
+        return add_barriers;
       }
     }
   }

--- a/src/occa/internal/lang/modes/withLauncher.hpp
+++ b/src/occa/internal/lang/modes/withLauncher.hpp
@@ -8,6 +8,8 @@ namespace occa {
   namespace lang {
     namespace okl {
       class withLauncher : public parser_t {
+       private:
+        bool add_barriers{true};
        public:
         serialParser launcherParser;
 


### PR DESCRIPTION
## Description

- Adds the option to control the automatic insertion of `@barrier`s using `occa::json` kernel property `okl/add_barriers`.
- The default value for this property is `true`.
- When `okl/add_barriers` is set to `false`, the net effect is equivalent to adding `@nobarrier` to every `@inner` loop block.
- This property does not affect explicit `@barrier` commands