### PR TITLE
cmake: expose CUDA::cuda_driver dependency in use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ if(OCCA_ENABLE_CUDA)
     message("-- CUDA driver library: ${CUDAToolkit_LIBRARY_DIR}")
 
     # Use the provided imported target CUDA::cuda_driver, to make our package relocatable
-    target_link_libraries(libocca PRIVATE CUDA::cuda_driver)
+	target_link_libraries(libocca PUBLIC CUDA::cuda_driver)
   else()
     set(OCCA_CUDA_ENABLED 0)
   endif()


### PR DESCRIPTION
## Description
Without this, `CUDA::cuda_driver` target is not linked to libocca during consumption and as a result there is a build problem: libcuda.so cannot be found. This occurs on machines which do not have CUDA lib in default, compiler included directories (e.g. in /lib64)

<!-- Thank you for contributing! -->
