### PR TITLE
Remove dpcpp from modes tested with inline kernel example on GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
     - name: Run CTests
       if: ${{ matrix.useCMake && !matrix.useoneAPI }}
       run: |
-        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_nonblocking_streams-opencl|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp|examples_cpp_nonblocking_streams-dpcpp"
+        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_nonblocking_streams-opencl|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp|examples_cpp_generic_inline_kernel-dpcpp|examples_cpp_nonblocking_streams-dpcpp"
 
         
 
@@ -179,7 +179,7 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh
         export ONEAPI_DEVICE_SELECTOR=*:cpu
-        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_nonblocking_streams-opencl|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp|examples_cpp_nonblocking_streams-dpcpp"
+        ctest --test-dir build --progress --output-on-failure --parallel 8 --schedule-random -E "examples_cpp_arrays-opencl|examples_cpp_for_loops-opencl|examples_cpp_generic_inline_kernel-opencl|examples_cpp_shared_memory-opencl|examples_cpp_nonblocking_streams-opencl|examples_cpp_for_loops-dpcpp|examples_cpp_arrays-dpcpp|examples_cpp_generic_inline_kernel-dpcpp|examples_cpp_nonblocking_streams-dpcpp"
 
     - name: Upload code coverage
       if: ${{ matrix.OCCA_COVERAGE }}


### PR DESCRIPTION
## Details

- The inline kernel cpp example passes for dpcpp mode on the second pass
- There is likely a bug related to kernel jitting
- For now remove from the GitHub CI pipeline since it will cause unrelated to PRs to fail checks