### PR TITLE
Add NO_RUNTIME_EXCEPTION option to hide errors and warnings backtraces.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option(OCCA_ENABLE_DPCPP "Build with SYCL/DPCPP if available" ON)
 option(OCCA_ENABLE_TESTS    "Build tests"               OFF)
 option(OCCA_ENABLE_EXAMPLES "Build simple examples"     OFF)
 option(OCCA_ENABLE_FORTRAN  "Enable Fortran interface"  OFF)
+option(NO_RUNTIME_EXCEPTION "Hide warnings and errors in runtime"  OFF)
 
 if(OCCA_ENABLE_FORTRAN)
   enable_language(Fortran)
@@ -282,6 +283,9 @@ set(OCCA_SRC
   ${OCCA_SRC_metal})
 
 target_sources(libocca PRIVATE ${OCCA_SRC})
+if (NO_RUNTIME_EXCEPTION)
+  target_compile_definitions(libocca PRIVATE NO_RUNTIME_EXCEPTION)
+endif()
 
 install(TARGETS libocca EXPORT occaExport DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)

--- a/src/utils/exception.cpp
+++ b/src/utils/exception.cpp
@@ -26,6 +26,7 @@ namespace occa {
   std::string exception::toString(const int stackTraceStart) const {
     std::stringstream ss;
 
+  #ifndef NO_RUNTIME_EXCEPTION
     // Pad message lines
     strVector lines = split(message, '\n');
     const int lineCount = (int) lines.size();
@@ -47,6 +48,7 @@ namespace occa {
        << "    Stack\n"
        << sys::stacktrace(stackTraceStart, "      ")
        << std::string(80, '=') << '\n';
+#endif  // NO_RUNTIME_EXCEPTION
 
     return ss.str();
   }

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -22,7 +22,9 @@ namespace occa {
     if (exitInFailure) {
       throw exp;
     }
+#ifndef NO_RUNTIME_EXCEPTION
     io::stderr << exp;
+#endif  // NO_RUNTIME_EXCEPTION
   }
 
   void warn(const std::string &filename,


### PR DESCRIPTION
Turning off errors/warnings might be useful in some release builds, so that application doesn't flood stdout/stderr with some sensitive information (for example compiler output). 