### PR TITLE
[HIP] Resize the argument buffer to be able to fit large arguments passed by value

### DIFF
--- a/src/occa/internal/modes/hip/kernel.hpp
+++ b/src/occa/internal/modes/hip/kernel.hpp
@@ -15,7 +15,7 @@ namespace occa {
       hipModule_t hipModule;
       hipFunction_t hipFunction;
 
-      mutable std::vector<void*> vArgs;
+      mutable std::vector<std::byte> vArgs;
 
     public:
       kernel(modeDevice_t *modeDevice_,


### PR DESCRIPTION
## Description
Fixes an issue where large (`>sizeof(void*)`) arguments passed by value in HIP mode would overflow the allocated space for kernel arguments passed to `hipModuleLaunchKernel`

Thanks to @ooreilly for reporting the issue!


<!-- Thank you for contributing! -->
