### PR TITLE
Replace CMAKE_SOURCE_DIR by OCCA_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ include(ExportAndPackageConfig)
 
 install(CODE
   "configure_file(
-    ${CMAKE_SOURCE_DIR}/modulefiles/occa
+    ${OCCA_SOURCE_DIR}/modulefiles/occa
     ${CMAKE_INSTALL_PREFIX}/modulefiles/occa
     @ONLY
   )"


### PR DESCRIPTION
## Description

Using CMAKE_SOURCE_DIR prevents OCCA being nested in another project (like nekRS)
using `add_subdirectory`.


<!-- Thank you for contributing! -->
