### PR TITLE
Initial support for compiler attribute statements

### DIFF
--- a/src/occa/internal/lang/builtins/types.cpp
+++ b/src/occa/internal/lang/builtins/types.cpp
@@ -11,6 +11,10 @@ namespace occa {
     const qualifier_t volatile_     ("volatile"      , qualifierType::volatile_);
     const qualifier_t long_         ("long"          , qualifierType::long_);
     const qualifier_t longlong_     ("long long"     , qualifierType::longlong_);
+    const qualifier_t attribute_    ("__attribute__" , qualifierType::attribute_);
+
+    // Windows types
+    const qualifier_t declspec_     ("__declspec"    , qualifierType::declspec_);
 
     const qualifier_t extern_       ("extern"        , qualifierType::extern_);
     const qualifier_t externC       ("extern \"C\""  , qualifierType::externC);
@@ -28,10 +32,6 @@ namespace occa {
     const qualifier_t enum_         ("enum"          , qualifierType::enum_);
     const qualifier_t struct_       ("struct"        , qualifierType::struct_);
     const qualifier_t union_        ("union"         , qualifierType::union_);
-
-    // Windows types
-    // TODO: Properly handle compiler extension attributes
-    const qualifier_t dllexport_    ("__declspec(dllexport)", qualifierType::dllexport_);
 
     const primitive_t bool_         ("bool");
     const primitive_t char_         ("char");
@@ -89,6 +89,6 @@ namespace occa {
     const primitive_t double2       ("double2");
     const primitive_t double3       ("double3");
     const primitive_t double4       ("double4");
-    
+
   } // namespace lang
 }

--- a/src/occa/internal/lang/builtins/types.hpp
+++ b/src/occa/internal/lang/builtins/types.hpp
@@ -14,6 +14,11 @@ namespace occa {
     extern const qualifier_t volatile_;
     extern const qualifier_t long_;
     extern const qualifier_t longlong_;
+    extern const qualifier_t attribute_;
+
+    // Windows types
+    // TODO: Properly handle compiler extension attributes
+    extern const qualifier_t declspec_;
 
     extern const qualifier_t extern_;
     extern const qualifier_t externC;
@@ -31,10 +36,6 @@ namespace occa {
     extern const qualifier_t enum_;
     extern const qualifier_t struct_;
     extern const qualifier_t union_;
-
-    // Windows types
-    // TODO: Properly handle compiler extension attributes
-    extern const qualifier_t dllexport_;
 
     extern const primitive_t bool_;
     extern const primitive_t char_;
@@ -92,7 +93,7 @@ namespace occa {
     extern const primitive_t double2;
     extern const primitive_t double3;
     extern const primitive_t double4;
-    
+
     // DPCPP Primitives
     extern const primitive_t syclQueue;
     extern const primitive_t syclNdRange;

--- a/src/occa/internal/lang/keyword.cpp
+++ b/src/occa/internal/lang/keyword.cpp
@@ -291,6 +291,8 @@ namespace occa {
       keywords.add(*(new qualifierKeyword(volatile_)));
       keywords.add(*(new qualifierKeyword(long_)));
       keywords.add(*(new qualifierKeyword(longlong_)));
+      keywords.add(*(new qualifierKeyword(attribute_)));
+      keywords.add(*(new qualifierKeyword(declspec_)));
 
       keywords.add(*(new qualifierKeyword(extern_)));
       keywords.add(*(new qualifierKeyword(externC)));

--- a/src/occa/internal/lang/loaders/typeLoader.hpp
+++ b/src/occa/internal/lang/loaders/typeLoader.hpp
@@ -23,8 +23,7 @@ namespace occa {
 
       bool loadType(vartype_t &vartype);
 
-      void loadVartypeQualifier(token_t *token,
-                                const qualifier_t &qualifier,
+      void loadVartypeQualifier(const qualifier_t &qualifier,
                                 vartype_t &vartype);
 
       void setVartypePointers(vartype_t &vartype);

--- a/src/occa/internal/lang/modes/okl.cpp
+++ b/src/occa/internal/lang/modes/okl.cpp
@@ -42,7 +42,7 @@ namespace occa {
       bool kernelHasValidReturnType(functionDeclStatement &kernelSmnt) {
         vartype_t &returnType = kernelSmnt.function().returnType;
 
-        if (returnType.qualifiers.size() || (*returnType.type != void_)) {
+        if (*returnType.type != void_) {
           returnType.printError(
             "[@kernel] functions must have a [void] return type"
           );

--- a/src/occa/internal/lang/qualifier.cpp
+++ b/src/occa/internal/lang/qualifier.cpp
@@ -23,8 +23,12 @@ namespace occa {
       const udim_t long_         = (((uint64_t) 1) << 7);
       const udim_t longlong_     = (((uint64_t) 1) << 8);
       const udim_t register_     = (((uint64_t) 1) << 9);
+      const udim_t attribute_    = (((uint64_t) 1) << 10);
 
-      const udim_t typeInfo_     = (((uint64_t) 1) << 10);
+      // Windows types
+      const udim_t declspec_    = (((uint64_t) 1) << 11);
+
+      const udim_t typeInfo_     = (((uint64_t) 1) << 12);
       const udim_t typeInfo      = (const_     |
                                     constexpr_ |
                                     signed_    |
@@ -33,20 +37,24 @@ namespace occa {
                                     long_      |
                                     longlong_  |
                                     register_  |
+                                    attribute_ |
+                                    declspec_  |
                                     typeInfo_);
 
-      const udim_t forPointers_  = (((uint64_t) 1) << 11);
-      const udim_t forPointers   = (const_    |
-                                    volatile_ |
+      const udim_t forPointers_  = (((uint64_t) 1) << 13);
+      const udim_t forPointers   = (const_     |
+                                    volatile_  |
+                                    attribute_ |
+                                    declspec_  |
                                     forPointers_);
 
-      const udim_t extern_       = (((uint64_t) 1) << 12);
-      const udim_t externC       = (((uint64_t) 1) << 13);
-      const udim_t externCpp     = (((uint64_t) 1) << 14);
-      const udim_t static_       = (((uint64_t) 1) << 15);
-      const udim_t thread_local_ = (((uint64_t) 1) << 16);
+      const udim_t extern_       = (((uint64_t) 1) << 14);
+      const udim_t externC       = (((uint64_t) 1) << 15);
+      const udim_t externCpp     = (((uint64_t) 1) << 16);
+      const udim_t static_       = (((uint64_t) 1) << 17);
+      const udim_t thread_local_ = (((uint64_t) 1) << 18);
 
-      const udim_t globalScope_  = (((uint64_t) 1) << 17);
+      const udim_t globalScope_  = (((uint64_t) 1) << 19);
       const udim_t globalScope   = (extern_       |
                                     externC       |
                                     externCpp     |
@@ -54,36 +62,33 @@ namespace occa {
                                     thread_local_ |
                                     globalScope_);
 
-      const udim_t friend_       = (((uint64_t) 1) << 18);
-      const udim_t mutable_      = (((uint64_t) 1) << 19);
+      const udim_t friend_       = (((uint64_t) 1) << 20);
+      const udim_t mutable_      = (((uint64_t) 1) << 21);
 
-      const udim_t classInfo_    = (((uint64_t) 1) << 20);
+      const udim_t classInfo_    = (((uint64_t) 1) << 22);
       const udim_t classInfo     = (friend_  |
                                     mutable_ |
                                     classInfo_);
 
-      const udim_t inline_       = (((uint64_t) 1) << 21);
-      const udim_t virtual_      = (((uint64_t) 1) << 22);
-      const udim_t explicit_     = (((uint64_t) 1) << 23);
+      const udim_t inline_       = (((uint64_t) 1) << 23);
+      const udim_t virtual_      = (((uint64_t) 1) << 24);
+      const udim_t explicit_     = (((uint64_t) 1) << 25);
 
-      const udim_t functionInfo_ = (((uint64_t) 1) << 24);
+      const udim_t functionInfo_ = (((uint64_t) 1) << 26);
       const udim_t functionInfo  = (typeInfo  |
                                     inline_   |
                                     virtual_  |
                                     explicit_ |
                                     functionInfo_);
 
-      const udim_t builtin_      = (((uint64_t) 1) << 25);
-      const udim_t typedef_      = (((uint64_t) 1) << 26);
-      const udim_t class_        = (((uint64_t) 1) << 27);
-      const udim_t enum_         = (((uint64_t) 1) << 28);
-      const udim_t struct_       = (((uint64_t) 1) << 29);
-      const udim_t union_        = (((uint64_t) 1) << 30);
+      const udim_t builtin_      = (((uint64_t) 1) << 27);
+      const udim_t typedef_      = (((uint64_t) 1) << 28);
+      const udim_t class_        = (((uint64_t) 1) << 29);
+      const udim_t enum_         = (((uint64_t) 1) << 30);
+      const udim_t struct_       = (((uint64_t) 1) << 31);
+      const udim_t union_        = (((uint64_t) 1) << 32);
 
-      // Windows types
-      const udim_t dllexport_    = (((uint64_t) 1) << 31);
-
-      const udim_t newType_      = (((uint64_t) 1) << 32);
+      const udim_t newType_      = (((uint64_t) 1) << 33);
       const udim_t newType       = (typedef_ |
                                     class_   |
                                     enum_    |
@@ -91,7 +96,7 @@ namespace occa {
                                     union_   |
                                     newType_);
 
-      const udim_t custom        = (((uint64_t) 1) << 33);
+      const udim_t custom        = (((uint64_t) 1) << 34);
     }
 
     //---[ Qualifier ]------------------
@@ -127,6 +132,38 @@ namespace occa {
       origin(origin_),
       qualifier(&qualifier_) {}
 
+    qualifierWithSource::qualifierWithSource(const fileOrigin &origin_,
+                                             const qualifier_t &qualifier_,
+                                             const exprNodeVector &args_) :
+      origin(origin_),
+      qualifier(&qualifier_) {
+      cloneExprNodeVector(args, args_);
+    }
+
+    qualifierWithSource::qualifierWithSource(const qualifierWithSource &other) :
+      origin(),
+      qualifier() {
+
+      *this = other;
+    }
+
+    qualifierWithSource::~qualifierWithSource() {
+      freeExprNodeVector(args);
+      args.clear();
+    }
+
+    qualifierWithSource& qualifierWithSource::operator = (const qualifierWithSource &other) {
+      if (this == &other) {
+        return *this;
+      }
+
+      origin = other.origin;
+      qualifier = other.qualifier;
+      cloneExprNodeVector(args, other.args);
+
+      return *this;
+    }
+
     void qualifierWithSource::printWarning(const std::string &message) const {
       origin.printWarning(message);
     }
@@ -134,9 +171,66 @@ namespace occa {
       origin.printError(message);
     }
 
-    qualifiers_t::qualifiers_t() {}
+    printer& operator << (printer &pout,
+                          const qualifierWithSource &qualifier) {
 
-    qualifiers_t::~qualifiers_t() {}
+      if (!qualifier.args.size()) {
+        pout << *(qualifier.qualifier);
+      } else {
+        bool useNewlineDelimiters = false;
+        std::string qualifierName = qualifier.qualifier->name;
+        int lineWidth = (
+          pout.cursorPosition()
+          + (int) qualifierName.size()
+        );
+
+        const int argCount = (int) qualifier.args.size();
+        for (int i = 0; i < argCount; ++i) {
+          const std::string argStr = qualifier.args[i]->toString();
+          const int argSize = (int) argStr.size();
+          lineWidth += argSize;
+
+          useNewlineDelimiters |= (
+            argSize > PRETTIER_MAX_VAR_WIDTH
+            || lineWidth > PRETTIER_MAX_LINE_WIDTH
+          );
+        }
+
+        pout << qualifierName
+             << '(';
+
+        if (useNewlineDelimiters) {
+          pout.addIndentation();
+          pout.printNewline();
+          pout.printIndentation();
+        }
+
+        for (int i = 0; i < argCount; ++i) {
+          if (i) {
+            if (useNewlineDelimiters) {
+              pout << ',';
+              pout.printNewline();
+              pout.printIndentation();
+            } else {
+              pout << ", ";
+            }
+          }
+          pout << *(qualifier.args[i]);
+        }
+
+        if (useNewlineDelimiters) {
+          pout.removeIndentation();
+          pout.printNewline();
+          pout.printIndentation();
+        }
+
+        pout << ')';
+      }
+
+      return pout;
+    }
+
+    qualifiers_t::qualifiers_t() {}
 
     void qualifiers_t::clear() {
       qualifiers.clear();
@@ -217,6 +311,17 @@ namespace occa {
       return *this;
     }
 
+    qualifiers_t& qualifiers_t::add(const fileOrigin &origin,
+                                    const qualifier_t &qualifier,
+                                    const exprNodeVector &args) {
+      if (!has(qualifier)) {
+        qualifiers.push_back(
+          qualifierWithSource(origin, qualifier, args)
+        );
+      }
+      return *this;
+    }
+
     qualifiers_t& qualifiers_t::add(const qualifierWithSource &qualifier) {
       if (!has(*(qualifier.qualifier))) {
         qualifiers.push_back(qualifier);
@@ -235,6 +340,23 @@ namespace occa {
         qualifiers.insert(
           qualifiers.begin() + safeIndex,
           qualifierWithSource(origin, qualifier)
+        );
+      }
+      return *this;
+    }
+
+    qualifiers_t& qualifiers_t::add(const int index,
+                                    const fileOrigin &origin,
+                                    const qualifier_t &qualifier,
+                                    const exprNodeVector &args) {
+      if (!has(qualifier)) {
+        int safeIndex = 0;
+        if (index > (int) qualifiers.size()) {
+          safeIndex = (int) qualifiers.size();
+        }
+        qualifiers.insert(
+          qualifiers.begin() + safeIndex,
+          qualifierWithSource(origin, qualifier, args)
         );
       }
       return *this;
@@ -292,9 +414,9 @@ namespace occa {
       if (!count) {
         return pout;
       }
-      pout << *(quals[0].qualifier);
+      pout << quals[0];
       for (int i = 1; i < count; ++i) {
-        pout << ' ' << *(quals[i].qualifier);
+        pout << ' ' << quals[i];
       }
       return pout;
     }

--- a/src/occa/internal/lang/qualifier.hpp
+++ b/src/occa/internal/lang/qualifier.hpp
@@ -9,7 +9,11 @@
 
 namespace occa {
   namespace lang {
+    class exprNode;
+    typedef std::vector<exprNode*> exprNodeVector;
+
     namespace qualifierType {
+
       extern const udim_t none;
 
       extern const udim_t auto_;
@@ -21,6 +25,11 @@ namespace occa {
       extern const udim_t register_;
       extern const udim_t long_;
       extern const udim_t longlong_;
+      extern const udim_t attribute_;
+
+      // Windows types
+      extern const udim_t declspec_;
+
       extern const udim_t typeInfo;
 
       extern const udim_t forPointers_;
@@ -55,9 +64,6 @@ namespace occa {
       extern const udim_t struct_;
       extern const udim_t union_;
 
-      // Windows types
-      extern const udim_t dllexport_;
-
       extern const udim_t newType_;
       extern const udim_t newType;
 
@@ -88,15 +94,29 @@ namespace occa {
     public:
       fileOrigin origin;
       const qualifier_t *qualifier;
+      exprNodeVector args;
 
       qualifierWithSource(const qualifier_t &qualifier_);
 
       qualifierWithSource(const fileOrigin &origin_,
                           const qualifier_t &qualifier_);
 
+      qualifierWithSource(const fileOrigin &origin_,
+                          const qualifier_t &qualifier_,
+                          const exprNodeVector &args_);
+
+      qualifierWithSource(const qualifierWithSource &other);
+
+      ~qualifierWithSource();
+
+      qualifierWithSource& operator = (const qualifierWithSource &other);
+
       void printWarning(const std::string &message) const;
       void printError(const std::string &message) const;
     };
+
+    printer& operator << (printer &pout,
+                          const qualifierWithSource &qualifier);
 
     typedef std::vector<qualifierWithSource> qualifierVector_t;
 
@@ -105,7 +125,6 @@ namespace occa {
       qualifierVector_t qualifiers;
 
       qualifiers_t();
-      ~qualifiers_t();
 
       void clear();
 
@@ -128,11 +147,20 @@ namespace occa {
       qualifiers_t& add(const fileOrigin &origin,
                         const qualifier_t &qualifier);
 
+      qualifiers_t& add(const fileOrigin &origin,
+                        const qualifier_t &qualifier,
+                        const exprNodeVector &args);
+
       qualifiers_t& add(const qualifierWithSource &qualifier);
 
       qualifiers_t& add(const int index,
                         const fileOrigin &origin,
                         const qualifier_t &qualifier);
+
+      qualifiers_t& add(const int index,
+                        const fileOrigin &origin,
+                        const qualifier_t &qualifier,
+                        const exprNodeVector &args);
 
       qualifiers_t& add(const int index,
                         const qualifierWithSource &qualifier);

--- a/src/occa/internal/lang/type/vartype.cpp
+++ b/src/occa/internal/lang/type/vartype.cpp
@@ -270,6 +270,12 @@ namespace occa {
       qualifiers.add(origin, qualifier);
     }
 
+    void vartype_t::add(const fileOrigin &origin,
+                        const qualifier_t &qualifier,
+                        const exprNodeVector &args) {
+      qualifiers.add(origin, qualifier, args);
+    }
+
     void vartype_t::add(const qualifierWithSource &qualifier) {
       qualifiers.add(qualifier);
     }
@@ -278,6 +284,13 @@ namespace occa {
                         const fileOrigin &origin,
                         const qualifier_t &qualifier) {
       qualifiers.add(index, origin, qualifier);
+    }
+
+    void vartype_t::add(const int index,
+                        const fileOrigin &origin,
+                        const qualifier_t &qualifier,
+                        const exprNodeVector &args) {
+      qualifiers.add(index, origin, qualifier, args);
     }
 
     void vartype_t::add(const int index,

--- a/src/occa/internal/lang/type/vartype.hpp
+++ b/src/occa/internal/lang/type/vartype.hpp
@@ -73,11 +73,20 @@ namespace occa {
       void add(const fileOrigin &origin,
                const qualifier_t &qualifier);
 
+      void add(const fileOrigin &origin,
+               const qualifier_t &qualifier,
+               const exprNodeVector &args);
+
       void add(const qualifierWithSource &qualifier);
 
       void add(const int index,
                const fileOrigin &origin,
                const qualifier_t &qualifier);
+
+      void add(const int index,
+               const fileOrigin &origin,
+               const qualifier_t &qualifier,
+               const exprNodeVector &args);
 
       void add(const int index,
                const qualifierWithSource &qualifier);

--- a/src/occa/internal/lang/variable.cpp
+++ b/src/occa/internal/lang/variable.cpp
@@ -120,6 +120,12 @@ namespace occa {
       vartype.add(origin, qualifier);
     }
 
+    void variable_t::add(const fileOrigin &origin,
+                         const qualifier_t &qualifier,
+                         const exprNodeVector &args) {
+      vartype.add(origin, qualifier, args);
+    }
+
     void variable_t::add(const qualifierWithSource &qualifier) {
       vartype.add(qualifier);
     }
@@ -128,6 +134,13 @@ namespace occa {
                          const fileOrigin &origin,
                          const qualifier_t &qualifier) {
       vartype.add(index, origin, qualifier);
+    }
+
+    void variable_t::add(const int index,
+                         const fileOrigin &origin,
+                         const qualifier_t &qualifier,
+                         const exprNodeVector &args) {
+      vartype.add(index, origin, qualifier, args);
     }
 
     void variable_t::add(const int index,

--- a/src/occa/internal/lang/variable.hpp
+++ b/src/occa/internal/lang/variable.hpp
@@ -55,11 +55,20 @@ namespace occa {
       void add(const fileOrigin &origin,
                const qualifier_t &qualifier);
 
+      void add(const fileOrigin &origin,
+               const qualifier_t &qualifier,
+               const exprNodeVector &args);
+
       void add(const qualifierWithSource &qualifier);
 
       void add(const int index,
                const fileOrigin &origin,
                const qualifier_t &qualifier);
+
+      void add(const int index,
+               const fileOrigin &origin,
+               const qualifier_t &qualifier,
+               const exprNodeVector &args);
 
       void add(const int index,
                const qualifierWithSource &qualifier);


### PR DESCRIPTION
## Description
This added a generic ability of the OCCA parser to allow `qualifier_t` tokens to take arguments, and adds the `__attribute__` keyword as a qualifier. Consequently, some initial `__attribute__` and `dllexport__` statements should be possible. 

This is useful when using some backend-specific compiler attributes on variables/functions, e.g.
```c++
@kernel
__attribute__((amdgpu_waves_per_eu(1,1)))
void myKernel(...)
```
or when needing specific variable traits, e.g. with AMD GPUs and MFMA instructions:
```c++
for(int l=0;l<64;++l;@inner(0)){
  __attribute__((__vector_size__(4 * 8))) double C = {0.};
  
  ...

  // C = A*B
  C = __builtin_amdgcn_mfma_f64_16x16x4f64(A, B, C, 0, 0, 0);
}
```

<!-- Thank you for contributing! -->
