### PR TITLE
Fixes for metal backend

### DIFF
--- a/cmake/FindMETAL.cmake
+++ b/cmake/FindMETAL.cmake
@@ -3,24 +3,24 @@
 # This Find module is also distributed alongside the occa package config file!
 ###############################################################################
 
+find_library(FOUNDATION_LIBRARY Foundation)
 find_library(METAL_LIBRARY Metal)
-find_library(CORE_SERVICES CoreServices)
-find_library(APP_KIT AppKit)
+find_library(METAL_KIT_LIBRARY MetalKit)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
     METAL
     REQUIRED_VARS
+    FOUNDATION_LIBRARY
     METAL_LIBRARY
-    CORE_SERVICES
-    APP_KIT
-    )
+    METAL_KIT_LIBRARY
+)
 
 if(METAL_FOUND AND NOT TARGET OCCA::depends::METAL)
   # Create our wrapper imported target
   # Put it in the OCCA namespace to make it clear that we created it.
   add_library(OCCA::depends::METAL INTERFACE IMPORTED)
-  set_target_properties(OCCA::depends::METAL PROPERTIES
-    INTERFACE_LINK_LIBRARIES "${METAL_LIBRARY} ${CORE_SERVICES} ${APP_KIT}"
+  target_link_libraries(OCCA::depends::METAL INTERFACE
+    ${FOUNDATION_LIBRARY} ${METAL_LIBRARY} ${METAL_KIT_LIBRARY}
   )
 endif()

--- a/src/occa/internal/api/metal.mm
+++ b/src/occa/internal/api/metal.mm
@@ -16,7 +16,7 @@ namespace occa {
       }
 
       device_t getDevice(const int deviceId) {
-        NSArray <id<MTLDevice>> *devices = MTLCopyAllDevices();
+        NSArray<id<MTLDevice>> *devices = MTLCopyAllDevices();
 
         id<MTLDevice> device = devices[deviceId];
         void *deviceObj = (__bridge void*) device;


### PR DESCRIPTION
## Description

Trying to get the Metal backend tests pass on my M2.
The following tests fail as of now:

- [ ]  5 - bin-c-kernel (SEGFAULT)
- [ ] 10 - bin-core-kernel (SEGFAULT)
- [ ] 16 - bin-functional-array (Subprocess aborted)
- [ ] 17 - bin-functional-range (Subprocess aborted)
- [ ] 55 - bin-loops-forLoop (SEGFAULT)


<!-- Thank you for contributing! -->
