### PR TITLE
Correctly handle linkage qualifiers for dpcpp device functions.

### DIFF
--- a/examples/cpp/30_device_function/addVectors.okl
+++ b/examples/cpp/30_device_function/addVectors.okl
@@ -1,4 +1,4 @@
-float add(const float* a,
+static float add(const float* a,
           int i,
           const float* b,
           int j) {

--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -257,13 +257,12 @@ namespace occa
             .forEach([&](statement_t *smnt)
                      {
                        functionDeclStatement &funcDeclSmnt = (functionDeclStatement &)*smnt;
-
-                       if (funcDeclSmnt.hasAttribute("kernel"))
-                       {
-                         return;
-                       }
+                       if (funcDeclSmnt.hasAttribute("kernel")) return;
 
                        vartype_t &vartype = funcDeclSmnt.function().returnType;
+                       if (vartype.has(occa::lang::static_)) return;
+                       
+                       // Only add SYCL_EXTERNAL if we have external linkage
                        vartype.qualifiers.addFirst(vartype.origin(), device);
                      });
       }


### PR DESCRIPTION
## Description

- SYCL device functions can only be declared with `SYCL_EXTERNAL` if they have external linkage under the normal C++ rules.
- Avoids adding the `SYCL_EXTERNAL` macro to functions declared with the `static` qualifier. 

Closes #660 

<!-- Thank you for contributing! -->
