### PR TITLE
Fixes for macOS

### DIFF
--- a/src/occa/internal/modes/opencl/polyfill.hpp
+++ b/src/occa/internal/modes/opencl/polyfill.hpp
@@ -14,7 +14,7 @@
 #    include <CL/cl.h>
 #    include <CL/cl_gl.h>
 #  elif (OCCA_OS & OCCA_MACOS_OS)
-#    include <OpenCL/OpenCl.h>
+#    include <OpenCL/opencl.h>
 #  else
 #    include "CL/opencl.h"
 #  endif

--- a/src/occa/internal/utils/sys.cpp
+++ b/src/occa/internal/utils/sys.cpp
@@ -82,7 +82,7 @@ namespace occa {
 
       return (double) (ct.tv_sec + (1.0e-9 * ct.tv_nsec));
 #elif (OCCA_OS == OCCA_MACOS_OS)
-#  ifdef __clang__
+#  if defined __clang__ && defined CLOCK_UPTIME_RAW
       uint64_t nanoseconds = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 
       return 1.0e-9 * nanoseconds;

--- a/src/occa/internal/utils/sys.cpp
+++ b/src/occa/internal/utils/sys.cpp
@@ -401,7 +401,7 @@ namespace occa {
 
     int getTID() {
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
-#if OCCA_OS == OCCA_MACOS_OS & (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12)
+#if OCCA_OS == OCCA_MACOS_OS & (MAC_OS_X_VERSION_MAX_ALLOWED >= 101200)
       uint64_t tid64;
       pthread_threadid_np(NULL, &tid64);
       pid_t tid = (pid_t)tid64;


### PR DESCRIPTION
## Description

Existing condition is meaningless, since the macro is undefined on systems in question:
```
#if OCCA_OS == OCCA_MACOS_OS & (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12)
```
The code inside the condition is supposed to apply only to OS > 10.12, however it does not, since undefined macro is implicitly evaluated to 0, and you get the following error on 10.6, for example:
```
/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_libocca/libocca/work/occa-1.5.0/src/occa/internal/utils/sys.cpp: In function 'int occa::sys::getTID()':
/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_libocca/libocca/work/occa-1.5.0/src/occa/internal/utils/sys.cpp:406:7: error: 'pthread_threadid_np' was not declared in this scope; did you mean 'pthread_is_threaded_np'?
  406 |       pthread_threadid_np(NULL, &tid64);
      |       ^~~~~~~~~~~~~~~~~~~
      |       pthread_is_threaded_np
make[2]: *** [CMakeFiles/libocca.dir/src/occa/internal/utils/sys.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```
That is, the condition fails to have any effect. Use numerical constant instead, fix the build.

P. S. This is a minimal change just to unbreak the build. Otherwise something like the following might be preferable:
```
 #if MAC_OS_X_VERSION_MAX_ALLOWED < 1070
   uint64_t tid;
   tid = pthread_mach_thread_np(pthread_self());
 #elif MAC_OS_X_VERSION_MIN_REQUIRED < 1070
   uint64_t tid;
   tid = pthread_mach_thread_np(pthread_self());
 #else
   uint64_t tid;
   pthread_threadid_np(nullptr, &tid);
   return tid;
 #endif
```
Also see what is done in Ruby: https://github.com/ruby/ruby/blob/3e098224077e8c43a1d8c2070b26ffdfda422780/thread_pthread.c#L1862-L1887
Earlier version of the same, more readable: https://github.com/barracuda156/ruby-darwin-ppc/blob/94eac2a283337be272b29841ef3390737cadcf03/thread_pthread.c#L1767-L1785
