### PR TITLE
Fixes corruption of memory datatypes caused by short circuit logic in `modeMemory_t::slice`

### DIFF
--- a/src/occa/internal/core/memory.cpp
+++ b/src/occa/internal/core/memory.cpp
@@ -77,10 +77,6 @@ namespace occa {
 
   modeMemory_t* modeMemory_t::slice(const dim_t offset_,
                                     const udim_t bytes) {
-
-    //quick return if we're not really slicing
-    if ((offset_ == 0) && (bytes == size)) return this;
-
     OCCA_ERROR("ModeMemory not initialized or has been freed",
                modeBuffer != NULL);
 

--- a/tests/src/core/memory.cpp
+++ b/tests/src/core/memory.cpp
@@ -4,11 +4,13 @@
 void testMalloc();
 void testSlice();
 void testUnwrap();
+void testCast();
 
 int main(const int argc, const char **argv) {
   testMalloc();
   testSlice();
   testUnwrap();
+  testCast();
 
   return 0;
 }
@@ -153,4 +155,19 @@ void testUnwrap() {
   }
 
   delete[] host_memory;
+}
+
+void testCast() {
+  occa::device occa_device({{"mode", "Serial"}});
+
+  occa::memory occa_memory = occa_device.malloc<double>(10);
+
+  ASSERT_TRUE(occa::dtype::double_ == occa_memory.dtype());
+
+  occa::memory casted_memory = occa_memory.cast(occa::dtype::byte);
+
+  ASSERT_TRUE(occa::dtype::double_ == occa_memory.dtype());
+  ASSERT_TRUE(occa::dtype::byte == casted_memory.dtype());
+
+  ASSERT_EQ(occa_memory.size(), casted_memory.size());
 }


### PR DESCRIPTION
Closes #690 