### PR TITLE
Declare `memoryPool::reserve` specialization for `void` in header to make available in other translation units.

### DIFF
--- a/include/occa/core/memoryPool.hpp
+++ b/include/occa/core/memoryPool.hpp
@@ -215,12 +215,6 @@ namespace occa {
     template <class T = void>
     occa::memory reserve(const dim_t entries);
 
-
-    // Need to declare this function template specialization
-    // in the header so it is available in other translation units.
-    template <>
-    occa::memory reserve<void>(const dim_t entries);
-
     /**
      * @startDoc{reserve[1]}
      *
@@ -257,6 +251,10 @@ namespace occa {
     void setAlignment(const udim_t alignment);
   };
 
+  // Need to declare this function template specialization
+  // in the header so it is available in other translation units.
+  template <>
+  occa::memory memoryPool::reserve<void>(const dim_t entries);
 }
 
 #include "memoryPool.tpp"

--- a/include/occa/core/memoryPool.hpp
+++ b/include/occa/core/memoryPool.hpp
@@ -215,6 +215,12 @@ namespace occa {
     template <class T = void>
     occa::memory reserve(const dim_t entries);
 
+
+    // Need to declare this function template specialization
+    // in the header so it is available in other translation units.
+    template <>
+    occa::memory reserve<void>(const dim_t entries);
+
     /**
      * @startDoc{reserve[1]}
      *
@@ -233,7 +239,7 @@ namespace occa {
      * @endDoc
      */
     occa::memory reserve(const dim_t entries,
-                         const dtype_t &dtype);\
+                         const dtype_t &dtype);
 
     /**
      * @startDoc{setAlignment}

--- a/tests/src/core/memoryPool.cpp
+++ b/tests/src/core/memoryPool.cpp
@@ -2,9 +2,11 @@
 #include <occa/internal/utils/testing.hpp>
 
 void testReserve();
+void testVoid();
 
 int main(const int argc, const char **argv) {
   testReserve();
+  testVoid();
 
   return 0;
 }
@@ -164,4 +166,16 @@ void testReserve() {
 
   delete[] test;
   delete[] data;
+}
+
+void testVoid() {
+#define ASSERT_SAME_SIZE(a, b) \
+  ASSERT_EQ((size_t) (a), (size_t) (b))
+
+  occa::device device({{"mode", "Serial"}});
+  occa::memoryPool memory_pool = device.createMemoryPool();
+
+  const int size = 10;
+  occa::memory memory = memory_pool.reserve(10);
+  ASSERT_SAME_SIZE(memory.size(), size);
 }


### PR DESCRIPTION
Currently an explicit specialization for `void` is defined in `memoryPool.cpp`, however this is not visible in other translation units, so the default defined in `memoryPool.tpp` is selected by the compiler.

Closes #753 
