### PR TITLE
sys.cpp: fix code fallbacks for older Darwin

### DIFF
--- a/src/occa/internal/utils/sys.cpp
+++ b/src/occa/internal/utils/sys.cpp
@@ -19,6 +19,7 @@
 #    include <errno.h>
 #    include <sys/sysinfo.h>
 #  else // OCCA_MACOS_OS
+#    include <AvailabilityMacros.h>
 #    include <mach/mach_host.h>
 #    ifdef __clang__
 #      include <CoreServices/CoreServices.h>

--- a/src/occa/internal/utils/sys.cpp
+++ b/src/occa/internal/utils/sys.cpp
@@ -21,7 +21,7 @@
 #  else // OCCA_MACOS_OS
 #    include <AvailabilityMacros.h>
 #    include <mach/mach_host.h>
-#    ifdef __clang__
+#    if MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
 #      include <CoreServices/CoreServices.h>
 #      include <mach/mach_time.h>
 #    else
@@ -83,7 +83,7 @@ namespace occa {
 
       return (double) (ct.tv_sec + (1.0e-9 * ct.tv_nsec));
 #elif (OCCA_OS == OCCA_MACOS_OS)
-#  if defined __clang__ && defined CLOCK_UPTIME_RAW
+#  if MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
       uint64_t nanoseconds = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 
       return 1.0e-9 * nanoseconds;

--- a/src/occa/internal/utils/sys.cpp
+++ b/src/occa/internal/utils/sys.cpp
@@ -402,12 +402,13 @@ namespace occa {
 
     int getTID() {
 #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
-#if OCCA_OS == OCCA_MACOS_OS & (MAC_OS_X_VERSION_MAX_ALLOWED >= 101200)
+#if OCCA_OS == OCCA_MACOS_OS & (MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)
       uint64_t tid64;
-      pthread_threadid_np(NULL, &tid64);
+      pthread_threadid_np(nullptr, &tid64);
       pid_t tid = (pid_t)tid64;
 #else
-      pid_t tid = syscall(SYS_gettid);
+      uint64_t tid;
+      tid = pthread_mach_thread_np(pthread_self());
 #endif
       return tid;
 #else


### PR DESCRIPTION
Not sure why it was conditioned on Clang at all, since `clock_gettime` is provided by SDK and not compiler. Fix that.
Include `AvailabilityMacros.h` – apparently nothing in the codebase does that (or did I miss it?).
Amend fallback code for threadid for older macOS.