### PR TITLE
[WORKAROUND] Avoid unloading dynamic libraries for dpcpp kernels.

### DIFF
--- a/src/occa/internal/modes/dpcpp/kernel.cpp
+++ b/src/occa/internal/modes/dpcpp/kernel.cpp
@@ -49,7 +49,12 @@ namespace occa
     {
       if (dlHandle)
       {
-        sys::dlclose(dlHandle);
+        // WORKAROUND: dynamically loaded device code is effectively a
+        // shared resource managed by the sycl runtime. Unloading the
+        // dynamic library for our kernels can corrupt objects owned
+        // by the sycl implementation (e.g., kernel bundles), leading
+        // to runtime errors. For now avoid calling dlclose.
+        // sys::dlclose(dlHandle);
         dlHandle = nullptr;
       }
       function = nullptr;


### PR DESCRIPTION
## Description

- Dynamically loaded device code is effectively a shared resource managed by the sycl runtime. 
- Unloading the dynamic library for our kernels can corrupt objects owned by the sycl implementation (e.g., kernel bundles), leading to runtime errors. 
- Avoid calling `dlclose` as a temporary workaround until issues related to dynamically loaded device code are resolved by the sycl spec and/or implementers. (See discussion [here](https://intel.github.io/llvm-docs/design/SharedLibraries.html))


<!-- Thank you for contributing! -->
