### PR TITLE
Use gcnArchName instead of gcnArch. 

### DIFF
--- a/src/occa/internal/modes/hip/polyfill.hpp
+++ b/src/occa/internal/modes/hip/polyfill.hpp
@@ -37,7 +37,6 @@ namespace occa {
     char *name;
     size_t totalGlobalMem;
     int maxThreadsPerBlock;
-    int gcnArch;
     char gcnArchName[256];
     int major;
     int minor;
@@ -46,7 +45,6 @@ namespace occa {
         name(NULL),
         totalGlobalMem(0),
         maxThreadsPerBlock(-1),
-        gcnArch(-1),
         major(-1),
         minor(-1) {}
   };

--- a/src/occa/internal/modes/hip/utils.cpp
+++ b/src/occa/internal/modes/hip/utils.cpp
@@ -57,12 +57,9 @@ namespace occa {
       OCCA_HIP_ERROR("Getting HIP device properties",
                      hipGetDeviceProperties(&hipProps, deviceId));
 
-      if (hipProps.gcnArch) { // AMD or NVIDIA
-#if HIP_VERSION >= 306
-        return hipProps.gcnArchName;
-#else
-        return "gfx" + toString(hipProps.gcnArch);
-#endif
+      std::string gcnArchName{hipProps.gcnArchName};
+      if (!gcnArchName.empty()) {  // AMD or NVIDIA
+        return gcnArchName;
       }
 
       std::string sm = "sm_";


### PR DESCRIPTION
gcnArch has been deprecated for quite some time now.

gcnArch being an int type can not handle the names like gfx90a.

ROCm 6.0 will remove that particular entry all together.