### PR TITLE
[#657] Relax thread-local constraint for the device shrable by multiple threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,14 @@ if(ENABLE_FORTRAN)
   enable_language(Fortran)
 endif()
 
+option(ENABLE_SHARABLE_DEVICE  "Enable sharable device by multiple threads"  OFF)
+if (ENABLE_SHARABLE_DEVICE)
+  add_compile_definitions(OCCA_THREAD_SHARABLE_ENABLED=1)
+  message("-- OCCA sharable by multi-threads     : Enabled")
+else()
+  add_compile_definitions(OCCA_THREAD_SHARABLE_ENABLED=0)
+endif()
+
 set(OCCA_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(OCCA_BUILD_DIR  ${CMAKE_BINARY_DIR})
 

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ MAKE_COMPILED_DEFINES := $(shell cat "$(OCCA_DIR)/scripts/build/compiledDefinesT
                                       s,@@OCCA_OPENCL_ENABLED@@,$(OCCA_OPENCL_ENABLED),g;\
                                       s,@@OCCA_METAL_ENABLED@@,$(OCCA_METAL_ENABLED),g;\
 				      												s,@@OCCA_DPCPP_ENABLED@@,$(OCCA_DPCPP_ENABLED),g;\
+                                      s,@@OCCA_THREAD_SHARABLE_ENABLED@@,$(OCCA_THREAD_SHARABLE_ENABLED),g;\
                                       s,@@OCCA_BUILD_DIR@@,$(OCCA_BUILD_DIR),g;"\
                                       > "$(NEW_COMPILED_DEFINES)")
 

--- a/src/occa/internal/utils/env.cpp
+++ b/src/occa/internal/utils/env.cpp
@@ -6,12 +6,25 @@
 #include <occa/internal/utils/env.hpp>
 #include <occa/internal/utils/sys.hpp>
 
+#if OCCA_THREAD_SHARABLE_ENABLED
+#include <occa/utils/mutex.hpp>
+#endif
+
 namespace occa {
   json& settings() {
+#if OCCA_THREAD_SHARABLE_ENABLED
+    static json props;
+    static mutex_t mutex;
+    mutex.lock();
+#else
     thread_local  json props;
+#endif
     if (!props.size()) {
       props = env::baseSettings();
     }
+#if OCCA_THREAD_SHARABLE_ENABLED
+    mutex.unlock();
+#endif
     return std::ref(props);
   }
 

--- a/src/occa/internal/utils/gc.hpp
+++ b/src/occa/internal/utils/gc.hpp
@@ -8,6 +8,10 @@
 
 #include <occa/utils/gc.hpp>
 
+#if OCCA_THREAD_SHARABLE_ENABLED
+#include <occa/utils/mutex.hpp>
+#endif
+
 namespace occa {
   namespace gc {
     class withRefs {
@@ -27,6 +31,11 @@ namespace occa {
 
     template <class entry_t>
     class ring_t {
+  #if OCCA_THREAD_SHARABLE_ENABLED
+    private:
+      static mutex_t mutex;
+  #endif
+
     public:
       bool useRefs;
       ringEntry_t *head;
@@ -37,7 +46,11 @@ namespace occa {
       void clear();
 
       void addRef(entry_t *entry);
+    #if OCCA_THREAD_SHARABLE_ENABLED
+      void removeRef(entry_t *entry, const bool threadLock = true);
+    #else
       void removeRef(entry_t *entry);
+    #endif
 
       bool needsFree() const;
 


### PR DESCRIPTION
This is a change related to an issue #657. This can be a minimal change possibly being made to enable sharable OCCA device by multiple threads. With this change two threads invoking kernel builds/runs simultaneously could be demonstrated in our application. Unlocking broader support for multi-threading might require more changes, but it would probably be better to have that happens when an actual case presented to ensure necessary changes and testing IMO. As suggested in the issue, this feature is currently hidden behind a cmake build option (turned off by default), so it is required to be turned on by a user to enable it.
