### PR TITLE
cmake: Small fix to prevent empty module path

### DIFF
--- a/cmake/OCCAConfig.cmake.in
+++ b/cmake/OCCAConfig.cmake.in
@@ -8,13 +8,16 @@
 # Dependencies that need to be found will depend on the build settings used
 include(CMakeFindDependencyMacro)
 # For some dependencies, we provide custom Find modules, that have been installed next to this file.
-# Temporarily add this directory to the CMAKE_MODULE_PATH
-set(_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
+#   Temporarily add this directory to the CMAKE_MODULE_PATH
+#   Use a variable with an OCCA prefix to store the old value, to prevent the variable being
+#   overwritten by code in the dependencies, executed before the reset
+set(_OCCA_STORE_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}")
 @exportPackageDependencies@
 # Reset CMAKE_MODULE_PATH
-set(CMAKE_MODULE_PATH ${_CMAKE_MODULE_PATH})
-unset(_CMAKE_MODULE_PATH)
+# Do not use list(REMOVE CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}"), because that would remove all instances, even if they were not added here
+set(CMAKE_MODULE_PATH ${_OCCA_STORE_CMAKE_MODULE_PATH})
+unset(_OCCA_STORE_CMAKE_MODULE_PATH)
 
 # The exported targets are defined in an auto-generated file:
 include( "${CMAKE_CURRENT_LIST_DIR}/OCCATargets.cmake" )


### PR DESCRIPTION
## Description
In a chain of cmake package config projects using find_dependency(), where each would use the same code to temporarily adapt the module path, the path would end up empty in the end, even if it wasn't empty before, because of the unset() call of a not-package-specific variable. Therefore, make the variable name package specific.



<!-- Thank you for contributing! -->
