### PR TITLE
Add missing header <cstdint> to fix building with GCC 13

### DIFF
--- a/src/occa/internal/modes/dpcpp/polyfill.hpp
+++ b/src/occa/internal/modes/dpcpp/polyfill.hpp
@@ -6,6 +6,7 @@
 #if OCCA_DPCPP_ENABLED
 #include <sycl.hpp>
 #else
+#include <cstdint>
 #include <vector>
 namespace sycl {
 


### PR DESCRIPTION
Ref: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Resolves: #683 