### PR TITLE
Prefix user variables in CMake configure scripts

### DIFF
--- a/configure-cmake.sh
+++ b/configure-cmake.sh
@@ -8,9 +8,9 @@
 #FFLAGS=
 
 # Default build parameters
-: ${BUILD_DIR:=`pwd`/build}
-: ${INSTALL_DIR:=`pwd`/install}
-: ${BUILD_TYPE:="RelWithDebInfo"}
+: ${OCCA_BUILD_DIR:=`pwd`/build}
+: ${OCCA_INSTALL_DIR:=`pwd`/install}
+: ${OCCA_BUILD_TYPE:="RelWithDebInfo"}
 
 : ${CC:="gcc"}
 : ${CXX:="g++"}
@@ -26,9 +26,9 @@
 : ${OCCA_ENABLE_TESTS="ON"}
 : ${OCCA_ENABLE_EXAMPLES="ON"}
 
-cmake -S . -B ${BUILD_DIR} \
-  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+cmake -S . -B ${OCCA_BUILD_DIR} \
+  -DCMAKE_BUILD_TYPE=${OCCA_BUILD_TYPE} \
+  -DCMAKE_INSTALL_PREFIX=${OCCA_INSTALL_DIR} \
   -DCMAKE_C_COMPILER=${CC} \
   -DCMAKE_CXX_COMPILER=${CXX} \
   -DCMAKE_Fortran_COMPILER=${FC} \

--- a/configure-sycl-nv-cmake.sh
+++ b/configure-sycl-nv-cmake.sh
@@ -10,11 +10,10 @@ export OCCA_DPCPP_COMPILER_FLAGS="-fsycl -fsycl-targets=nvptx64-nvidia-cuda"
 CC=clang
 CXX=clang++
 #FC=
-
 # Default build parameters
-: ${BUILD_DIR:=`pwd`/build}
-: ${INSTALL_DIR:=`pwd`/install}
-: ${BUILD_TYPE:="RelWithDebInfo"}
+: ${OCCA_BUILD_DIR:=`pwd`/build}
+: ${OCCA_INSTALL_DIR:=`pwd`/install}
+: ${OCCA_BUILD_TYPE:="RelWithDebInfo"}
 
 : ${CC:="gcc"}
 : ${CXX:="g++"}
@@ -30,9 +29,9 @@ CXX=clang++
 : ${OCCA_ENABLE_TESTS="ON"}
 : ${OCCA_ENABLE_EXAMPLES="ON"}
 
-cmake -S . -B ${BUILD_DIR} \
-  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+cmake -S . -B ${OCCA_BUILD_DIR} \
+  -DCMAKE_BUILD_TYPE=${OCCA_BUILD_TYPE} \
+  -DCMAKE_INSTALL_PREFIX=${OCCA_INSTALL_DIR} \
   -DCMAKE_C_COMPILER=${CC} \
   -DCMAKE_CXX_COMPILER=${CXX} \
   -DCMAKE_Fortran_COMPILER=${FC} \


### PR DESCRIPTION
## Description

Probably it is a good idea to prefix the variables used in the configure CMake
scripts as these could be called from other bash scripts. This PR makes calling
configure scripts similar to the following:
```sh
export OCCA_BUILD_DIR=`pwd`/build
export OCCA_INSTALL_DIR=`pwd`/install
./configure-cmake.sh
```

instead of the following:
```sh
export BUILD_DIR=`pwd`/build
export INSTALL_DIR=`pwd`/install
./configure-cmake.sh
```