### PR TITLE
Set SYCL subgroup size via kernel property or `@simd_length` attribute.

### DIFF
--- a/src/occa/internal/lang/attribute.cpp
+++ b/src/occa/internal/lang/attribute.cpp
@@ -54,6 +54,11 @@ namespace occa {
     bool attributeArg_t::exists() const {
       return expr;
     }
+
+    bool attributeArg_t::canEvaluate() const {
+      if (!expr) return false;
+      return expr->canEvaluate();  
+    }
     //==================================
 
     //---[ Attribute ]------------------

--- a/src/occa/internal/lang/attribute.cpp
+++ b/src/occa/internal/lang/attribute.cpp
@@ -66,6 +66,11 @@ namespace occa {
       attrType(&attrType_),
       source((identifierToken*) token_t::clone(&source_)) {}
 
+    attributeToken_t::attributeToken_t(attribute_t *attrType_,
+                                       identifierToken* source_,
+                                       attribute_style style_)
+      : attrType(attrType_), source(source_), style(style_) {}
+
     attributeToken_t::attributeToken_t(const attributeToken_t &other) :
       attrType(NULL),
       source(NULL) {

--- a/src/occa/internal/lang/attribute.cpp
+++ b/src/occa/internal/lang/attribute.cpp
@@ -66,11 +66,6 @@ namespace occa {
       attrType(&attrType_),
       source((identifierToken*) token_t::clone(&source_)) {}
 
-    attributeToken_t::attributeToken_t(attribute_t *attrType_,
-                                       identifierToken* source_,
-                                       attribute_style style_)
-      : attrType(attrType_), source(source_), style(style_) {}
-
     attributeToken_t::attributeToken_t(const attributeToken_t &other) :
       attrType(NULL),
       source(NULL) {

--- a/src/occa/internal/lang/attribute.hpp
+++ b/src/occa/internal/lang/attribute.hpp
@@ -63,6 +63,8 @@ namespace occa {
       void clear();
 
       bool exists() const;
+
+      bool canEvaluate() const;
     };
     //==================================
 

--- a/src/occa/internal/lang/builtins/attributes.hpp
+++ b/src/occa/internal/lang/builtins/attributes.hpp
@@ -14,6 +14,7 @@
 #include <occa/internal/lang/builtins/attributes/outer.hpp>
 #include <occa/internal/lang/builtins/attributes/restrict.hpp>
 #include <occa/internal/lang/builtins/attributes/shared.hpp>
+#include <occa/internal/lang/builtins/attributes/simdLength.hpp>
 #include <occa/internal/lang/builtins/attributes/tile.hpp>
 
 #endif

--- a/src/occa/internal/lang/builtins/attributes/simdLength.cpp
+++ b/src/occa/internal/lang/builtins/attributes/simdLength.cpp
@@ -1,0 +1,50 @@
+#include <occa/internal/lang/expr.hpp>
+#include <occa/internal/lang/parser.hpp>
+#include <occa/internal/lang/statement.hpp>
+#include <occa/internal/lang/variable.hpp>
+#include <occa/internal/lang/builtins/attributes/simdLength.hpp>
+
+namespace occa {
+namespace lang {
+namespace attributes {
+
+  const std::string& simdLength::name() const { return name_;}
+
+  bool simdLength::forStatementType(const int sType) const {
+    return (sType & statementType::for_);
+  }
+
+  bool simdLength::isValid(const attributeToken_t &attr) const {
+    if (attr.kwargs.size()) {
+      attr.printError(name_ + " does not take kwargs");
+      return false;
+    }
+
+    if (1 != attr.args.size()) {
+      attr.printError(name_ + " takes one argument");
+      return false;
+    }
+    
+    const auto& attr_arg = attr.args[0];
+    if (!attr_arg.canEvaluate()) {
+      attr.printError(name_ + " cannot evaluate argument");
+      return false;
+    }
+
+    primitive value = attr_arg.expr->evaluate();
+    if (!value.isInteger()) {
+      attr.printError(name_ + " take an integer argument");
+      return false;
+    }
+
+    if(0 > value.to<int>())  {
+      attr.printError(name_ + " arguments must be postive!");
+      return false;
+    }
+
+    return true;
+  }
+
+}
+}
+}

--- a/src/occa/internal/lang/builtins/attributes/simdLength.hpp
+++ b/src/occa/internal/lang/builtins/attributes/simdLength.hpp
@@ -1,0 +1,24 @@
+#ifndef OCCA_INTERNAL_LANG_BUILTINS_ATTRIBUTES_SIMD_LENGTH_HEADER
+#define OCCA_INTERNAL_LANG_BUILTINS_ATTRIBUTES_SIMD_LENGTH_HEADER
+
+#include <occa/internal/lang/attribute.hpp>
+
+namespace occa {
+namespace lang {
+namespace attributes {
+
+class simdLength : public attribute_t {
+public:
+  simdLength() = default;
+  const std::string& name() const override;
+  bool forStatementType(const int sType) const override;
+  bool isValid(const attributeToken_t &attr) const override;
+private:
+  static const inline std::string name_{"simd_length"};
+};
+
+}
+}
+}
+
+#endif

--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -80,15 +80,7 @@ namespace occa
 
       std::string dpcppParser::launchBoundsAttribute(const int innerDims[3])
       {
-        std::stringstream ss; 
-        ss << "[[sycl::reqd_work_group_size("
-           << innerDims[2]
-           << ","
-           << innerDims[1]
-           << ","
-           << innerDims[0]
-           << ")]]\n";
-        return ss.str();
+        return "";
       }
 
       // @note: As of SYCL 2020 this will need to change from `CL/sycl.hpp` to `sycl.hpp`

--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -35,7 +35,7 @@ namespace occa
             shared("auto", qualifierType::custom)
       {
         okl::addOklAttributes(*this);
-        simd_length = settings.get("simd_length",-1);
+        simd_length_default = settings_.get("simd_length",-1);
       }
 
       void dpcppParser::onClear()
@@ -199,18 +199,21 @@ namespace occa
                          lambda_t &sycl_kernel = *(new lambda_t(capture_t::byValue));
                          sycl_kernel.addArgument(sycl_nditem);
 
+                         int simd_length = simd_length_default;
+                         if (k.hasAttribute("simd_length")) {
+                           const attributeToken_t& attr = k.attributes["simd_length"];
+                           simd_length = attr.args[0].expr->evaluate();
+                         }
+
                          if(0 < simd_length) {
-                           // Make idenifierNode for attributeArg
                            attributeArg_t subgroup_size_arg(
                             new identifierNode(
                               new identifierToken(originSource::builtin, "subgroup_size_arg"),
                               std::to_string(simd_length)));
                            
-                           // Create attributeToken
                            attributeToken_t subgroup_size_token(new SubgroupSize(),
                              new identifierToken(originSource::builtin, "subgroup_size"),
                              occa::lang::attribute_style::cpp);
-
                            subgroup_size_token.args.push_back(subgroup_size_arg);
 
                            sycl_kernel.attributes["subgroup_size"] = subgroup_size_token;

--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -20,6 +20,7 @@ namespace occa
             shared("auto", qualifierType::custom)
       {
         okl::addOklAttributes(*this);
+        simd_length = settings.get("simd_length",-1);
       }
 
       void dpcppParser::onClear()

--- a/src/occa/internal/lang/modes/dpcpp.hpp
+++ b/src/occa/internal/lang/modes/dpcpp.hpp
@@ -42,7 +42,6 @@ namespace occa
         void setSharedQualifiers();
         void setKernelQualifiers(function_t &function);
         void migrateLocalDecls(functionDeclStatement &kernelSmnt);
-        void setLaunchBounds();
 
         void setupAtomics();
         static bool transformAtomicBlockStatement(blockStatement &blockSmnt);

--- a/src/occa/internal/lang/modes/dpcpp.hpp
+++ b/src/occa/internal/lang/modes/dpcpp.hpp
@@ -48,7 +48,7 @@ namespace occa
         static bool transformAtomicBasicExpressionStatement(expressionStatement &exprSmnt);
 
       private:
-        int simd_length;
+        int simd_length_default;
 
         inline int dpcppDimensionOrder(const int index) { return 2 - index; }
       };

--- a/src/occa/internal/lang/modes/dpcpp.hpp
+++ b/src/occa/internal/lang/modes/dpcpp.hpp
@@ -49,6 +49,8 @@ namespace occa
         static bool transformAtomicBasicExpressionStatement(expressionStatement &exprSmnt);
 
       private:
+        int simd_length;
+
         inline int dpcppDimensionOrder(const int index) { return 2 - index; }
       };
     } // namespace okl

--- a/src/occa/internal/lang/modes/okl.cpp
+++ b/src/occa/internal/lang/modes/okl.cpp
@@ -392,6 +392,7 @@ namespace occa {
         parser.addAttribute<attributes::shared>();
         parser.addAttribute<attributes::maxInnerDims>();
         parser.addAttribute<attributes::noBarrier>();
+        parser.addAttribute<attributes::simdLength>();
       }
 
       void setOklLoopIndices(functionDeclStatement &kernelSmnt) {

--- a/src/occa/internal/lang/modes/withLauncher.cpp
+++ b/src/occa/internal/lang/modes/withLauncher.cpp
@@ -437,6 +437,10 @@ namespace occa {
         forStatement &newForSmnt = (forStatement&) forSmnt.clone();
         newKernelSmnt.set(newForSmnt);
 
+        if (newForSmnt.hasAttribute("simd_length")) {
+          newKernelSmnt.addAttribute(newForSmnt.attributes["simd_length"]);
+        }
+
         bool addLaunchBoundsAttribute{true};
         int kernelInnerDims[3] = {1,1,1};
         if (newForSmnt.hasAttribute("max_inner_dims")) {


### PR DESCRIPTION
## Description

- Introduces the `@simd_length` attribute and kernel property
- For dpcpp mode these can be used to prescribe which subgroup size will be used
- OpenCL and OpenMP modes could make use of this property in the future

Closes #693 