### PR TITLE
Update MAX_ARGS value in the code generation script

### DIFF
--- a/scripts/codegen/setup_kernel_operators.py
+++ b/scripts/codegen/setup_kernel_operators.py
@@ -24,7 +24,7 @@ EDIT_WARNING = f'''
 // =========================================
 '''.strip()
 
-MAX_ARGS = 50
+MAX_ARGS = 60
 
 
 def to_file(filename):


### PR DESCRIPTION
Update the value of the maximum arguments in code generation python script which was missing from the PR #671. This should fix the incorrect behavior for a kernel having the number of arguments greater than 50.