### PR TITLE
Include original file name in the cached sources

### DIFF
--- a/src/occa/internal/core/launchedDevice.cpp
+++ b/src/occa/internal/core/launchedDevice.cpp
@@ -91,7 +91,7 @@ namespace occa {
                                                   const bool usingOkl,
                                                   const occa::json &kernelProps) {
     const std::string hashDir = io::hashDir(filename, kernelHash);
-    std::string sourceFilename = hashDir + kc::sourceFile;
+    std::string sourceFilename = hashDir + kc::cachedSourceFilename(filename);
     const std::string binaryFilename = hashDir + kc::binaryFile;
 
     // Check if binary exists and is finished
@@ -140,12 +140,12 @@ namespace occa {
       // Cache raw origin
       sourceFilename = (
         io::cacheFile(filename,
-                      kc::cppRawSourceFile,
+                      kc::cachedRawSourceFilename(filename),
                       kernelHash,
                       assembleKernelHeader(kernelProps))
       );
 
-      const std::string outputFile = hashDir + kc::sourceFile;
+      const std::string outputFile = hashDir + kc::cachedSourceFilename(filename);
       const std::string launcherOutputFile = hashDir + kc::launcherSourceFile;
       bool valid = parseFile(sourceFilename,
                              outputFile,
@@ -180,7 +180,7 @@ namespace occa {
       // Cache in sourceFile to directly compile file
       sourceFilename = (
         io::cacheFile(filename,
-                      kc::sourceFile,
+                      kc::cachedSourceFilename(filename),
                       kernelHash,
                       assembleKernelHeader(kernelProps))
       );

--- a/src/occa/internal/io/utils.cpp
+++ b/src/occa/internal/io/utils.cpp
@@ -30,9 +30,6 @@
 namespace occa {
   // Kernel Caching
   namespace kc {
-    const std::string cppRawSourceFile   = "raw_source.cpp";
-    const std::string cRawSourceFile     = "raw_source.c";
-    const std::string sourceFile         = "source.cpp";
     const std::string launcherSourceFile = "launcher_source.cpp";
     const std::string buildFile          = "build.json";
     const std::string launcherBuildFile  = "launcher_build.json";
@@ -43,6 +40,16 @@ namespace occa {
     const std::string binaryFile         = "binary.dll";
     const std::string launcherBinaryFile = "launcher_binary.dll";
 #endif
+
+    std::string cachedRawSourceFilename(std::string filename, bool compilingCpp) {
+      const std::string basename = io::basename(filename, false);
+      const std::string extension = compilingCpp ? ".cpp" : ".c";
+      return basename + std::string(".raw_source") + extension;
+    }
+    std::string cachedSourceFilename(std::string filename) {
+      const std::string basename = io::basename(filename, false);
+      return basename + std::string(".source.cpp");
+    }
   }
 
   namespace io {

--- a/src/occa/internal/io/utils.hpp
+++ b/src/occa/internal/io/utils.hpp
@@ -10,14 +10,14 @@
 namespace occa {
   // Kernel Caching
   namespace kc {
-    extern const std::string cppRawSourceFile;
-    extern const std::string cRawSourceFile;
-    extern const std::string sourceFile;
     extern const std::string binaryFile;
     extern const std::string buildFile;
     extern const std::string launcherSourceFile;
     extern const std::string launcherBinaryFile;
     extern const std::string launcherBuildFile;
+
+    std::string cachedRawSourceFilename(std::string filename, bool compilingCpp=true);
+    std::string cachedSourceFilename(std::string filename);
   }
 
   namespace io {

--- a/src/occa/internal/modes/serial/device.cpp
+++ b/src/occa/internal/modes/serial/device.cpp
@@ -276,22 +276,16 @@ namespace occa {
       if (isLauncherKernel) {
         sourceFilename = filename;
       } else {
-        const std::string &rawSourceFile = (
-          compilingCpp
-          ? kc::cppRawSourceFile
-          : kc::cRawSourceFile
-        );
-
         // Cache raw origin
         sourceFilename = (
           io::cacheFile(filename,
-                        rawSourceFile,
+                        kc::cachedRawSourceFilename(filename, compilingCpp),
                         kernelHash,
                         assembleKernelHeader(kernelProps))
         );
 
         if (compilingOkl) {
-          const std::string outputFile = hashDir + kc::sourceFile;
+          const std::string outputFile = hashDir + kc::cachedSourceFilename(filename);
           bool valid = parseFile(sourceFilename,
                                  outputFile,
                                  kernelProps,


### PR DESCRIPTION
This aids debugging, e.g. in stack traces or when setting breakpoints.