### PR TITLE
Add C API to get the arch version from a device

### DIFF
--- a/include/occa/c/base.h
+++ b/include/occa/c/base.h
@@ -25,6 +25,10 @@ occaJson occaDeviceProperties();
 
 void occaFinish();
 
+void occaGetDeviceArchVersion(occaDevice device,
+                              int *archMajorVersion,
+                              int *archMinorVersion);
+
 occaStream occaCreateStream(occaJson props);
 
 occaStream occaGetStream();

--- a/include/occa/core/device.hpp
+++ b/include/occa/core/device.hpp
@@ -282,6 +282,19 @@ namespace occa {
      */
     const occa::json& properties() const;
 
+    /**
+     * @startDoc{getDeviceArchVersion}
+     *
+     * Description:
+     *   Returns the architecture version of a device.
+     *
+     * Returns:
+     *   The architecture version of a device.
+     *
+     * @endDoc
+     */
+    void getDeviceArchVersion(int *archMajorVersion, int *archMinorVersion) const;
+
     const occa::json& kernelProperties() const;
     occa::json kernelProperties(const occa::json &additionalProps) const;
 

--- a/src/c/base.cpp
+++ b/src/c/base.cpp
@@ -44,6 +44,12 @@ void occaFinish() {
   occa::finish();
 }
 
+void occaGetDeviceArchVersion(occaDevice device,
+                              int *archMajorVersion,
+                              int *archMinorVersion) {
+  (occa::c::device(device)).getDeviceArchVersion(archMajorVersion, archMinorVersion);
+}
+
 occaStream occaCreateStream(occaJson props) {
   occa::stream stream;
   if (occa::c::isDefault(props)) {

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -176,6 +176,11 @@ namespace occa {
     return modeDevice->properties;
   }
 
+  void device::getDeviceArchVersion(int *archMajorVersion, int *archMinorVersion) const {
+    assertInitialized();
+    modeDevice->getDeviceArchVersion(archMajorVersion, archMinorVersion);
+  }
+
   const occa::json& device::kernelProperties() const {
     assertInitialized();
     return (const occa::json&) modeDevice->properties["kernel"];

--- a/src/occa/internal/core/device.cpp
+++ b/src/occa/internal/core/device.cpp
@@ -142,4 +142,12 @@ namespace occa {
       cachedKernels.erase(it);
     }
   }
+
+  void modeDevice_t::getDeviceArchVersion(int *archMajorVersion,
+                                          int *archMinorVersion) const {
+    if (archMajorVersion != nullptr) *archMajorVersion = 0;
+    if (archMinorVersion != nullptr) *archMinorVersion = 0;
+    std::cout << "getDeviceArchVersion called with device mode = " <<
+          mode << ", but the functionality is not supported.\n";
+  }
 }

--- a/src/occa/internal/core/device.hpp
+++ b/src/occa/internal/core/device.hpp
@@ -70,6 +70,9 @@ namespace occa {
     virtual hash_t hash() const = 0;
     virtual hash_t kernelHash(const occa::json &props) const = 0;
 
+    virtual void getDeviceArchVersion(int *archMajorVersion,
+                                      int *archMinorVersion) const;
+
     //  |---[ Stream ]------------------
     virtual modeStream_t* createStream(const occa::json &props) = 0;
     virtual modeStream_t* wrapStream(void *ptr, const occa::json &props) = 0;

--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -128,6 +128,12 @@ namespace occa {
                       cuCtxSetCurrent(cuContext));
     }
 
+    void device::getDeviceArchVersion(int *archMajorVersion_,
+                                      int *archMinorVersion_) const {
+      if (archMajorVersion_ != nullptr) *archMajorVersion_ = archMajorVersion;
+      if (archMinorVersion_ != nullptr) *archMinorVersion_ = archMinorVersion;
+    }
+
     //---[ Stream ]---------------------
     modeStream_t* device::createStream(const occa::json &props) {
       CUstream cuStream = NULL;

--- a/src/occa/internal/modes/cuda/device.hpp
+++ b/src/occa/internal/modes/cuda/device.hpp
@@ -42,6 +42,9 @@ namespace occa {
 
       void setCudaContext();
 
+      void getDeviceArchVersion(int *archMajorVersion_,
+                                int *archMinorVersion_) const override;
+
       //---[ Stream ]-------------------
       modeStream_t* createStream(const occa::json &props) override;
       modeStream_t* wrapStream(void* ptr, const occa::json &props) override;

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -112,6 +112,12 @@ namespace occa {
       return new lang::okl::hipParser(props);
     }
 
+    void device::getDeviceArchVersion(int *archMajorVersion_,
+                                      int *archMinorVersion_) const {
+      if (archMajorVersion_ != nullptr) *archMajorVersion_ = archMajorVersion;
+      if (archMinorVersion_ != nullptr) *archMinorVersion_ = archMinorVersion;
+    }
+
     //---[ Stream ]---------------------
     modeStream_t* device::createStream(const occa::json &props) {
       hipStream_t hipStream = NULL;

--- a/src/occa/internal/modes/hip/device.hpp
+++ b/src/occa/internal/modes/hip/device.hpp
@@ -33,6 +33,9 @@ namespace occa {
 
       lang::okl::withLauncher* createParser(const occa::json &props) const override;
 
+      void getDeviceArchVersion(int *archMajorVersion_,
+                                int *archMinorVersion_) const override;
+
       //---[ Stream ]-------------------
       modeStream_t* createStream(const occa::json &props) override;
       modeStream_t* wrapStream(void* ptr, const occa::json &props) override;


### PR DESCRIPTION
This is an updated version of draft PR #606 to add a C API to get the arch version numbers for a given device. This change would still support cuda and hip for now.
