### PR TITLE
Remove qualifiers from lhs of sycl local variable declarations.

### DIFF
--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -284,6 +284,7 @@ namespace occa
                 var.vartype.setType(auto_);
                 var.vartype.setReferenceToken(var.source);
                 var.vartype.arrays.clear();
+                var.vartype.qualifiers.clear();
               }
             });
       }


### PR DESCRIPTION
## Details

- Currently `@shared` declarations with qualifiers lead to compilation errors since we use `auto&` 
- Example: `@shared long int x[3]` is translated to `long auto& x = ...` instead of `auto& x  = ...`
- Qualifiers are still included in the template parameter of the RHS call for allocating local memory.