### PR TITLE
[Core] Allow passing general objects by value to kernels

### DIFF
--- a/include/occa/core/kernelArg.hpp
+++ b/include/occa/core/kernelArg.hpp
@@ -88,6 +88,11 @@ namespace occa {
       addPointer((void*) const_cast<type4<T>*>(&arg), sizeof(type4<T>));
     }
 
+    template <class T>
+    kernelArg(const T &arg) {
+      addPointer((void*) const_cast<T*>(&arg), sizeof(T));
+    }
+
     int size() const;
 
     device getDevice() const;
@@ -103,6 +108,15 @@ namespace occa {
 
     static int argumentCount(const std::vector<kernelArg> &arguments);
   };
+
+  template <>
+  kernelArg::kernelArg(const char &arg);
+
+  template <>
+  kernelArg::kernelArg(const unsigned char &arg);
+
+  template <>
+  kernelArg::kernelArg(const memory &arg);
 
   template <>
   kernelArg::kernelArg(modeMemory_t *arg);
@@ -181,6 +195,9 @@ namespace occa {
   template <>
   hash_t hash(const occa::scopeKernelArg &arg);
   //====================================
+
+  template <>
+  kernelArg::kernelArg(const scopeKernelArg &arg);
 }
 
 #endif

--- a/src/core/kernelArg.cpp
+++ b/src/core/kernelArg.cpp
@@ -53,7 +53,7 @@ namespace occa {
   }
 
   bool kernelArgData::isPointer() const {
-    return value.isPointer();
+    return ptrSize ? false : value.isPointer();
   }
 
   //====================================
@@ -76,6 +76,21 @@ namespace occa {
   kernelArg::~kernelArg() {}
 
   template <>
+  kernelArg::kernelArg(const char &arg) {
+    primitiveConstructor(static_cast<int8_t>(arg));
+  }
+
+  template <>
+  kernelArg::kernelArg(const unsigned char &arg) {
+    primitiveConstructor(static_cast<uint8_t>(arg));
+  }
+
+  template <>
+  kernelArg::kernelArg(const memory &arg) {
+    addMemory(arg.getModeMemory());
+  }
+
+  template <>
   kernelArg::kernelArg(modeMemory_t *arg) {
     addMemory(arg);
   }
@@ -83,6 +98,11 @@ namespace occa {
   template <>
   kernelArg::kernelArg(const modeMemory_t *arg) {
     addMemory(const_cast<modeMemory_t*>(arg));
+  }
+
+  template <>
+  kernelArg::kernelArg(const scopeKernelArg &arg) {
+    args = arg.args;
   }
 
   int kernelArg::size() const {

--- a/tests/files/argKernel.okl
+++ b/tests/files/argKernel.okl
@@ -1,16 +1,20 @@
+typedef struct {
+  double x, y;
+} mystruct;
+
 @kernel void argKernel(void *nullPtr,
                        int *mem,
                        char i8,
-                       char u8,
+                       unsigned char u8,
                        short i16,
-                       short u16,
+                       unsigned short u16,
                        int i32,
-                       int u32,
+                       unsigned int u32,
                        long i64,
-                       long u64,
+                       unsigned long u64,
                        float f,
                        double d,
-                       int *xy,
+                       mystruct xy,
                        const char *str) {
   for (int i = 0; i < 1; ++i; @tile(1, @outer, @inner)) {
     // Note: NULL is not 0 because some backends don't handle NULL arguments properly
@@ -27,7 +31,7 @@
       "u64: %d\n"
       "f: %f\n"
       "d: %f\n"
-      "xy: [%d, %d]\n"
+      "xy: [%f, %f]\n"
       "str: %s\n",
       nullPtr,
       (int) mem[0],
@@ -41,7 +45,7 @@
       (int) u64,
       f,
       d,
-      xy[0], xy[1],
+      xy.x, xy.y,
       str
     );
     if (i8 != 3) {

--- a/tests/src/c/kernel.cpp
+++ b/tests/src/c/kernel.cpp
@@ -110,7 +110,12 @@ void testRun() {
   occaMemory mem = occaMalloc(1 * sizeof(int), &value, occaDefault);
   value = 2;
 
-  int xy[2] = {13, 14};
+  struct {
+    double x,y;
+  } xy;
+  xy.x = 13.0;
+  xy.y = 14.0;
+
   std::string str = "fifteen";
 
   // Good argument types
@@ -128,7 +133,7 @@ void testRun() {
     occaUInt64(10),
     occaFloat(11.0),
     occaDouble(12.0),
-    occaStruct(xy, sizeof(xy)),
+    occaStruct(&xy, sizeof(xy)),
     occaString(str.c_str())
   );
 
@@ -146,7 +151,7 @@ void testRun() {
   occaKernelPushArg(argKernel, occaUInt64(10));
   occaKernelPushArg(argKernel, occaFloat(11.0));
   occaKernelPushArg(argKernel, occaDouble(12.0));
-  occaKernelPushArg(argKernel, occaStruct(xy, sizeof(xy)));
+  occaKernelPushArg(argKernel, occaStruct(&xy, sizeof(xy)));
   occaKernelPushArg(argKernel, occaString(str.c_str()));
   occaKernelRunFromArgs(argKernel);
 
@@ -164,7 +169,7 @@ void testRun() {
     occaUInt64(10),
     occaFloat(11.0),
     occaDouble(12.0),
-    occaStruct(xy, sizeof(xy)),
+    occaStruct(&xy, sizeof(xy)),
     occaString(str.c_str())
   };
 

--- a/tests/src/core/kernel.cpp
+++ b/tests/src/core/kernel.cpp
@@ -162,7 +162,13 @@ void testRun() {
   int value = 1;
   occa::memory mem = occa::malloc<int>(1, &value);
 
-  int xy[2] = {13, 14};
+  struct {
+    double x;
+    double y;
+  } xy;
+  xy.x = 13.0;
+  xy.y = 14.0;
+
   std::string str = "fifteen";
 
   argKernel(


### PR DESCRIPTION
## Description

Title says it all. tests/src/core/kernel.cpp shows the intended usage, and tests/src/c/kernel.cpp shows the equivalent C API usage (C needs the argument wrapped in an occaStruct object).


<!-- Thank you for contributing! -->
