### PR TITLE
enable occa on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,16 @@
 name: Build
 
-on:
+on: 
   push:
-    branches: [ main, development ]
+    paths-ignore:
+      - 'README.md'
+      - 'INSTALL.md'
+      - 'docs/**'
   pull_request:
-    branches: [ main, development ]
+    paths-ignore:
+      - 'README.md'
+      - 'INSTALL.md'
+      - 'docs/**'
 
 jobs:
   run:

--- a/include/occa/defines/msvc.hpp
+++ b/include/occa/defines/msvc.hpp
@@ -1,0 +1,55 @@
+#ifndef OCCA_DEFINES_MSVC_HEADER
+#define OCCA_DEFINES_MSVC_HEADER
+
+// NBN: adapted from compiledDefines.hpp
+// FIXME: #defines appropriate for local win64 build
+// FIXME: user must edit for current system
+// TODO: enable local generation with cmake?
+
+#ifndef OCCA_LINUX_OS
+#  define OCCA_LINUX_OS 1
+#endif
+
+#ifndef OCCA_MACOS_OS
+#  define OCCA_MACOS_OS 2
+#endif
+
+#ifndef OCCA_WINDOWS_OS
+#  define OCCA_WINDOWS_OS 4
+#endif
+
+#ifndef OCCA_WINUX_OS
+#  define OCCA_WINUX_OS (OCCA_LINUX_OS | OCCA_WINDOWS_OS)
+#endif
+
+#define OCCA_OS             OCCA_WINDOWS_OS
+#define OCCA_USING_VS       1
+#define OCCA_VS_VERSION     _MSC_VER
+#define OCCA_UNSAFE         0
+
+#define OCCA_MPI_ENABLED    1
+#define OCCA_OPENMP_ENABLED 1
+#define OCCA_CUDA_ENABLED   1
+#define OCCA_DPCPP_ENABLED  0
+#define OCCA_HIP_ENABLED    0
+#define OCCA_OPENCL_ENABLED 0
+#define OCCA_METAL_ENABLED  0
+
+// TODO: select appropriate intrinsics
+#define __AVX__
+#define __SSE4_2__
+#define __SSE4_1__
+#define __SSE3__
+#define __SSE2__
+
+// TODO: define appropriate paths
+#define OCCA_BUILD_DIR     "D:/TW/occa"
+#define OCCA_SOURCE_DIR    "D:/TW/occa"
+
+#ifdef NDEBUG
+#  define OCCA_DEBUG_ENABLED 0
+#else
+#  define OCCA_DEBUG_ENABLED 1
+#endif
+
+#endif  // OCCA_DEFINES_MSVC_HEADER

--- a/include/occa/defines/windows.hpp
+++ b/include/occa/defines/windows.hpp
@@ -1,10 +1,8 @@
 #ifndef OCCA_DEFINES_WINDOWS_HEADER
 #define OCCA_DEFINES_WINDOWS_HEADER
-#  if OCCA_OS == OCCA_WINDOWS_OS
 
-// (OCCA_VS_VERSION == 1900) : MSVC++ 14.x - Visual Studio 2015
-// (OCCA_VS_VERSION >= 1910) : MSVC++ 15.x - Visual Studio 2017
-#define OCCA_VS_VERSION _MSC_VER
+#ifdef _MSC_VER
+#include <occa/defines/msvc.hpp>
+#endif
 
-#  endif
 #endif

--- a/include/occa/types/primitive.hpp
+++ b/include/occa/types/primitive.hpp
@@ -316,11 +316,15 @@ namespace occa {
       case primitiveType::int16_  : return (T) value.int16_;
       case primitiveType::int32_  : return (T) value.int32_;
       case primitiveType::int64_  : return (T) value.int64_;
+#ifndef _MSC_VER   // NBN: GCC only
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
       case primitiveType::float_  : return (T) value.float_;
       case primitiveType::double_ : return (T) value.double_;
+#ifndef _MSC_VER
 #pragma GCC diagnostic pop
+#endif
       default: OCCA_FORCE_ERROR("Type not set");
       }
       return T();

--- a/include/occa/types/typeinfo.hpp
+++ b/include/occa/types/typeinfo.hpp
@@ -39,6 +39,8 @@ namespace occa {
   typedef unsigned int   uint_t;
   typedef unsigned long  ulong_t;
 
+#ifndef _MSC_VER
+  // NBN: these are defined in /occa/src/types/typeinfo.cpp
   template <> const std::string primitiveinfo<char>::id;
   template <> const std::string primitiveinfo<char>::name;
   template <> const bool        primitiveinfo<char>::isUnsigned;
@@ -202,6 +204,173 @@ namespace occa {
   template <> const std::string typeinfo<double4>::id;
   template <> const std::string typeinfo<double4>::name;
   template <> const bool        typeinfo<double4>::isUnsigned;
+#else
+  // NBN: MSVC error C2737: "const object must be initialized"
+  template <> const std::string primitiveinfo<char>::id         = "c";
+  template <> const std::string primitiveinfo<char>::name       = "char";
+  template <> const bool        primitiveinfo<char>::isUnsigned = false;
+
+  template <> const std::string primitiveinfo<short>::id         = "s";
+  template <> const std::string primitiveinfo<short>::name       = "short";
+  template <> const bool        primitiveinfo<short>::isUnsigned = false;
+
+  template <> const std::string primitiveinfo<int>::id         = "i";
+  template <> const std::string primitiveinfo<int>::name       = "int";
+  template <> const bool        primitiveinfo<int>::isUnsigned = false;
+
+  template <> const std::string primitiveinfo<long>::id         = "l";
+  template <> const std::string primitiveinfo<long>::name       = "long";
+  template <> const bool        primitiveinfo<long>::isUnsigned = false;
+
+  template <> const std::string primitiveinfo<schar_t>::id         = "sc";
+  template <> const std::string primitiveinfo<schar_t>::name       = "schar_t";
+  template <> const bool        primitiveinfo<schar_t>::isUnsigned = false;
+
+  template <> const std::string primitiveinfo<uchar_t>::id         = "uc";
+  template <> const std::string primitiveinfo<uchar_t>::name       = "uchar_t";
+  template <> const bool        primitiveinfo<uchar_t>::isUnsigned = true;
+
+  template <> const std::string primitiveinfo<ushort_t>::id         = "us";
+  template <> const std::string primitiveinfo<ushort_t>::name       = "ushort_t";
+  template <> const bool        primitiveinfo<ushort_t>::isUnsigned = true;
+
+  template <> const std::string primitiveinfo<uint_t>::id         = "ui";
+  template <> const std::string primitiveinfo<uint_t>::name       = "uint_t";
+  template <> const bool        primitiveinfo<uint_t>::isUnsigned = true;
+
+  template <> const std::string primitiveinfo<ulong_t>::id         = "ul";
+  template <> const std::string primitiveinfo<ulong_t>::name       = "ulong_t";
+  template <> const bool        primitiveinfo<ulong_t>::isUnsigned = true;
+
+  template <> const std::string primitiveinfo<float>::id         = "f";
+  template <> const std::string primitiveinfo<float>::name       = "float";
+  template <> const bool        primitiveinfo<float>::isUnsigned = false;
+
+  template <> const std::string primitiveinfo<double>::id         = "d";
+  template <> const std::string primitiveinfo<double>::name       = "double";
+  template <> const bool        primitiveinfo<double>::isUnsigned = false;
+
+  template <> const std::string typeinfo<uint8_t>::id         = "u8";
+  template <> const std::string typeinfo<uint8_t>::name       = "uint8";
+  template <> const bool        typeinfo<uint8_t>::isUnsigned = true;
+
+  template <> const std::string typeinfo<uint16_t>::id         = "u16";
+  template <> const std::string typeinfo<uint16_t>::name       = "uint16";
+  template <> const bool        typeinfo<uint16_t>::isUnsigned = true;
+
+  template <> const std::string typeinfo<uint32_t>::id         = "u32";
+  template <> const std::string typeinfo<uint32_t>::name       = "uint32";
+  template <> const bool        typeinfo<uint32_t>::isUnsigned = true;
+
+  template <> const std::string typeinfo<uint64_t>::id         = "u64";
+  template <> const std::string typeinfo<uint64_t>::name       = "uint64";
+  template <> const bool        typeinfo<uint64_t>::isUnsigned = true;
+
+  template <> const std::string typeinfo<int8_t>::id         = "i8";
+  template <> const std::string typeinfo<int8_t>::name       = "int8";
+  template <> const bool        typeinfo<int8_t>::isUnsigned = false;
+
+  template <> const std::string typeinfo<int16_t>::id         = "i16";
+  template <> const std::string typeinfo<int16_t>::name       = "int16";
+  template <> const bool        typeinfo<int16_t>::isUnsigned = false;
+
+  template <> const std::string typeinfo<int32_t>::id         = "i32";
+  template <> const std::string typeinfo<int32_t>::name       = "int32";
+  template <> const bool        typeinfo<int32_t>::isUnsigned = false;
+
+  template <> const std::string typeinfo<int64_t>::id         = "i64";
+  template <> const std::string typeinfo<int64_t>::name       = "int64";
+  template <> const bool        typeinfo<int64_t>::isUnsigned = false;
+
+  template <> const std::string typeinfo<float>::id         = "f32";
+  template <> const std::string typeinfo<float>::name       = "float";
+  template <> const bool        typeinfo<float>::isUnsigned = false;
+
+  template <> const std::string typeinfo<double>::id         = "f64";
+  template <> const std::string typeinfo<double>::name       = "double";
+  template <> const bool        typeinfo<double>::isUnsigned = false;
+
+  template <> const std::string typeinfo<uchar2>::id         = "vuc2";
+  template <> const std::string typeinfo<uchar2>::name       = "uchar2";
+  template <> const bool        typeinfo<uchar2>::isUnsigned = true;
+
+  template <> const std::string typeinfo<uchar4>::id         = "vuc4";
+  template <> const std::string typeinfo<uchar4>::name       = "uchar4";
+  template <> const bool        typeinfo<uchar4>::isUnsigned = true;
+
+  template <> const std::string typeinfo<char2>::id         = "vc2";
+  template <> const std::string typeinfo<char2>::name       = "char2";
+  template <> const bool        typeinfo<char2>::isUnsigned = false;
+
+  template <> const std::string typeinfo<char4>::id         = "vc4";
+  template <> const std::string typeinfo<char4>::name       = "char4";
+  template <> const bool        typeinfo<char4>::isUnsigned = false;
+
+  template <> const std::string typeinfo<ushort2>::id         = "vus2";
+  template <> const std::string typeinfo<ushort2>::name       = "ushort2";
+  template <> const bool        typeinfo<ushort2>::isUnsigned = true;
+
+  template <> const std::string typeinfo<ushort4>::id         = "vus4";
+  template <> const std::string typeinfo<ushort4>::name       = "ushort4";
+  template <> const bool        typeinfo<ushort4>::isUnsigned = true;
+
+  template <> const std::string typeinfo<short2>::id         = "vs2";
+  template <> const std::string typeinfo<short2>::name       = "short2";
+  template <> const bool        typeinfo<short2>::isUnsigned = false;
+
+  template <> const std::string typeinfo<short4>::id         = "vs4";
+  template <> const std::string typeinfo<short4>::name       = "short4";
+  template <> const bool        typeinfo<short4>::isUnsigned = false;
+
+  template <> const std::string typeinfo<uint2>::id         = "vui2";
+  template <> const std::string typeinfo<uint2>::name       = "uint2";
+  template <> const bool        typeinfo<uint2>::isUnsigned = true;
+
+  template <> const std::string typeinfo<uint4>::id         = "vui4";
+  template <> const std::string typeinfo<uint4>::name       = "uint4";
+  template <> const bool        typeinfo<uint4>::isUnsigned = true;
+
+  template <> const std::string typeinfo<int2>::id         = "vi2";
+  template <> const std::string typeinfo<int2>::name       = "int2";
+  template <> const bool        typeinfo<int2>::isUnsigned = false;
+
+  template <> const std::string typeinfo<int4>::id         = "vi4";
+  template <> const std::string typeinfo<int4>::name       = "int4";
+  template <> const bool        typeinfo<int4>::isUnsigned = false;
+
+  template <> const std::string typeinfo<ulong2>::id         = "vul2";
+  template <> const std::string typeinfo<ulong2>::name       = "ulong2";
+  template <> const bool        typeinfo<ulong2>::isUnsigned = true;
+
+  template <> const std::string typeinfo<ulong4>::id         = "vul4";
+  template <> const std::string typeinfo<ulong4>::name       = "ulong4";
+  template <> const bool        typeinfo<ulong4>::isUnsigned = true;
+
+  template <> const std::string typeinfo<long2>::id         = "vl2";
+  template <> const std::string typeinfo<long2>::name       = "long2";
+  template <> const bool        typeinfo<long2>::isUnsigned = false;
+
+  template <> const std::string typeinfo<long4>::id         = "vl4";
+  template <> const std::string typeinfo<long4>::name       = "long4";
+  template <> const bool        typeinfo<long4>::isUnsigned = false;
+
+  template <> const std::string typeinfo<float2>::id         = "vf2";
+  template <> const std::string typeinfo<float2>::name       = "float2";
+  template <> const bool        typeinfo<float2>::isUnsigned = false;
+
+  template <> const std::string typeinfo<float4>::id         = "vf4";
+  template <> const std::string typeinfo<float4>::name       = "float4";
+  template <> const bool        typeinfo<float4>::isUnsigned = false;
+
+  template <> const std::string typeinfo<double2>::id         = "vd2";
+  template <> const std::string typeinfo<double2>::name       = "double2";
+  template <> const bool        typeinfo<double2>::isUnsigned = false;
+
+  template <> const std::string typeinfo<double4>::id         = "vd4";
+  template <> const std::string typeinfo<double4>::name       = "double4";
+  template <> const bool        typeinfo<double4>::isUnsigned = false;
+#endif  // NBN: MSVC
+
 }
 
 #endif

--- a/scripts/buildvc/libocca.sln
+++ b/scripts/buildvc/libocca.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31702.278
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libocca", "libocca.vcxproj", "{9C04ABAC-B788-4C2D-ABFC-092DAE783731}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9C04ABAC-B788-4C2D-ABFC-092DAE783731}.Debug|x64.ActiveCfg = Debug|x64
+		{9C04ABAC-B788-4C2D-ABFC-092DAE783731}.Debug|x64.Build.0 = Debug|x64
+		{9C04ABAC-B788-4C2D-ABFC-092DAE783731}.Release|x64.ActiveCfg = Release|x64
+		{9C04ABAC-B788-4C2D-ABFC-092DAE783731}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D92D54DA-69C9-4E7F-96F0-BEA13CE74CAD}
+	EndGlobalSection
+EndGlobal

--- a/scripts/buildvc/libocca.vcxproj
+++ b/scripts/buildvc/libocca.vcxproj
@@ -1,0 +1,630 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{9c04abac-b788-4c2d-abfc-092dae783731}</ProjectGuid>
+    <RootNamespace>libocca</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>..\..\lib\</OutDir>
+    <TargetName>$(ProjectName)_d</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>..\..\lib\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>libocca_pch.hpp</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>D:\TW\occa\include;D:\TW\occa\src;$(MSMPI_INC);$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ForcedIncludeFiles>libocca_pch.hpp</ForcedIncludeFiles>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4267;4996;4250;</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>libocca_pch.hpp</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>D:\TW\occa\include;D:\TW\occa\src;$(MSMPI_INC);$(CUDA_PATH)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
+      <ForcedIncludeFiles>libocca_pch.hpp</ForcedIncludeFiles>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4267;4996;4250;</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\occa.hpp" />
+    <ClInclude Include="..\..\include\occa\core.hpp" />
+    <ClInclude Include="..\..\include\occa\core\base.hpp" />
+    <ClInclude Include="..\..\include\occa\core\device.hpp" />
+    <ClInclude Include="..\..\include\occa\core\kernel.hpp" />
+    <ClInclude Include="..\..\include\occa\core\kernelArg.hpp" />
+    <ClInclude Include="..\..\include\occa\core\memory.hpp" />
+    <ClInclude Include="..\..\include\occa\core\memoryPool.hpp" />
+    <ClInclude Include="..\..\include\occa\core\stream.hpp" />
+    <ClInclude Include="..\..\include\occa\core\streamTag.hpp" />
+    <ClInclude Include="..\..\include\occa\defines.hpp" />
+    <ClInclude Include="..\..\include\occa\defines\arch.hpp" />
+    <ClInclude Include="..\..\include\occa\defines\errors.hpp" />
+    <ClInclude Include="..\..\include\occa\defines\macros.hpp" />
+    <ClInclude Include="..\..\include\occa\defines\msvc.hpp" />
+    <ClInclude Include="..\..\include\occa\defines\occa.hpp" />
+    <ClInclude Include="..\..\include\occa\defines\okl.hpp" />
+    <ClInclude Include="..\..\include\occa\defines\os.hpp" />
+    <ClInclude Include="..\..\include\occa\dtype.hpp" />
+    <ClInclude Include="..\..\include\occa\dtype\builtins.hpp" />
+    <ClInclude Include="..\..\include\occa\dtype\dtype.hpp" />
+    <ClInclude Include="..\..\include\occa\dtype\utils.hpp" />
+    <ClInclude Include="..\..\include\occa\experimental.hpp" />
+    <ClInclude Include="..\..\include\occa\experimental\kernelBuilder.hpp" />
+    <ClInclude Include="..\..\include\occa\functional.hpp" />
+    <ClInclude Include="..\..\include\occa\functional\array.hpp" />
+    <ClInclude Include="..\..\include\occa\functional\baseFunction.hpp" />
+    <ClInclude Include="..\..\include\occa\functional\function.hpp" />
+    <ClInclude Include="..\..\include\occa\functional\functionDefinition.hpp" />
+    <ClInclude Include="..\..\include\occa\functional\range.hpp" />
+    <ClInclude Include="..\..\include\occa\functional\scope.hpp" />
+    <ClInclude Include="..\..\include\occa\functional\typelessArray.hpp" />
+    <ClInclude Include="..\..\include\occa\functional\types.hpp" />
+    <ClInclude Include="..\..\include\occa\functional\utils.hpp" />
+    <ClInclude Include="..\..\include\occa\loops.hpp" />
+    <ClInclude Include="..\..\include\occa\loops\forLoop.hpp" />
+    <ClInclude Include="..\..\include\occa\loops\innerForLoop.hpp" />
+    <ClInclude Include="..\..\include\occa\loops\iteration.hpp" />
+    <ClInclude Include="..\..\include\occa\loops\outerForLoop.hpp" />
+    <ClInclude Include="..\..\include\occa\loops\typelessForLoop.hpp" />
+    <ClInclude Include="..\..\include\occa\types.hpp" />
+    <ClInclude Include="..\..\include\occa\types\bits.hpp" />
+    <ClInclude Include="..\..\include\occa\types\dim.hpp" />
+    <ClInclude Include="..\..\include\occa\types\generic.hpp" />
+    <ClInclude Include="..\..\include\occa\types\json.hpp" />
+    <ClInclude Include="..\..\include\occa\types\primitive.hpp" />
+    <ClInclude Include="..\..\include\occa\types\tuples.hpp" />
+    <ClInclude Include="..\..\include\occa\types\typedefs.hpp" />
+    <ClInclude Include="..\..\include\occa\types\typeinfo.hpp" />
+    <ClInclude Include="..\..\include\occa\utils.hpp" />
+    <ClInclude Include="..\..\include\occa\utils\env.hpp" />
+    <ClInclude Include="..\..\include\occa\utils\exception.hpp" />
+    <ClInclude Include="..\..\include\occa\utils\gc.hpp" />
+    <ClInclude Include="..\..\include\occa\utils\hash.hpp" />
+    <ClInclude Include="..\..\include\occa\utils\io.hpp" />
+    <ClInclude Include="..\..\include\occa\utils\logging.hpp" />
+    <ClInclude Include="..\..\include\occa\utils\mutex.hpp" />
+    <ClInclude Include="..\..\include\occa\utils\store.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\bin\occa.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\core\buffer.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\core\device.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\core\kernel.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\core\launchedDevice.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\core\launchedKernel.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\core\memory.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\core\memoryPool.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\core\stream.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\core\streamTag.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\functional\functionStore.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\io.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\io\cache.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\io\enums.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\io\output.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\io\utils.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\attribute.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\atomic.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\barrier.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\dim.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\exclusive.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\globalPtr.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\implicitArg.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\inner.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\kernel.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\maxInnerDims.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\noBarrier.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\outer.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\restrict.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\shared.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\tile.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\types.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\binaryOpNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\callNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\charNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\constCastNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\cudaCallNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\deleteNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\dpcppAtomicNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\dpcppLocalMemoryNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\dynamicCastNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\emptyNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\expr.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\expressionParser.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\exprNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\exprNodeArray.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\exprNodes.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\exprOpNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\funcCastNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\functionNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\identifierNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\lambdaNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\leftUnaryOpNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\newNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\pairNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\parenCastNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\parenthesesNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\primitiveNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\reinterpretCastNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\rightUnaryOpNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\sizeofNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\staticCastNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\stringNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\subscriptNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\ternaryOpNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\throwNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\tupleNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\typeNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\variableNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\vartypeNode.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\file.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\kernelMetadata.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\keyword.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\loaders.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\loaders\attributeLoader.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\loaders\structLoader.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\loaders\typeLoader.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\loaders\variableLoader.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\macro.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\cuda.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\dpcpp.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\hip.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\metal.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\okl.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\oklForStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\opencl.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\openmp.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\serial.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\withLauncher.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\operator.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\parser.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\preprocessor.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\printer.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\processingStages.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\qualifier.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\scope.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\specialMacros.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statementContext.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statementPeeker.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\blockStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\breakStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\caseStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\classAccessStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\commentStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\continueStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\declarationStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\defaultStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\directiveStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\elifStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\elseStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\emptyStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\expressionStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\forStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\functionDeclStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\functionStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\gotoLabelStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\gotoStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\ifStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\namespaceStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\pragmaStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\returnStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\sourceCodeStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\statement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\statementArray.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\switchStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\whileStatement.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\stream.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\tokenContext.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\tokenizer.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\charToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\commentToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\directiveToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\functionToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\identifierToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\newlineToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\operatorToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\pragmaToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\primitiveToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\qualifierToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\stringToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\token.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\typeToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\unknownToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\variableToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\token\vartypeToken.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\array.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\class.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\enum.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\function.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\functionPtr.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\lambda.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\pointer.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\primitive.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\struct.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\structure.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\type.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\typedef.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\union.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\type\vartype.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\utils\array.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\lang\variable.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\buffer.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\device.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\kernel.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\memory.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\memoryPool.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\polyfill.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\registration.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\stream.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\streamTag.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\utils.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\buffer.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\device.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\kernel.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\memory.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\memoryPool.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\polyfill.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\registration.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\stream.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\streamTag.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\utils.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\hip.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\metal.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\opencl.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\openmp\device.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\openmp\registration.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\openmp\utils.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\buffer.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\device.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\kernel.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\memory.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\memoryPool.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\registration.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\stream.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\streamTag.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\cli.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\enums.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\env.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\gc.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\lex.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\misc.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\store.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\string.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\styling.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\sys.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\testing.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\trie.hpp" />
+    <ClInclude Include="..\..\src\occa\internal\utils\vector.hpp" />
+    <ClInclude Include="libocca_pch.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\core\base.cpp" />
+    <ClCompile Include="..\..\src\core\device.cpp" />
+    <ClCompile Include="..\..\src\core\kernel.cpp" />
+    <ClCompile Include="..\..\src\core\kernelArg.cpp" />
+    <ClCompile Include="..\..\src\core\memory.cpp" />
+    <ClCompile Include="..\..\src\core\memoryPool.cpp" />
+    <ClCompile Include="..\..\src\core\stream.cpp" />
+    <ClCompile Include="..\..\src\core\streamTag.cpp" />
+    <ClCompile Include="..\..\src\dtype\builtins.cpp" />
+    <ClCompile Include="..\..\src\dtype\dtype.cpp" />
+    <ClCompile Include="..\..\src\experimental\kernelBuilder.cpp" />
+    <ClCompile Include="..\..\src\functional\baseFunction.cpp" />
+    <ClCompile Include="..\..\src\functional\functionDefinition.cpp" />
+    <ClCompile Include="..\..\src\functional\range.cpp" />
+    <ClCompile Include="..\..\src\functional\scope.cpp" />
+    <ClCompile Include="..\..\src\functional\utils.cpp" />
+    <ClCompile Include="..\..\src\loops\forLoop.cpp" />
+    <ClCompile Include="..\..\src\loops\iteration.cpp" />
+    <ClCompile Include="..\..\src\loops\typelessForLoop.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\bin\occa.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\core\buffer.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\core\device.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\core\kernel.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\core\launchedDevice.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\core\launchedKernel.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\core\memory.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\core\memoryPool.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\core\stream.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\core\streamTag.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\functional\functionStore.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\io\cache.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\io\output.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\io\utils.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\io\utils_win.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\attribute.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\atomic.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\barrier.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\dim.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\exclusive.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\globalPtr.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\implicitArg.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\inner.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\kernel.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\maxInnerDims.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\noBarrier.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\outer.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\restrict.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\shared.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\tile.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\types.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\binaryOpNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\callNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\charNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\constCastNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\cudaCallNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\deleteNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\dpcppAtomicNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\dpcppLocalMemoryNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\dynamicCastNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\emptyNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\expr.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\expressionParser.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\exprNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\exprNodeArray.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\exprOpNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\funcCastNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\functionNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\identifierNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\lambdaNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\leftUnaryOpNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\newNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\pairNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\parenCastNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\parenthesesNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\primitiveNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\reinterpretCastNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\rightUnaryOpNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\sizeofNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\staticCastNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\stringNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\subscriptNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\ternaryOpNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\throwNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\tupleNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\typeNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\variableNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\vartypeNode.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\file.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\kernelMetadata.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\keyword.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\loaders\attributeLoader.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\loaders\structLoader.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\loaders\typeLoader.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\loaders\variableLoader.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\macro.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\cuda.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\dpcpp.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\hip.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\metal.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\okl.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\oklForStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\opencl.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\openmp.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\serial.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\withLauncher.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\operator.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\parser.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\preprocessor.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\printer.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\processingStages.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\qualifier.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\scope.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\specialMacros.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statementContext.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statementPeeker.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\blockStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\breakStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\caseStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\classAccessStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\commentStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\continueStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\declarationStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\defaultStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\directiveStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\elifStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\elseStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\emptyStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\expressionStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\forStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\functionDeclStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\functionStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\gotoLabelStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\gotoStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\ifStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\namespaceStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\pragmaStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\returnStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\sourceCodeStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\statement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\statementArray.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\switchStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\whileStatement.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\tokenContext.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\tokenizer.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\charToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\commentToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\directiveToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\functionToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\identifierToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\newlineToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\operatorToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\pragmaToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\primitiveToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\qualifierToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\stringToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\token.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\typeToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\unknownToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\variableToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\token\vartypeToken.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\array.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\class.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\enum.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\function.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\functionPtr.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\lambda.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\pointer.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\primitive.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\struct.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\structure.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\type.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\typedef.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\union.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\type\vartype.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\lang\variable.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\buffer.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\device.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\kernel.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\memory.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\memoryPool.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\registration.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\stream.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\streamTag.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\utils.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\buffer.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\device.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\kernel.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\memory.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\memoryPool.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\registration.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\stream.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\streamTag.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\utils.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\openmp\device.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\openmp\registration.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\openmp\utils.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\buffer.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\device.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\kernel.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\memory.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\memoryPool.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\registration.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\stream.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\streamTag.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\cli.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\env.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\gc.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\lex.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\misc.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\string.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\styling.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\sys.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\testing.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\trie.cpp" />
+    <ClCompile Include="..\..\src\occa\internal\utils\vector.cpp" />
+    <ClCompile Include="..\..\src\types\dim.cpp" />
+    <ClCompile Include="..\..\src\types\json.cpp" />
+    <ClCompile Include="..\..\src\types\primitive.cpp" />
+    <ClCompile Include="..\..\src\types\typeinfo.cpp" />
+    <ClCompile Include="..\..\src\utils\exception.cpp" />
+    <ClCompile Include="..\..\src\utils\hash.cpp" />
+    <ClCompile Include="..\..\src\utils\io.cpp" />
+    <ClCompile Include="..\..\src\utils\logging.cpp" />
+    <ClCompile Include="..\..\src\utils\mutex.cpp" />
+    <ClCompile Include="libocca_pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\include\occa\core\base.tpp" />
+    <None Include="..\..\include\occa\core\device.tpp" />
+    <None Include="..\..\include\occa\core\memory.tpp" />
+    <None Include="..\..\include\occa\core\memoryPool.tpp" />
+    <None Include="..\..\include\occa\types\json.tpp" />
+    <None Include="..\..\src\occa\internal\io\output.tpp" />
+    <None Include="..\..\src\occa\internal\lang\loaders\variableLoader.tpp" />
+    <None Include="..\..\src\occa\internal\lang\parser.tpp" />
+    <None Include="..\..\src\occa\internal\lang\stream.tpp" />
+    <None Include="..\..\src\occa\internal\lang\utils\array.tpp" />
+    <None Include="..\..\src\occa\internal\utils\cli.tpp" />
+    <None Include="..\..\src\occa\internal\utils\gc.tpp" />
+    <None Include="..\..\src\occa\internal\utils\trie.tpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/scripts/buildvc/libocca.vcxproj.filters
+++ b/scripts/buildvc/libocca.vcxproj.filters
@@ -1,0 +1,1696 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Source Files\src">
+      <UniqueIdentifier>{41e1a450-2b8d-4038-877b-e3207a900a5a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\core">
+      <UniqueIdentifier>{1d8e314e-9850-45a3-bd1a-c558143b3534}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\dtype">
+      <UniqueIdentifier>{886fd1da-c8fd-4a8d-aa5d-97857ba5f385}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\experimental">
+      <UniqueIdentifier>{8a6038d8-a8af-4ebe-a618-74d8028c7ba9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\functional">
+      <UniqueIdentifier>{dce7f23f-8d90-453c-91c5-cec137dadff2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\loops">
+      <UniqueIdentifier>{66d05912-2af4-4b15-acfa-71e19aed8f63}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa">
+      <UniqueIdentifier>{ce45b918-d38c-4fd8-83cc-29483fea76fb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\types">
+      <UniqueIdentifier>{9c17c26a-a7e8-4377-a826-c293d052937c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\utils">
+      <UniqueIdentifier>{f8bb39dd-2f1c-4b60-91a9-79ca8199c88b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal">
+      <UniqueIdentifier>{01b8f024-08f3-4945-b891-eb368bd6ac65}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\api">
+      <UniqueIdentifier>{0b0bc983-065e-4e0b-9c35-5c00a653d766}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\bin">
+      <UniqueIdentifier>{af7bed23-f189-4f90-b5a6-1d3bc2a0b45b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\core">
+      <UniqueIdentifier>{40057dca-70d2-4656-921a-d686c99475f5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\functional">
+      <UniqueIdentifier>{1898e662-b74f-4ba3-98d7-bae05fc6e8ff}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\io">
+      <UniqueIdentifier>{e98a0019-0102-4e1d-a2eb-c8df36cac07a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\lang">
+      <UniqueIdentifier>{63fc2f55-8f45-461f-9aad-2e471bdd2ec5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\modes">
+      <UniqueIdentifier>{a26fe1c6-bcfa-4b74-aee2-c45814a56aa2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\utils">
+      <UniqueIdentifier>{26ab8cdf-0acf-48f3-8770-0f15d639a18d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\lang\builtins">
+      <UniqueIdentifier>{30d396a6-e3ee-467b-bf67-366cede9ee73}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\lang\expr">
+      <UniqueIdentifier>{ef8d3018-0463-4a90-b86c-00594e6ab457}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\lang\loaders">
+      <UniqueIdentifier>{e7ec218e-588a-45a5-8eac-9b80a8e99d8a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\lang\modes">
+      <UniqueIdentifier>{49dcfec3-52a4-4cf2-9f23-82242f39772d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\lang\statement">
+      <UniqueIdentifier>{54a13efb-7da1-4e04-a092-780410aaa8b5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\lang\token">
+      <UniqueIdentifier>{f986a8a9-c1e8-429d-b362-86911bcafcf7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\lang\type">
+      <UniqueIdentifier>{ca953529-50fb-4874-a940-374d1786c7ef}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\lang\utils">
+      <UniqueIdentifier>{b62eb426-c704-4b64-b2e4-fd98e52de39e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\lang\builtins\attributes">
+      <UniqueIdentifier>{d07a86cf-3c73-45bd-af5c-dbdfe7a1a8ef}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\modes\cuda">
+      <UniqueIdentifier>{0f68fb06-e58c-402c-9313-fb9cf783f067}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\modes\dpcpp">
+      <UniqueIdentifier>{28b12a12-1571-4220-9e0a-61b81520ceb2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\modes\hip">
+      <UniqueIdentifier>{2fb6f37e-45ac-49ab-90f6-5375ffe7f2c4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\modes\metal">
+      <UniqueIdentifier>{ed12418c-995c-41d9-8e48-685b03ddc6dd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\modes\opencl">
+      <UniqueIdentifier>{272045a0-1dd9-4170-83a4-b95e1db76801}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\modes\openmp">
+      <UniqueIdentifier>{e367ff9e-6fba-4379-8778-f45cfb4b3a52}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\occa\internal\modes\serial">
+      <UniqueIdentifier>{d96ec962-2e3a-4fa5-b22b-2167f6ee74fc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\include">
+      <UniqueIdentifier>{0b34b246-2805-4498-aa9f-8f887814415d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\include\occa">
+      <UniqueIdentifier>{c33635e7-53eb-4a6e-ad13-293ec42dece5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\include\occa\core">
+      <UniqueIdentifier>{0ba9bf73-eec0-4564-af4b-2258cc6d9e73}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\include\occa\defines">
+      <UniqueIdentifier>{6d03dfdb-81dd-4098-8dc2-1cc6a5ef3dc8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\include\occa\dtype">
+      <UniqueIdentifier>{fec33727-3e56-4bc9-a317-19095b338bfe}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\include\occa\experimental">
+      <UniqueIdentifier>{a91eab94-ae52-43bc-9404-d51bdb0b2191}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\include\occa\functional">
+      <UniqueIdentifier>{804c620e-82e6-4474-8e44-0113ebeae656}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\include\occa\loops">
+      <UniqueIdentifier>{04f1da64-73c3-40d5-836a-c375255eb7c0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\include\occa\types">
+      <UniqueIdentifier>{9017a416-28b6-4197-9d61-1060bf4f07f7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\include\occa\utils">
+      <UniqueIdentifier>{e5073c8c-acbd-4284-a516-9ef147c6e04a}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\occa\internal\io.hpp">
+      <Filter>Source Files\src\occa\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes.hpp">
+      <Filter>Source Files\src\occa\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils.hpp">
+      <Filter>Source Files\src\occa\internal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\bin\occa.hpp">
+      <Filter>Source Files\src\occa\internal\bin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\core\buffer.hpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\core\device.hpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\core\kernel.hpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\core\launchedDevice.hpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\core\launchedKernel.hpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\core\memory.hpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\core\stream.hpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\core\streamTag.hpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\functional\functionStore.hpp">
+      <Filter>Source Files\src\occa\internal\functional</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\io\cache.hpp">
+      <Filter>Source Files\src\occa\internal\io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\io\enums.hpp">
+      <Filter>Source Files\src\occa\internal\io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\io\output.hpp">
+      <Filter>Source Files\src\occa\internal\io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\io\utils.hpp">
+      <Filter>Source Files\src\occa\internal\io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\cli.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\enums.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\env.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\gc.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\lex.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\misc.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\store.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\string.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\styling.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\sys.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\testing.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\trie.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\utils\vector.hpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\attribute.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\file.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\kernelMetadata.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\keyword.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\loaders.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\macro.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\operator.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\parser.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\preprocessor.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\printer.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\processingStages.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\qualifier.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\scope.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\specialMacros.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statementContext.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statementPeeker.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\stream.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\tokenContext.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\tokenizer.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\variable.hpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\types.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\atomic.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\barrier.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\dim.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\exclusive.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\globalPtr.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\implicitArg.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\inner.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\kernel.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\outer.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\restrict.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\shared.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\tile.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\binaryOpNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\callNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\charNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\constCastNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\cudaCallNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\deleteNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\dpcppAtomicNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\dpcppLocalMemoryNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\dynamicCastNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\emptyNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\expr.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\expressionParser.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\exprNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\exprNodeArray.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\exprNodes.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\exprOpNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\funcCastNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\functionNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\identifierNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\lambdaNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\leftUnaryOpNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\newNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\pairNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\parenCastNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\parenthesesNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\primitiveNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\reinterpretCastNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\rightUnaryOpNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\sizeofNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\staticCastNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\stringNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\subscriptNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\ternaryOpNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\throwNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\tupleNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\typeNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\variableNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\expr\vartypeNode.hpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\loaders\attributeLoader.hpp">
+      <Filter>Source Files\src\occa\internal\lang\loaders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\loaders\structLoader.hpp">
+      <Filter>Source Files\src\occa\internal\lang\loaders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\loaders\typeLoader.hpp">
+      <Filter>Source Files\src\occa\internal\lang\loaders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\loaders\variableLoader.hpp">
+      <Filter>Source Files\src\occa\internal\lang\loaders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\cuda.hpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\dpcpp.hpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\hip.hpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\metal.hpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\okl.hpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\oklForStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\opencl.hpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\openmp.hpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\serial.hpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\modes\withLauncher.hpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\blockStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\breakStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\caseStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\classAccessStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\commentStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\continueStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\declarationStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\defaultStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\directiveStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\elifStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\elseStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\emptyStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\expressionStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\forStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\functionDeclStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\functionStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\gotoLabelStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\gotoStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\ifStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\namespaceStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\pragmaStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\returnStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\sourceCodeStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\statement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\statementArray.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\switchStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\statement\whileStatement.hpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\charToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\commentToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\directiveToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\functionToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\identifierToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\newlineToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\operatorToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\pragmaToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\primitiveToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\qualifierToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\stringToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\token.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\typeToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\unknownToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\variableToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\token\vartypeToken.hpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\array.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\class.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\enum.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\function.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\functionPtr.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\lambda.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\pointer.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\primitive.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\struct.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\structure.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\type.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\typedef.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\union.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\type\vartype.hpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\utils\array.hpp">
+      <Filter>Source Files\src\occa\internal\lang\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda.hpp">
+      <Filter>Source Files\src\occa\internal\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp.hpp">
+      <Filter>Source Files\src\occa\internal\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\hip.hpp">
+      <Filter>Source Files\src\occa\internal\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\metal.hpp">
+      <Filter>Source Files\src\occa\internal\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\opencl.hpp">
+      <Filter>Source Files\src\occa\internal\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\buffer.hpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\device.hpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\kernel.hpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\memory.hpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\polyfill.hpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\registration.hpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\stream.hpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\streamTag.hpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\utils.hpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\buffer.hpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\device.hpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\kernel.hpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\memory.hpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\registration.hpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\stream.hpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\streamTag.hpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\openmp\device.hpp">
+      <Filter>Source Files\src\occa\internal\modes\openmp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\openmp\registration.hpp">
+      <Filter>Source Files\src\occa\internal\modes\openmp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\openmp\utils.hpp">
+      <Filter>Source Files\src\occa\internal\modes\openmp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\buffer.hpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\device.hpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\kernel.hpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\memory.hpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\polyfill.hpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\registration.hpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\stream.hpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\streamTag.hpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\utils.hpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa.hpp">
+      <Filter>Header Files\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\core.hpp">
+      <Filter>Header Files\include\occa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\defines.hpp">
+      <Filter>Header Files\include\occa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\dtype.hpp">
+      <Filter>Header Files\include\occa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\experimental.hpp">
+      <Filter>Header Files\include\occa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\functional.hpp">
+      <Filter>Header Files\include\occa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\loops.hpp">
+      <Filter>Header Files\include\occa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\types.hpp">
+      <Filter>Header Files\include\occa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\utils.hpp">
+      <Filter>Header Files\include\occa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\core\base.hpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\core\device.hpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\core\kernel.hpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\core\kernelArg.hpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\core\memory.hpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\core\stream.hpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\core\streamTag.hpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\defines\arch.hpp">
+      <Filter>Header Files\include\occa\defines</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\defines\errors.hpp">
+      <Filter>Header Files\include\occa\defines</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\defines\macros.hpp">
+      <Filter>Header Files\include\occa\defines</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\defines\occa.hpp">
+      <Filter>Header Files\include\occa\defines</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\defines\okl.hpp">
+      <Filter>Header Files\include\occa\defines</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\defines\os.hpp">
+      <Filter>Header Files\include\occa\defines</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\defines\msvc.hpp">
+      <Filter>Header Files\include\occa\defines</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\dtype\builtins.hpp">
+      <Filter>Header Files\include\occa\dtype</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\dtype\dtype.hpp">
+      <Filter>Header Files\include\occa\dtype</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\dtype\utils.hpp">
+      <Filter>Header Files\include\occa\dtype</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\experimental\kernelBuilder.hpp">
+      <Filter>Header Files\include\occa\experimental</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\functional\array.hpp">
+      <Filter>Header Files\include\occa\functional</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\functional\baseFunction.hpp">
+      <Filter>Header Files\include\occa\functional</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\functional\function.hpp">
+      <Filter>Header Files\include\occa\functional</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\functional\functionDefinition.hpp">
+      <Filter>Header Files\include\occa\functional</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\functional\range.hpp">
+      <Filter>Header Files\include\occa\functional</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\functional\scope.hpp">
+      <Filter>Header Files\include\occa\functional</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\functional\typelessArray.hpp">
+      <Filter>Header Files\include\occa\functional</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\functional\types.hpp">
+      <Filter>Header Files\include\occa\functional</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\functional\utils.hpp">
+      <Filter>Header Files\include\occa\functional</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\loops\forLoop.hpp">
+      <Filter>Header Files\include\occa\loops</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\loops\innerForLoop.hpp">
+      <Filter>Header Files\include\occa\loops</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\loops\iteration.hpp">
+      <Filter>Header Files\include\occa\loops</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\loops\outerForLoop.hpp">
+      <Filter>Header Files\include\occa\loops</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\loops\typelessForLoop.hpp">
+      <Filter>Header Files\include\occa\loops</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\types\bits.hpp">
+      <Filter>Header Files\include\occa\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\types\dim.hpp">
+      <Filter>Header Files\include\occa\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\types\generic.hpp">
+      <Filter>Header Files\include\occa\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\types\json.hpp">
+      <Filter>Header Files\include\occa\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\types\primitive.hpp">
+      <Filter>Header Files\include\occa\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\types\tuples.hpp">
+      <Filter>Header Files\include\occa\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\types\typedefs.hpp">
+      <Filter>Header Files\include\occa\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\types\typeinfo.hpp">
+      <Filter>Header Files\include\occa\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\utils\env.hpp">
+      <Filter>Header Files\include\occa\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\utils\exception.hpp">
+      <Filter>Header Files\include\occa\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\utils\gc.hpp">
+      <Filter>Header Files\include\occa\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\utils\hash.hpp">
+      <Filter>Header Files\include\occa\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\utils\io.hpp">
+      <Filter>Header Files\include\occa\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\utils\logging.hpp">
+      <Filter>Header Files\include\occa\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\utils\mutex.hpp">
+      <Filter>Header Files\include\occa\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\utils\store.hpp">
+      <Filter>Header Files\include\occa\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="libocca_pch.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\maxInnerDims.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\lang\builtins\attributes\noBarrier.hpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\occa\core\memoryPool.hpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\core\memoryPool.hpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\serial\memoryPool.hpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\dpcpp\memoryPool.hpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\occa\internal\modes\cuda\memoryPool.hpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="libocca_pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\base.cpp">
+      <Filter>Source Files\src\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\device.cpp">
+      <Filter>Source Files\src\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\kernel.cpp">
+      <Filter>Source Files\src\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\kernelArg.cpp">
+      <Filter>Source Files\src\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\memory.cpp">
+      <Filter>Source Files\src\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\stream.cpp">
+      <Filter>Source Files\src\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\streamTag.cpp">
+      <Filter>Source Files\src\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\dtype\builtins.cpp">
+      <Filter>Source Files\src\dtype</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\dtype\dtype.cpp">
+      <Filter>Source Files\src\dtype</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\experimental\kernelBuilder.cpp">
+      <Filter>Source Files\src\experimental</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\functional\baseFunction.cpp">
+      <Filter>Source Files\src\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\functional\functionDefinition.cpp">
+      <Filter>Source Files\src\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\functional\range.cpp">
+      <Filter>Source Files\src\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\functional\scope.cpp">
+      <Filter>Source Files\src\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\functional\utils.cpp">
+      <Filter>Source Files\src\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\loops\forLoop.cpp">
+      <Filter>Source Files\src\loops</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\loops\iteration.cpp">
+      <Filter>Source Files\src\loops</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\loops\typelessForLoop.cpp">
+      <Filter>Source Files\src\loops</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\utils\exception.cpp">
+      <Filter>Source Files\src\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\utils\hash.cpp">
+      <Filter>Source Files\src\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\utils\io.cpp">
+      <Filter>Source Files\src\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\utils\logging.cpp">
+      <Filter>Source Files\src\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\utils\mutex.cpp">
+      <Filter>Source Files\src\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\types\dim.cpp">
+      <Filter>Source Files\src\types</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\types\json.cpp">
+      <Filter>Source Files\src\types</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\types\primitive.cpp">
+      <Filter>Source Files\src\types</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\types\typeinfo.cpp">
+      <Filter>Source Files\src\types</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes.cpp">
+      <Filter>Source Files\src\occa\internal</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\bin\occa.cpp">
+      <Filter>Source Files\src\occa\internal\bin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\core\buffer.cpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\core\device.cpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\core\kernel.cpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\core\launchedDevice.cpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\core\launchedKernel.cpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\core\memory.cpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\core\stream.cpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\core\streamTag.cpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\functional\functionStore.cpp">
+      <Filter>Source Files\src\occa\internal\functional</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\io\cache.cpp">
+      <Filter>Source Files\src\occa\internal\io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\io\output.cpp">
+      <Filter>Source Files\src\occa\internal\io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\io\utils.cpp">
+      <Filter>Source Files\src\occa\internal\io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\cli.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\env.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\gc.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\lex.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\misc.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\string.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\styling.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\sys.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\testing.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\trie.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\utils\vector.cpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\attribute.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\file.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\kernelMetadata.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\keyword.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\macro.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\operator.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\parser.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\preprocessor.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\printer.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\processingStages.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\qualifier.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\scope.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\specialMacros.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statementContext.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statementPeeker.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\tokenContext.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\tokenizer.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\variable.cpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\types.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\atomic.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\barrier.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\dim.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\exclusive.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\globalPtr.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\implicitArg.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\inner.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\kernel.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\outer.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\restrict.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\shared.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\tile.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\binaryOpNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\callNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\charNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\constCastNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\cudaCallNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\deleteNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\dpcppAtomicNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\dpcppLocalMemoryNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\dynamicCastNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\emptyNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\expr.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\expressionParser.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\exprNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\exprNodeArray.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\exprOpNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\funcCastNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\functionNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\identifierNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\lambdaNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\leftUnaryOpNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\newNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\pairNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\parenCastNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\parenthesesNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\primitiveNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\reinterpretCastNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\rightUnaryOpNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\sizeofNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\staticCastNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\stringNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\subscriptNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\ternaryOpNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\throwNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\tupleNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\typeNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\variableNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\expr\vartypeNode.cpp">
+      <Filter>Source Files\src\occa\internal\lang\expr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\loaders\attributeLoader.cpp">
+      <Filter>Source Files\src\occa\internal\lang\loaders</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\loaders\structLoader.cpp">
+      <Filter>Source Files\src\occa\internal\lang\loaders</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\loaders\typeLoader.cpp">
+      <Filter>Source Files\src\occa\internal\lang\loaders</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\loaders\variableLoader.cpp">
+      <Filter>Source Files\src\occa\internal\lang\loaders</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\cuda.cpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\dpcpp.cpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\hip.cpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\metal.cpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\okl.cpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\oklForStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\opencl.cpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\openmp.cpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\serial.cpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\modes\withLauncher.cpp">
+      <Filter>Source Files\src\occa\internal\lang\modes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\blockStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\breakStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\caseStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\classAccessStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\commentStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\continueStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\declarationStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\defaultStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\directiveStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\elifStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\elseStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\emptyStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\expressionStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\forStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\functionDeclStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\functionStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\gotoLabelStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\gotoStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\ifStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\namespaceStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\pragmaStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\returnStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\sourceCodeStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\statement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\statementArray.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\switchStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\statement\whileStatement.cpp">
+      <Filter>Source Files\src\occa\internal\lang\statement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\charToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\commentToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\directiveToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\functionToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\identifierToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\newlineToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\operatorToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\pragmaToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\primitiveToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\qualifierToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\stringToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\token.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\typeToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\unknownToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\variableToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\token\vartypeToken.cpp">
+      <Filter>Source Files\src\occa\internal\lang\token</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\array.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\class.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\enum.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\function.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\functionPtr.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\lambda.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\pointer.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\primitive.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\struct.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\structure.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\type.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\typedef.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\union.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\type\vartype.cpp">
+      <Filter>Source Files\src\occa\internal\lang\type</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\buffer.cpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\device.cpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\kernel.cpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\memory.cpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\registration.cpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\stream.cpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\streamTag.cpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\utils.cpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\buffer.cpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\device.cpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\kernel.cpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\memory.cpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\registration.cpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\stream.cpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\openmp\device.cpp">
+      <Filter>Source Files\src\occa\internal\modes\openmp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\openmp\registration.cpp">
+      <Filter>Source Files\src\occa\internal\modes\openmp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\openmp\utils.cpp">
+      <Filter>Source Files\src\occa\internal\modes\openmp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\buffer.cpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\device.cpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\kernel.cpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\memory.cpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\registration.cpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\stream.cpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\streamTag.cpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\utils.cpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\io\utils_win.cpp">
+      <Filter>Source Files\src\occa\internal\io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\maxInnerDims.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\lang\builtins\attributes\noBarrier.cpp">
+      <Filter>Source Files\src\occa\internal\lang\builtins\attributes</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\memoryPool.cpp">
+      <Filter>Source Files\src\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\core\memoryPool.cpp">
+      <Filter>Source Files\src\occa\internal\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\memoryPool.cpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\dpcpp\memoryPool.cpp">
+      <Filter>Source Files\src\occa\internal\modes\dpcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\cuda\memoryPool.cpp">
+      <Filter>Source Files\src\occa\internal\modes\cuda</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\occa\internal\modes\serial\streamTag.cpp">
+      <Filter>Source Files\src\occa\internal\modes\serial</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\src\occa\internal\io\output.tpp">
+      <Filter>Source Files\src\occa\internal\io</Filter>
+    </None>
+    <None Include="..\..\src\occa\internal\utils\cli.tpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </None>
+    <None Include="..\..\src\occa\internal\utils\gc.tpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </None>
+    <None Include="..\..\src\occa\internal\utils\trie.tpp">
+      <Filter>Source Files\src\occa\internal\utils</Filter>
+    </None>
+    <None Include="..\..\src\occa\internal\lang\parser.tpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </None>
+    <None Include="..\..\src\occa\internal\lang\stream.tpp">
+      <Filter>Source Files\src\occa\internal\lang</Filter>
+    </None>
+    <None Include="..\..\src\occa\internal\lang\loaders\variableLoader.tpp">
+      <Filter>Source Files\src\occa\internal\lang\loaders</Filter>
+    </None>
+    <None Include="..\..\src\occa\internal\lang\utils\array.tpp">
+      <Filter>Source Files\src\occa\internal\lang\utils</Filter>
+    </None>
+    <None Include="..\..\include\occa\core\base.tpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </None>
+    <None Include="..\..\include\occa\core\device.tpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </None>
+    <None Include="..\..\include\occa\core\memory.tpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </None>
+    <None Include="..\..\include\occa\types\json.tpp">
+      <Filter>Header Files\include\occa\types</Filter>
+    </None>
+    <None Include="..\..\include\occa\core\memoryPool.tpp">
+      <Filter>Header Files\include\occa\core</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/scripts/buildvc/libocca.vcxproj.user
+++ b/scripts/buildvc/libocca.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/scripts/buildvc/libocca_pch.cpp
+++ b/scripts/buildvc/libocca_pch.cpp
@@ -1,0 +1,15 @@
+// libocca_pch.cpp: source file to build pre-compiled header
+// NBN: switch off warnings:
+// 2021/10/05
+//---------------------------------------------------------
+#include "libocca_pch.hpp"
+
+// NBN: switch off warnings:
+// /w: 4068;4244;4250;4267;4804;4996;
+// 4068: unknown pragma
+// 4244: conversion from [occa::udim_t] to int
+// 4250: inherits ... via dominance
+// 4267: conversion from size_t to int
+// 4804: ...
+// 4996: 'fopen' ... may be unsafe.
+

--- a/scripts/buildvc/libocca_pch.hpp
+++ b/scripts/buildvc/libocca_pch.hpp
@@ -1,0 +1,36 @@
+// libocca_pch.h
+// add headers to be precompiled
+// 2021/10/05
+// /w: 4068;4244;4250;4267;4804;4996;
+//---------------------------------------------------------
+#ifndef LIBOCCA_PCH_HEADER
+#define LIBOCCA_PCH_HEADER
+
+
+#define THIS_IS_READY 0
+
+
+#if (1)
+#define WIN32_LEAN_AND_MEAN
+#define _USE_MATH_DEFINES
+#define NOMINMAX
+#endif
+
+#include <cmath>
+#include <algorithm>
+
+#if (1)
+
+#include "occa.hpp"
+
+#else
+
+#include <iostream>
+#include <sstream>
+#include <map>
+#include <vector>
+
+#endif
+
+
+#endif // LIBOCCA_PCH_HEADER

--- a/src/occa/internal/io/output.hpp
+++ b/src/occa/internal/io/output.hpp
@@ -4,6 +4,11 @@
 #include <iostream>
 #include <sstream>
 
+#ifdef _MSC_VER   // NBN: clear macro defs
+#undef stdout
+#undef stderr
+#endif
+
 namespace occa {
   namespace io {
     typedef void (*outputFunction_t)(const char *str);

--- a/src/occa/internal/io/utils.hpp
+++ b/src/occa/internal/io/utils.hpp
@@ -102,6 +102,11 @@ namespace occa {
 
     void moveStagedTempFile(const std::string &tempFilename,
                             const std::string &expFilename);
+
+#if (OCCA_USING_VS)
+    std::string getVScompilerScript();    // NBN: helper routine, see ./utils_win.cpp
+#endif
+
   }
 }
 

--- a/src/occa/internal/io/utils_win.cpp
+++ b/src/occa/internal/io/utils_win.cpp
@@ -1,0 +1,303 @@
+#include <occa/defines.hpp>
+#include <occa/types/typedefs.hpp>
+#include <occa/internal/io/output.hpp>
+
+// Only used by Visual Studio
+#ifdef _MSC_VER
+
+
+// NBN: extra utility routines for Visual Studio / Windows
+//
+// 1. getVScompilerScript() - find VC compiler
+// 2. initModesForVS()      - force registration of occa modes
+// 3. getline(...)          - add missing routine
+// 4. getProcFreq()         - helper routine
+// 5. mkdtemp (...)         - add missing routine
+
+
+//---------------------------------------------------------
+// 1. getVScompilerScript() - find VC compiler
+//---------------------------------------------------------
+namespace occa {
+  namespace io {
+
+    std::string getVScompilerScript()
+    {
+      std::string byteness;
+      if (sizeof(void*) == 4) {
+        byteness = "x86 ";               // NBN: 32bit not supported by recent CUDA
+      } else if (sizeof(void*) == 8) {
+        byteness = "x64";
+      } else {
+        OCCA_FORCE_ERROR("sizeof(void*) is not equal to 4 or 8");
+      }
+
+      // get Visual C++ installation directory
+      char* sz = NULL; size_t len = 0;
+
+# if   (OCCA_VS_VERSION >= 1933)
+      _dupenv_s(&sz, &len, "VSINSTALLDIR");         // NBN: MSVC++ 17.x - Visual Studio 2022
+# elif (OCCA_VS_VERSION >= 1920)
+      _dupenv_s(&sz, &len, "VS2019INSTALLDIR" );    // NBN: MSVC++ 16.x - Visual Studio 2019
+# else
+      // Handle other versions here:
+      // NBN: add as required
+
+      OCCA_FORCE_ERROR("Please adjust getVScompilerScript for Visual Studio version ["
+        << OCCA_VS_VERSION
+        << ".  Exiting simulation");
+
+# endif
+
+      std::string VSdir(sz);
+      ::free(sz);
+      std::string compilerEnvScript;
+      if (!VSdir.empty()) {
+      //compilerEnvScript = "\"" + VSdir + "\\VC\\Auxiliary\\Build\\vcvarsall.bat\" " + byteness;
+        compilerEnvScript = "\"" + VSdir +   "VC\\Auxiliary\\Build\\vcvarsall.bat\" " + byteness;
+      } else {
+        io::stdout << "WARNING: Visual Studio 'vcvarsall.bat' not found.\n";
+      }
+      
+      return compilerEnvScript;
+    }
+  }
+}
+
+
+//---------------------------------------------------------
+// 2. initModesForVS() - force registration of occa modes
+//---------------------------------------------------------
+#include <occa/internal/modes/serial/registration.hpp>
+#include <occa/internal/modes/openmp/registration.hpp>
+#include <occa/internal/modes/cuda/registration.hpp>
+//#include <occa/internal/modes/opencl/registration.hpp>
+
+namespace occa {
+
+  // NBN: referring to these modes in a source file appears to make 
+  // VC compiler enable them. No need to actually call this routine.
+  bool initModesForVS()
+  {
+    if (occa::getModeMap().size() < 1) {
+      printf("no occa modes are enabled?");
+      return false;
+    }
+
+    // Add modes as required
+    occa::serial::mode.getDescription();
+    occa::openmp::mode.getDescription();
+    occa::cuda::mode.getDescription();
+  //occa::opencl::mode.getDescription();
+
+    // check which modes are enabled in occa library
+    occa::printModeInfo();
+    return true;
+  }
+}
+
+
+//---------------------------------------------------------
+// 3. getline(...) - add missing routine
+//---------------------------------------------------------
+int64_t getline(char** line, size_t* len, FILE* fp) 
+{
+  // NBN: Visual Studio replacement for POSIX getline
+  // See: https://solarianprogrammer.com/2019/04/03/c-programming-read-file-lines-fgets-getline-implement-portable-getline/
+
+  // Check if either line, len or fp are NULL pointers
+  if (line == NULL || len == NULL || fp == NULL) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  // Use a chunk array of 128 bytes as parameter for fgets
+  char chunk[128] = {'\0'};
+
+  // NBN: in case file has no '\n', use chunkFlag 
+  // to flag when all chars have been read.
+  int chunkFlag = (128-1);
+//int chunkFlag = sizeof(chunk)-1;  // 127
+
+  // Allocate a block of memory for *line if it is NULL or smaller than the chunk array
+  if (*line == NULL || *len < sizeof(chunk)) {
+    *len = sizeof(chunk);
+    if ((*line = (char*) malloc(*len)) == NULL) {
+      errno = ENOMEM;
+      return -1;
+    }
+  }
+
+  // Make the string empty
+  (*line)[0] = '\0';
+
+  // read from current stream position
+  while (fgets(chunk, sizeof(chunk), fp) != NULL) {
+    // Resize the line buffer if necessary
+    size_t len_used = strlen(*line);
+    size_t chunk_used = strlen(chunk);
+
+    if (*len - len_used < chunk_used) {
+      // Check for overflow
+      if (*len > SIZE_MAX / 2) {
+        errno = EOVERFLOW;
+        return -1;
+      }
+      else {
+        *len *= 2;
+      }
+
+      if ((*line = (char*)realloc(*line, *len)) == NULL) {
+        errno = ENOMEM;
+        return -1;
+      }
+    }
+
+    // Copy the chunk to the end of the line buffer
+    memcpy(*line + len_used, chunk, chunk_used);
+    len_used += chunk_used;
+    (*line)[len_used] = '\0';
+
+    // if *line contains '\n',
+    if ((*line)[len_used - 1] == '\n') {
+      // ... return current length of line buffer
+      return len_used;
+    }
+
+    // if all chars in *line have been read,
+    if (chunk_used < chunkFlag) {
+      // ... return current length of line buffer
+      return len_used;
+    }
+  }
+
+  return -1;
+}
+
+
+//---------------------------------------------------------
+// 4. getProcFreq() - helper routine
+//---------------------------------------------------------
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <powrprof.h>
+#include <vector>
+
+// link the necessary libray
+#pragma comment(lib, "Powrprof.lib")
+
+typedef struct _PROCESSOR_POWER_INFORMATION {
+    ULONG  Number;
+    ULONG  MaxMhz;
+    ULONG  CurrentMhz;
+    ULONG  MhzLimit;
+    ULONG  MaxIdleState;
+    ULONG  CurrentIdleState;
+} PROCESSOR_POWER_INFORMATION, *PPROCESSOR_POWER_INFORMATION;
+
+
+occa::udim_t getProcFreq()
+{
+  SYSTEM_INFO si = {0}; GetSystemInfo(&si);
+  int nprocs = si.dwNumberOfProcessors;
+  std::vector<PROCESSOR_POWER_INFORMATION> buf(nprocs);
+  DWORD dwSize = sizeof(PROCESSOR_POWER_INFORMATION) * nprocs;
+  CallNtPowerInformation(ProcessorInformation, NULL, 0, &buf[0], dwSize);
+  occa::udim_t max_Mhz = buf[0].MaxMhz;
+  buf.clear();
+  return (max_Mhz*1000*1000);  // return Hz
+}
+
+
+//---------------------------------------------------------
+// 5. mkdtemp (...) - add missing routine
+// NBN: 2023/01/20 - no longer needed?
+//---------------------------------------------------------
+#if (0)
+#include <process.h>
+#include <direct.h>
+#include <errno.h>
+#include <random>
+
+// NBN: reproduce expected behavior of mkdtemp()
+//      adapted from adaption from OpenBSD
+// 
+// Generate a unique temporary directory from TEMPLATE.
+// The last six characters of TEMPLATE must be "XXXXXX";
+// these are replaced with string that makes filename unique.
+// The directory is created, and its name is returned.
+
+// characters used to build temporary file name [62 chars]
+static const char s_letters[] =
+"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+// if success, return name of newly created directory
+// else, return NULL
+char* mkdtemp (char *TMPL)
+{
+  uint64_t value = 0;
+  int fd = -1;
+  int save_errno = errno;
+  int len = strlen (TMPL);
+
+  // check that template name ends with "XXXXXX"
+  if (len < 6 || memcmp (&TMPL[len-6],  "XXXXXX", 6)) {
+    _set_errno (EINVAL);
+    return NULL;
+  }
+
+  // NBN: make static? Avoid recreating when building lots of kernel files
+  static std::random_device rd;
+  static std::mt19937_64 gen(rd());
+
+  value = gen();                          // generate a random 64 bit value
+  value ^= ((uint64_t) _getpid()) << 32;  // adjust value for this proc
+
+  // number of times to try generating a unique temp name.
+  int attempts = 1;
+
+  // pointer into template name string
+  char* XXXXXX = &TMPL[len - 6]; // point to start of [XXXXXX]
+
+  for (int count = 0; count < attempts; value += 7777, ++count) 
+  {
+    uint64_t v = value;
+
+    // fill in the random bits.
+    XXXXXX[0] = s_letters[v % 62];  v /= 62;
+    XXXXXX[1] = s_letters[v % 62];  v /= 62;
+    XXXXXX[2] = s_letters[v % 62];  v /= 62;
+    XXXXXX[3] = s_letters[v % 62];  v /= 62;
+    XXXXXX[4] = s_letters[v % 62];  v /= 62;
+    XXXXXX[5] = s_letters[v % 62];
+
+
+#if (OCCA_OS != OCCA_WINDOWS_OS)
+    fd = __mkdir (TMPL, S_IRUSR | S_IWUSR | S_IXUSR);
+#else
+    fd =  _mkdir (TMPL);
+#endif
+
+    if (0 == fd) {
+      _set_errno (save_errno);  // restore old errno
+      return TMPL;              // return name of created directory
+    }
+    else 
+    {
+      if (EEXIST != errno) { 
+        // abort: some other error state
+        return NULL; 
+      } 
+      else { 
+        // directory exists. try again with new temp_name
+        printf("*** directory %s exists (attempt %d of %d)\n", TMPL, count, attempts);
+      }
+    }
+  }
+
+  // Exceeded max combinations to try.
+  _set_errno (EEXIST);
+  return NULL;
+}
+#endif  // no longer needed
+#endif  // _MSC_VER

--- a/src/occa/internal/lang/printer.cpp
+++ b/src/occa/internal/lang/printer.cpp
@@ -19,9 +19,9 @@ namespace occa {
     }
 
     int printer::size() {
-      int pos = ss.tellg();
+      int pos = (int)ss.tellg();
       ss.seekg(0, ss.end);
-      int size = ss.tellg();
+      int size = (int)ss.tellg();
       ss.seekg(pos);
       return size;
     }

--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -288,19 +288,31 @@ namespace occa {
       }
 
       //---[ Compiling Command ]--------
+
       std::stringstream command;
+      
+#if (OCCA_USING_VS)
+      // NBN: TODO: add VS compiler script to allProps
+      command << io::getVScompilerScript() << " && ";
+#endif
+      
       command << allProps["compiler"]
               << ' ' << compilerFlags
               << " -cubin"
 #if (OCCA_OS == OCCA_WINDOWS_OS)
-              << " -D OCCA_OS=OCCA_WINDOWS_OS -D _MSC_VER=1800"
-#endif
+              << " -DOCCA_OS=OCCA_WINDOWS_OS -D_MSC_VER=" << _MSC_VER
+              << " -I"        << env::OCCA_DIR << "include"
+              << " -x cu " << sourceFilename
+              << " -o "    << binaryFilename
+              << " 2>&1";
+#else
               << " -I"        << env::OCCA_DIR << "include"
               << " -I"        << env::OCCA_INSTALL_DIR << "include"
               << " -L"        << env::OCCA_INSTALL_DIR << "lib -locca"
               << " -x cu " << sourceFilename
               << " -o "    << binaryFilename
               << " 2>&1";
+#endif
 
       const std::string &sCommand = command.str();
       if (verbose) {

--- a/src/occa/internal/utils/env.cpp
+++ b/src/occa/internal/utils/env.cpp
@@ -66,6 +66,11 @@ namespace occa {
       settings_["okl_version"] = OKL_VERSION_STR;
 
       OCCA_VERBOSE = env::get<bool>("OCCA_VERBOSE", false);
+
+#ifdef _DEBUG
+      OCCA_VERBOSE = true;    // NBN: test with verbose
+#endif
+
       if (OCCA_VERBOSE) {
         settings_["device/verbose"] = true;
         settings_["kernel/verbose"] = true;
@@ -91,6 +96,13 @@ namespace occa {
       io::endWithSlash(HOME);
       io::endWithSlash(CWD);
       io::endWithSlash(PATH);
+#else
+      // NBN:
+      OCCA_CACHE_DIR    = env::var("OCCA_CACHE_DIR");
+      OCCA_KERNEL_PATH  = split(env::var("OCCA_K_DIR"), ':', '\\');
+
+      HOME = occa::io::convertSlashes(env::var("HOMEPATH"));
+      CWD  = occa::io::convertSlashes(occa::io::currentWorkingDirectory());
 #endif
 
       // OCCA environment variables
@@ -149,13 +161,7 @@ namespace occa {
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
         ss << env::var("HOME") << "/.occa";
 #else
-        ss << env::var("USERPROFILE") << "/AppData/Local/OCCA";
-
-#  if OCCA_64_BIT
-        ss << "_amd64";  // use different dir's fro 32 and 64 bit
-#  else
-        ss << "_x86";    // use different dir's fro 32 and 64 bit
-#  endif
+        ss << env::var("USERPROFILE") << "/AppData/Local/.occa";
 #endif
         env::OCCA_CACHE_DIR = ss.str();
       }

--- a/src/occa/internal/utils/styling.cpp
+++ b/src/occa/internal/utils/styling.cpp
@@ -73,7 +73,7 @@ namespace occa {
       int fields = 0;
       std::vector<fieldGroup>::const_iterator it = groups.begin();
       while (it != groups.end()) {
-        fields += it->size();
+        fields += (int)it->size();
         ++it;
       }
       return fields;

--- a/src/occa/internal/utils/trie.tpp
+++ b/src/occa/internal/utils/trie.tpp
@@ -253,7 +253,7 @@ namespace occa {
         else {
           ++c;
           if (0 <= valueIndices[offset + OCCA_TRIE_MID]) {
-            retLength   = (c - cStart);
+            retLength   = (int)(c - cStart);
             retValueIndex = valueIndices[offset + OCCA_TRIE_MID];
           }
 

--- a/src/types/primitive.cpp
+++ b/src/types/primitive.cpp
@@ -179,7 +179,10 @@ namespace occa {
 
   primitive primitive::loadBinary(const char *&c, const bool isNegative) {
     const char *c0 = c;
-    uint64_t value_ = 0;
+    
+  //uint64_t value_ = 0;  // NBN: compiler, cannot negate unsigned
+    int64_t  value_ = 0;  // NBN: return signed?
+
     while (*c == '0' || *c == '1') {
       value_ = (value_ << 1) | (*c - '0');
       ++c;
@@ -188,7 +191,7 @@ namespace occa {
       return primitive();
     }
 
-    const int bits = c - c0 + isNegative;
+    const int bits = (int)(c - c0 + isNegative);
     if (bits < 8) {
       return isNegative ? primitive((int8_t) -value_) : primitive((uint8_t) value_);
     } else if (bits < 16) {
@@ -202,7 +205,10 @@ namespace occa {
 
   primitive primitive::loadHex(const char *&c, const bool isNegative) {
     const char *c0 = c;
-    uint64_t value_ = 0;
+    
+  //uint64_t value_ = 0;  // NBN: compiler, cannot negate unsigned
+    int64_t  value_ = 0;  // NBN: return signed?
+
     while (true) {
       const char C = uppercase(*c);
       if (('0' <= C) && (C <= '9')) {
@@ -219,7 +225,7 @@ namespace occa {
       return primitive();
     }
 
-    const int bits = 4*(c - c0) + isNegative;
+    const int bits = (int)(4*(c - c0) + isNegative);
     if (bits < 8) {
       return isNegative ? primitive((int8_t) -value_) : primitive((uint8_t) value_);
     } else if (bits < 16) {
@@ -319,6 +325,8 @@ namespace occa {
 
   primitive primitive::negative(const primitive &p) {
     switch(p.type) {
+
+#if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
       case primitiveType::bool_   : return primitive(-p.value.bool_);
       case primitiveType::int8_   : return primitive(-p.value.int8_);
       case primitiveType::uint8_  : return primitive(-p.value.uint8_);
@@ -330,6 +338,26 @@ namespace occa {
       case primitiveType::uint64_ : return primitive(-p.value.uint64_);
       case primitiveType::float_  : return primitive(-p.value.float_);
       case primitiveType::double_ : return primitive(-p.value.double_);
+#else
+      // NBN: VC++ error C4146: complains about negating unsigned types
+      case primitiveType::bool_   : return primitive(-p.value.bool_);
+      case primitiveType::int8_   : return primitive(-p.value.int8_);
+      case primitiveType::int16_  : return primitive(-p.value.int16_);
+      case primitiveType::int32_  : return primitive(-p.value.int32_);
+      case primitiveType::int64_  : return primitive(-p.value.int64_);
+      case primitiveType::float_  : return primitive(-p.value.float_);
+      case primitiveType::double_ : return primitive(-p.value.double_);
+
+    //case primitiveType::uint8_  : return primitive(-p.value.uint8_);
+      case primitiveType::uint8_  : OCCA_FORCE_ERROR("NBN: check: negating uint8_"); break;
+    //case primitiveType::uint16_ : return primitive(-p.value.uint16_);
+      case primitiveType::uint16_ : OCCA_FORCE_ERROR("NBN: check: negating uint16_"); break;
+    //case primitiveType::uint32_ : return primitive(-p.value.uint32_);
+      case primitiveType::uint32_ : OCCA_FORCE_ERROR("NBN: check: negating uint32_"); break;
+    //case primitiveType::uint64_ : return primitive(-p.value.uint64_);
+      case primitiveType::uint64_ : OCCA_FORCE_ERROR("NBN: check: negating uint64_"); break;
+#endif
+
       default: ;
     }
     return primitive();

--- a/src/types/typeinfo.cpp
+++ b/src/types/typeinfo.cpp
@@ -1,5 +1,8 @@
 #include <occa/types/typeinfo.hpp>
 
+// NBN: MSVC requires these to be defined in header
+#ifndef _MSC_VER
+
 namespace occa {
   template <> const std::string primitiveinfo<char>::id         = "c";
   template <> const std::string primitiveinfo<char>::name       = "char";
@@ -165,3 +168,5 @@ namespace occa {
   template <> const std::string typeinfo<double4>::name       = "double4";
   template <> const bool        typeinfo<double4>::isUnsigned = false;
 }
+
+#endif  // NBN: MSVC

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -19,8 +19,9 @@ namespace occa {
                   line,
                   message);
 
+    io::stdout << exp;     // NBN: show error messages...
     if (exitInFailure) {
-      throw exp;
+      throw exp;           // NBN: ... when exp not caught()
     }
     io::stderr << exp;
   }

--- a/src/utils/mutex.cpp
+++ b/src/utils/mutex.cpp
@@ -1,10 +1,17 @@
 #include <occa/utils/mutex.hpp>
 #include <occa/utils/logging.hpp>
 
+#if (OCCA_USING_VS)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 namespace occa {
+
+#if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
+
   mutex_t::mutex_t() :
     mutexHandle(PTHREAD_MUTEX_INITIALIZER) {
-#if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
     int error = pthread_mutex_init(&mutexHandle, NULL);
 #if OCCA_UNSAFE
     ignoreResult(error);
@@ -12,10 +19,17 @@ namespace occa {
 
     OCCA_ERROR("Error initializing mutex",
                error == 0);
-#else
-    mutexHandle = CreateMutex(NULL, FALSE, NULL);
-#endif
   }
+
+#else
+
+  mutex_t::mutex_t() {
+    mutexHandle = (void*)CreateMutex(NULL, FALSE, NULL);
+    OCCA_ERROR("Error initializing mutex",
+               mutexHandle != NULL);
+  }
+    
+#endif
 
   void mutex_t::free() {
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
@@ -26,8 +40,13 @@ namespace occa {
 
     OCCA_ERROR("Error freeing mutex",
                error == 0);
+
 #else
-    CloseHandle(mutexHandle);
+
+    BOOL bOK = CloseHandle(mutexHandle);
+    OCCA_ERROR("Error freeing mutex",
+               bOK != 0);
+
 #endif
   }
 


### PR DESCRIPTION
## Description

Enable the building of occa for 64-bit Windows using Visual Studio 2022 (v17.4.4)

Note: to build libocca.lib using the project in /occa/scripts/buildvc/, please edit paths in file libocca.vcxproj to suit local system (see "AdditionalIncludeDirectories", both release and debug sections).
