### PR TITLE
Avoid unintended calls to sycl default device/context ctor.

### DIFF
--- a/src/occa/internal/modes/dpcpp/device.cpp
+++ b/src/occa/internal/modes/dpcpp/device.cpp
@@ -17,39 +17,13 @@ namespace occa
 {
   namespace dpcpp
   {
-    device::device(const occa::json &properties_)
-        : occa::launchedModeDevice_t(properties_)
+    device::device(const occa::json &properties_, 
+                   const ::sycl::context& context_,
+                   const ::sycl::device& device_)
+        : occa::launchedModeDevice_t(properties_), dpcppContext(context_), dpcppDevice(device_)
     {
-      if (!properties.has("wrapped"))
-      {
-        OCCA_ERROR(
-            "[dpcpp] device not given a [platform_id] integer",
-            properties.has("platform_id") && properties["platform_id"].isNumber());
-
-        OCCA_ERROR(
-            "[dpcpp] device not given a [device_id] integer",
-            properties.has("device_id") && properties["device_id"].isNumber());
-
-        platformID = properties.get<int>("platform_id");
-        deviceID = properties.get<int>("device_id");
-
-        auto platforms{::sycl::platform::get_platforms()};
-        OCCA_ERROR(
-            "Invalid platform number (" + toString(platformID) + ")",
-            (static_cast<size_t>(platformID) < platforms.size()));
-
-        auto devices{platforms[platformID].get_devices()};
-        OCCA_ERROR(
-            "Invalid device number (" + toString(deviceID) + ")",
-            (static_cast<size_t>(deviceID) < devices.size()));
-
-        dpcppDevice = devices[deviceID];
-        dpcppContext = ::sycl::context(devices[deviceID]);
-      }
-
       occa::json &kernelProps = properties["kernel"];
       setCompilerLinkerOptions(kernelProps);
-
       arch = dpcppDevice.get_info<::sycl::info::device::name>();
     }
 

--- a/src/occa/internal/modes/dpcpp/device.cpp
+++ b/src/occa/internal/modes/dpcpp/device.cpp
@@ -18,9 +18,8 @@ namespace occa
   namespace dpcpp
   {
     device::device(const occa::json &properties_, 
-                   const ::sycl::context& context_,
                    const ::sycl::device& device_)
-        : occa::launchedModeDevice_t(properties_), dpcppContext(context_), dpcppDevice(device_)
+        : occa::launchedModeDevice_t(properties_), dpcppDevice(device_), dpcppContext(device_) 
     {
       occa::json &kernelProps = properties["kernel"];
       setCompilerLinkerOptions(kernelProps);

--- a/src/occa/internal/modes/dpcpp/device.hpp
+++ b/src/occa/internal/modes/dpcpp/device.hpp
@@ -17,11 +17,10 @@ namespace occa
       mutable hash_t hash_;
 
     public:
-      ::sycl::context dpcppContext;
       ::sycl::device dpcppDevice;
+      ::sycl::context dpcppContext;
 
       device(const occa::json &properties_, 
-             const ::sycl::context& context_,
              const ::sycl::device& device_);
       
       virtual ~device() = default;

--- a/src/occa/internal/modes/dpcpp/device.hpp
+++ b/src/occa/internal/modes/dpcpp/device.hpp
@@ -17,12 +17,13 @@ namespace occa
       mutable hash_t hash_;
 
     public:
-      int platformID{-1}, deviceID{-1};
-
-      ::sycl::device dpcppDevice;
       ::sycl::context dpcppContext;
+      ::sycl::device dpcppDevice;
 
-      device(const occa::json &properties_);
+      device(const occa::json &properties_, 
+             const ::sycl::context& context_,
+             const ::sycl::device& device_);
+      
       virtual ~device() = default;
 
       inline bool hasSeparateMemorySpace() const override { return true; }

--- a/src/occa/internal/modes/dpcpp/registration.cpp
+++ b/src/occa/internal/modes/dpcpp/registration.cpp
@@ -105,12 +105,7 @@ namespace occa {
           (static_cast<size_t>(deviceID) < devices.size()));
       auto& dpcppDevice = devices[deviceID];
 
-#if SYCL_EXT_ONEAPI_DEFAULT_CONTEXT
-      ::sycl::context dpcppContext = platform.ext_oneapi_get_default_context();
-#else
-      ::sycl::context dpcppContext(devices);
-#endif
-      return new occa::dpcpp::device(setModeProp(props), dpcppContext, dpcppDevice);
+      return new occa::dpcpp::device(setModeProp(props), dpcppDevice);
     }
 
     int dpcppMode::getDeviceCount(const occa::json& props) {

--- a/src/occa/internal/modes/dpcpp/registration.cpp
+++ b/src/occa/internal/modes/dpcpp/registration.cpp
@@ -82,7 +82,35 @@ namespace occa {
     }
 
     modeDevice_t* dpcppMode::newDevice(const occa::json &props) {
-      return new occa::dpcpp::device(setModeProp(props));
+      // Refactor this into a helper function.
+      OCCA_ERROR(
+          "[dpcpp] device not given a [platform_id] integer",
+          props.has("platform_id") && props["platform_id"].isNumber());
+      int platformID = props.get<int>("platform_id");
+      
+      auto platforms{::sycl::platform::get_platforms()};
+      OCCA_ERROR(
+          "Invalid platform number (" + toString(platformID) + ")",
+          (static_cast<size_t>(platformID) < platforms.size()));
+      auto& platform = platforms[platformID];
+
+      OCCA_ERROR(
+          "[dpcpp] device not given a [device_id] integer",
+          props.has("device_id") && props["device_id"].isNumber());
+
+      int deviceID = props.get<int>("device_id");
+      auto devices{platform.get_devices()};
+      OCCA_ERROR(
+          "Invalid device number (" + toString(deviceID) + ")",
+          (static_cast<size_t>(deviceID) < devices.size()));
+      auto& dpcppDevice = devices[deviceID];
+
+#if SYCL_EXT_ONEAPI_DEFAULT_CONTEXT
+      ::sycl::context dpcppContext = platform.ext_oneapi_get_default_context();
+#else
+      ::sycl::context dpcppContext(devices);
+#endif
+      return new occa::dpcpp::device(setModeProp(props), dpcppContext, dpcppDevice);
     }
 
     int dpcppMode::getDeviceCount(const occa::json& props) {

--- a/src/occa/internal/modes/dpcpp/utils.cpp
+++ b/src/occa/internal/modes/dpcpp/utils.cpp
@@ -119,8 +119,7 @@ namespace occa
       allProps["wrapped"] = true;
       allProps += props;
 
-      ::sycl::context sycl_context(sycl_device);
-      auto* wrapper{new dpcpp::device(allProps, sycl_context, sycl_device)};
+      auto* wrapper{new dpcpp::device(allProps, sycl_device)};
       wrapper->dontUseRefs();
 
       wrapper->currentStream = wrapper->createStream(allProps["stream"]);

--- a/src/occa/internal/modes/dpcpp/utils.cpp
+++ b/src/occa/internal/modes/dpcpp/utils.cpp
@@ -111,23 +111,19 @@ namespace occa
       return *dpcppTag;
     }
 
-    occa::device wrapDevice(::sycl::device device,
+    occa::device wrapDevice(::sycl::device sycl_device,
                             const occa::properties &props)
     {
       occa::properties allProps;
       allProps["mode"] = "dpcpp";
-      allProps["device_id"] = -1;
-      allProps["platform_id"] = -1;
       allProps["wrapped"] = true;
       allProps += props;
 
-      auto* wrapper{new dpcpp::device(allProps)};
+      ::sycl::context sycl_context(sycl_device);
+      auto* wrapper{new dpcpp::device(allProps, sycl_context, sycl_device)};
       wrapper->dontUseRefs();
 
-      wrapper->dpcppDevice = device;
-      wrapper->dpcppContext = ::sycl::context(device);
       wrapper->currentStream = wrapper->createStream(allProps["stream"]);
-
       return occa::device(wrapper);
     }
 

--- a/src/occa/internal/modes/dpcpp/utils.hpp
+++ b/src/occa/internal/modes/dpcpp/utils.hpp
@@ -37,7 +37,7 @@ namespace occa {
     occa::dpcpp::stream& getDpcppStream(const occa::stream& stream_);
     occa::dpcpp::streamTag &getDpcppStreamTag(const occa::streamTag& tag);
 
-    occa::device wrapDevice(::sycl::device device,
+    occa::device wrapDevice(::sycl::device sycl_device,
                             const occa::properties &props = occa::properties());
 
     void warn(const ::sycl::exception &e,


### PR DESCRIPTION
## Description

- In the SYCL 2020 spec, the default device and context constructors use the default device selector
- The default device selector may return a device from a different platform, which can result in runtime errors
- To avoid this, directly initialize the device and context instead of using assignment