### PR TITLE
C api for 'unwrap' occaStream type

### DIFF
--- a/include/occa/c/base.h
+++ b/include/occa/c/base.h
@@ -37,6 +37,8 @@ void occaWaitForTag(occaStreamTag tag);
 
 double occaTimeBetweenTags(occaStreamTag startTag,
                            occaStreamTag endTag);
+
+void* occaStreamUnwrap(occaStream stream);
 //======================================
 
 //---[ Kernel ]-------------------------

--- a/src/c/base.cpp
+++ b/src/c/base.cpp
@@ -80,6 +80,10 @@ double occaTimeBetweenTags(occaStreamTag startTag,
   return occa::timeBetween(occa::c::streamTag(startTag),
                            occa::c::streamTag(endTag));
 }
+
+void* occaStreamUnwrap(occaStream stream) {
+  return occa::c::stream(stream).unwrap();
+}
 //======================================
 
 //---[ Kernel ]-------------------------


### PR DESCRIPTION
C api for unwrap to get native stream pointer. This is one of the data types supports unwarp, and exposure of them to C API could be done need based IMO as CPP API has its complete support. This is related to an issue #664.
