### PR TITLE
Fix a bug in parsing occa cli options

### DIFF
--- a/src/occa/internal/bin/occa.hpp
+++ b/src/occa/internal/bin/occa.hpp
@@ -6,6 +6,7 @@
 namespace occa {
   namespace bin {
     cli::command buildOccaCommand();
+    bool runTranslate(const json &args);
   }
 }
 

--- a/src/occa/internal/utils/cli.cpp
+++ b/src/occa/internal/utils/cli.cpp
@@ -405,6 +405,7 @@ namespace occa {
     }
 
     occa::json parser::parseArgs(const strVector &args_,
+                                 const std::vector<command> &commands,
                                  const bool supressErrors) {
       strVector args = splitShortOptionArgs(args_);
       const int argc = (int) args.size();
@@ -445,7 +446,12 @@ namespace occa {
 
         // No option
         if (!opt) {
-          checkOptions = (arg == "==");
+          for (auto cmd : commands) {
+            if (arg == cmd.name) {
+              checkOptions = 0;
+              break;
+            }
+          }
           jArguments += arg;
           continue;
         }
@@ -779,7 +785,7 @@ namespace occa {
 
       const bool hasCommands = commands.size();
 
-      json parsedArgs = parseArgs(shellArgs, supressErrors);
+      json parsedArgs = parseArgs(shellArgs, commands, supressErrors);
       lastCommandArgs = parsedArgs;
 
       json &jArguments = parsedArgs["arguments"];

--- a/src/occa/internal/utils/cli.hpp
+++ b/src/occa/internal/utils/cli.hpp
@@ -120,6 +120,8 @@ namespace occa {
     };
     //==================================
 
+    class command;
+
     //---[ Parser ]---------------------
     class parser : public printable {
     public:
@@ -157,6 +159,7 @@ namespace occa {
 
       occa::json parseArgs(const int argc, const char **argv);
       occa::json parseArgs(const strVector &args_,
+                           const std::vector<command> &commands = {},
                            const bool supressErrors = false);
 
       bool hasCustomHelpOption();


### PR DESCRIPTION
## Description

With the current `development` branch, the following doesn't work (it produces serial output):
```sh
./bin/occa translate ~/addVectors.okl --mode cuda
```

With this change, the above work as expected and produces cuda output.

### Todo
- [x] Add a test for the failed case