### PR TITLE
Add kernel/include_occa and kernel/link_occa properties

### DIFF
--- a/examples/cpp/18_nonblocking_streams/main.cpp
+++ b/examples/cpp/18_nonblocking_streams/main.cpp
@@ -27,6 +27,7 @@ int main(int argc, const char **argv) {
   occa::json kernelProps({
     {"defines/block", block},
     {"defines/group", group},
+    {"serial/include_std", true},
   });
   occa::kernel powerOfPi = occa::buildKernel("powerOfPi.okl",
                                              "powerOfPi",

--- a/src/loops/typelessForLoop.cpp
+++ b/src/loops/typelessForLoop.cpp
@@ -34,6 +34,8 @@ namespace occa {
       loopScope.device = device;
     }
 
+    loopScope.props["kernel/include_occa"] = true;
+
     const int outerIterationCount = (int) outerIterations.size();
     const int innerIterationCount = (int) innerIterations.size();
 

--- a/src/occa/internal/lang/modes/serial.cpp
+++ b/src/occa/internal/lang/modes/serial.cpp
@@ -34,8 +34,11 @@ namespace occa {
 
       void serialParser::setupHeaders() {
         strVector headers;
-        const bool includingStd = settings.get("serial/include_std", true);
-        headers.push_back("include <occa.hpp>\n");
+        const bool includeOcca = settings.get("kernel/include_occa", false);
+        if (includeOcca) {
+          headers.push_back("include <occa.hpp>\n");
+        }
+        const bool includingStd = settings.get("serial/include_std", false);
         if (includingStd) {
           headers.push_back("include <stdint.h>");
           headers.push_back("include <cstdlib>");
@@ -51,7 +54,9 @@ namespace occa {
             if (includingStd) {
               header += "\nusing namespace std;";
             }
-            header += "\nusing namespace occa;";
+            if (includeOcca) {
+              header += "\nusing namespace occa;";
+            }
           }
           directiveToken token(root.source->origin,
                                header);

--- a/src/occa/internal/modes/cuda/device.cpp
+++ b/src/occa/internal/modes/cuda/device.cpp
@@ -91,7 +91,8 @@ namespace occa {
       return (
         occa::hash(props["compiler"])
         ^ props["compiler_flags"]
-        ^ props["compiler_env_script"]
+        ^ props["kernel/include_occa"]
+        ^ props["kernel/link_occa"]
       );
     }
 
@@ -273,6 +274,9 @@ namespace occa {
         sys::addCompilerLibraryFlags(compilerFlags);
       }
 
+      const bool includeOcca = kernelProps.get("kernel/include_occa", false);
+      const bool linkOcca    = kernelProps.get("kernel/link_occa", false);
+
       //---[ Compiling Command ]--------
       std::stringstream command;
       command << allProps["compiler"]
@@ -281,10 +285,15 @@ namespace occa {
 #if (OCCA_OS == OCCA_WINDOWS_OS)
               << " -D OCCA_OS=OCCA_WINDOWS_OS -D _MSC_VER=1800"
 #endif
-              << " -I"        << env::OCCA_DIR << "include"
-              << " -I"        << env::OCCA_INSTALL_DIR << "include"
-              << " -L"        << env::OCCA_INSTALL_DIR << "lib -locca"
-              << " -x cu " << sourceFilename
+          ;
+      if (includeOcca) {
+        command << " -I"        << env::OCCA_DIR << "include"
+                << " -I"        << env::OCCA_INSTALL_DIR << "include";
+      }
+      if (linkOcca) {
+        command << " -L"        << env::OCCA_INSTALL_DIR << "lib -locca";
+      }
+      command << " -x cu " << sourceFilename
               << " -o "    << binaryFilename
               << " 2>&1";
 

--- a/src/occa/internal/modes/dpcpp/device.cpp
+++ b/src/occa/internal/modes/dpcpp/device.cpp
@@ -73,7 +73,11 @@ namespace occa
     hash_t device::kernelHash(const occa::json &props) const
     {
       return (
-          occa::hash(props["compiler"]) ^ props["compiler_flags"]);
+          occa::hash(props["compiler"])
+          ^ props["compiler_flags"]
+          ^ props["kernel/include_occa"]
+          ^ props["kernel/link_occa"]
+      );
     }
 
     lang::okl::withLauncher *device::createParser(const occa::json &props) const
@@ -197,6 +201,16 @@ namespace occa
       {
         sys::addCompilerIncludeFlags(compilerFlags);
         sys::addCompilerLibraryFlags(compilerFlags);
+      }
+
+      const bool includeOcca = kernelProps.get("kernel/include_occa", false);
+      const bool linkOcca    = kernelProps.get("kernel/link_occa", false);
+      if (includeOcca) {
+        compilerFlags += " -I" + env::OCCA_DIR + "include";
+        compilerFlags += " -I" + env::OCCA_INSTALL_DIR + "include";
+      }
+      if (linkOcca) {
+        compilerLinkerFlags += " -L" + env::OCCA_INSTALL_DIR + "lib -locca";
       }
 
       std::stringstream command;

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -81,6 +81,9 @@ namespace occa {
         occa::hash(props["compiler"])
         ^ props["compiler_flags"]
         ^ props["compiler_env_script"]
+        ^ props["hipcc_compiler_flags"]
+        ^ props["kernel/include_occa"]
+        ^ props["kernel/link_occa"]
       );
     }
 
@@ -276,14 +279,20 @@ namespace occa {
 #else
               << " -f=\\\"" << compilerFlags << "\\\""
 #endif
-              << ' ' << hipccCompilerFlags
+              << ' ' << hipccCompilerFlags;
 #if defined(__HIP_PLATFORM_NVCC___) || (HIP_VERSION >= 305)
-              << " -I"        << env::OCCA_DIR << "include"
-              << " -I"        << env::OCCA_INSTALL_DIR << "include"
+      const bool includeOcca = kernelProps.get("kernel/include_occa", false);
+      const bool linkOcca    = kernelProps.get("kernel/link_occa", false);
+      if (includeOcca) {
+        command << " -I"        << env::OCCA_DIR << "include"
+                << " -I"        << env::OCCA_INSTALL_DIR << "include";
+      }
+      if (linkOcca) {
+            /* NC: hipcc doesn't seem to like linking a library in */
+              //<< " -L"        << env::OCCA_INSTALL_DIR << "lib -locca";
+      }
 #endif
-              /* NC: hipcc doesn't seem to like linking a library in */
-              //<< " -L"        << env::OCCA_INSTALL_DIR << "lib -locca"
-              << ' '    << sourceFilename
+      command << ' '    << sourceFilename
               << " -o " << binaryFilename
               << " 2>&1";
 

--- a/src/occa/internal/modes/opencl/device.cpp
+++ b/src/occa/internal/modes/opencl/device.cpp
@@ -55,6 +55,17 @@ namespace occa {
       }
       compilerFlags += " -cl-std=CL" + ocl_c_ver;
 
+      const bool includeOcca = kernelProps.get("kernel/include_occa", false);
+      const bool linkOcca    = kernelProps.get("kernel/link_occa", false);
+
+      if (includeOcca) {
+        compilerFlags += " -I" + env::OCCA_DIR + "include";
+        compilerFlags += " -I" + env::OCCA_INSTALL_DIR + "include";
+      }
+      if (linkOcca) {
+        compilerFlags += " -L" + env::OCCA_INSTALL_DIR + "lib -locca";
+      }
+
       kernelProps["compiler_flags"] = compilerFlags;
 
       arch = deviceName(platformID, deviceID);
@@ -87,7 +98,11 @@ namespace occa {
     }
 
     hash_t device::kernelHash(const occa::json &props) const {
-      return occa::hash(props["compiler_flags"]);
+      return (
+        occa::hash(props["compiler_flags"])
+        ^ props["kernel/include_occa"]
+        ^ props["kernel/link_occa"]
+      );
     }
 
     lang::okl::withLauncher* device::createParser(const occa::json &props) const {

--- a/tests/src/c/kernel.cpp
+++ b/tests/src/c/kernel.cpp
@@ -87,7 +87,7 @@ void testRun() {
     occa::env::OCCA_DIR + "tests/files/argKernel.okl"
   );
   occaJson kernelProps = occaJsonParse(
-    "{type_validation: false}"
+    "{type_validation: false, serial: {include_std: true}}"
   );
   occaKernel argKernel = (
     occaBuildKernel(argKernelFile.c_str(),

--- a/tests/src/core/kernel.cpp
+++ b/tests/src/core/kernel.cpp
@@ -154,7 +154,8 @@ void testRun() {
   );
   occa::kernel argKernel = occa::buildKernel(argKernelFile,
                                              "argKernel",
-                                             {{"type_validation", false}});
+                                             {{"type_validation", false},
+                                              {"serial/include_std", true}});
 
   argKernel.setRunDims(occa::dim(1, 1, 1),
                        occa::dim(1, 1, 1));

--- a/tests/src/math/fpMath.cpp
+++ b/tests/src/math/fpMath.cpp
@@ -55,45 +55,48 @@ std::string kernel_back_half =
 
 void testUnaryFunctions(const occa::device& d) {
   for (auto fp_type : arg_types) {
-    std::string arg_decl = 
+    std::string arg_decl =
       "        " + fp_type + " " + unary_args + ";\n";
     for(auto func : unary_functions) {
-      std::string function_call = 
+      std::string function_call =
         "        " + fp_type + " w = " + func + "(" + unary_args + ");\n";
-      std::string kernel_src = 
+      std::string kernel_src =
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
-      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+      occa::kernel k = d.buildKernelFromString(kernel_src, "f",
+                                               {{"serial/include_std", true}});
     }
   }
 }
 
 void testBinaryFunctions(const occa::device& d) {
   for (auto fp_type : arg_types) {
-    std::string arg_decl = 
+    std::string arg_decl =
       "        " + fp_type + " " + binary_args + ";\n";
     for(auto func : binary_functions) {
-      std::string function_call = 
+      std::string function_call =
         "        " + fp_type + " w = " + func + "(" + binary_args + ");\n";
-      std::string kernel_src = 
+      std::string kernel_src =
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
-      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+      occa::kernel k = d.buildKernelFromString(kernel_src, "f",
+                                               {{"serial/include_std", true}});
     }
   }
 }
 
 void testTernaryFunctions(const occa::device& d) {
   for (auto fp_type : arg_types) {
-    std::string arg_decl = 
+    std::string arg_decl =
       "        " + fp_type + " " + ternary_args + ";\n";
     for(auto func : ternary_functions) {
-      std::string function_call = 
+      std::string function_call =
         "        " + fp_type + " w = " + func + "(" + ternary_args + ");\n";
-      std::string kernel_src = 
+      std::string kernel_src =
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
-      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+      occa::kernel k = d.buildKernelFromString(kernel_src, "f",
+                                               {{"serial/include_std", true}});
     }
   }
 }

--- a/tests/src/math/intMath.cpp
+++ b/tests/src/math/intMath.cpp
@@ -29,30 +29,33 @@ std::string kernel_back_half =
 
 void testUnaryFunctions(const occa::device& d) {
   for (auto&& int_type : arg_types) {
-    const std::string arg_decl = 
+    const std::string arg_decl =
       "        " + int_type + " " + unary_args + "; \n";
     for (auto&& func : unary_functions) {
-      const std::string function_call = 
+      const std::string function_call =
         "        " + int_type + " w = " + func + "(" + unary_args + "); \n";
-      const std::string kernel_src = 
+      const std::string kernel_src =
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
-      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+      occa::kernel k = d.buildKernelFromString(kernel_src, "f",
+                                               {{"serial/include_std", true}});
     }
   }
 }
 
 void testBinaryFunctions(const occa::device& d) {
   for (auto&& int_type : arg_types) {
-    const std::string arg_decl = 
+    const std::string arg_decl =
       "        " + int_type + " " + binary_args + "; \n";
     for (auto&& func : binary_functions) {
-      const std::string function_call = 
+      const std::string function_call =
         "        " + int_type + " w = " + func + "(" + binary_args + "); \n";
-      const std::string kernel_src = 
+      const std::string kernel_src =
         kernel_front_half + arg_decl + function_call +kernel_back_half;
 
-      occa::kernel k = d.buildKernelFromString(kernel_src,"f");
+      occa::kernel k = d.buildKernelFromString(kernel_src, "f",
+                                               {{"serial/include_std", true},
+                                                {"kernel/include_occa", true}}); // For min/max
     }
   }
 }


### PR DESCRIPTION
Add kernel/include_occa and kernel/link_occa properties to control including and linking occa into kernels. This PR is a replica of the original PR #603 by @SFrijters with very minor cleanup (removed changes already merged in, and squash the original commits), just in case if there would be any further changes required.

Original description by @SFrijters in the PR was:

**Recently I have been debugging a segmentation fault in our code that seems to have been caused by transitive dependencies of occa. During this process I noticed that all kernels get linked to libocca and occa headers are #included at the top of the kernel code. However, none of our kernels require anything from inside occa, so I think it would be nice to be able to control this. Not linking in occa speeds things up a little bit and potentially prevents unexpected behaviour.

This PR keeps the default behaviour as-is, but makes linking to occa, and #include(i)ng the occa headers and namespace opt-out per kernel. This seems to work well in our code at this moment. Is this something that seems generally useful enough to include?

Open questions: should we do some bikeshedding on the flag name and where should this new option be documented? And I'm not quite sure if the markdown files in docs should just be edited directly or if there is some kind of automation for that?
Remark: I have not been able to test with HIP, but the change looks straightforward enough (famous last words).

I also noticed some inconsistencies in how the kernelHash is calculated, based on what goes into the compiler invocation so this is a separate fix commit. It could be taken out of this PR if requested.**

Please refer the original PR #603 for other discussions has been made.