### PR TITLE
Add missing includes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,9 +19,10 @@ ignore:
   - scripts
   - include/occa/scripts
   # Auto-generated files
-  - include/occa/core/kernelOperators.hpp_codegen
-  - src/core/kernelOperators.cpp_codegen
-  - src/occa/internal/utils/runFunction.cpp_codegen
+  - include/codegen/kernelOperators.cpp_codegen
+  - include/codegen/kernelOperators.hpp_codegen
+  - include/codegen/macros.hpp_codegen
+  - include/codegen/runFunction.cpp_codegen
   # Exception is not tracked properly
   - src/utils/exception.cpp
   # Modes that can't be tested with CI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,21 +139,21 @@ jobs:
         -DOCCA_ENABLE_EXAMPLES=ON \
         -DOCCA_ENABLE_FORTRAN=${OCCA_FORTRAN_ENABLED}
     
-    - name: CMake build
+    - name: CMake build and install
       if: ${{ matrix.useCMake && !matrix.useoneAPI}}
       run: |
-        cmake --build build --parallel 16
+        cmake --build build --target install --parallel 16
 
-    - name: CMake build
+    - name: CMake build and install
       if: ${{ matrix.useCMake && matrix.useoneAPI}}
       env:
         OCCA_CC: ${{ matrix.CC }}
         OCCA_CXX: ${{ matrix.CXX }}
       run: |
         source /opt/intel/oneapi/setvars.sh
-        cmake --build build --parallel 16
+        cmake --build build --target install --parallel 16
 
-    - name: Compile library
+    - name: Compile library and install
       if: ${{ !matrix.useCMake }}
       run: make -j 16
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,9 @@ jobs:
       uses: mxschmitt/action-tmate@v3.13
       if: ${{ inputs.debug_enabled }}
 
+    - name: Set OCCA install directory
+      run: echo "OCCA_INSTALL_DIR=${PWD}/install" >> ${GITHUB_ENV}
+
     - name: add oneAPI to apt
       if: ${{ matrix.useoneAPI }}
       shell: bash
@@ -104,14 +107,14 @@ jobs:
 
     - name: Compiler info
       if: ${{ !matrix.useCMake }}
-      run: make -j 16 info
+      run: make PREFIX=${{ env.OCCA_INSTALL_DIR }} -j 16 info
 
     - name: CMake configure
       if: ${{ matrix.useCMake && !matrix.useoneAPI}}
       run: |
         cmake -S . -B build \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-        -DCMAKE_INSTALL_PREFIX=install \
+        -DCMAKE_INSTALL_PREFIX=${{ env.OCCA_INSTALL_DIR }} \
         -DCMAKE_C_COMPILER=${CC} \
         -DCMAKE_CXX_COMPILER=${CXX} \
         -DCMAKE_Fortran_COMPILER=${FC} \
@@ -128,7 +131,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         cmake -S . -B build \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-        -DCMAKE_INSTALL_PREFIX=install \
+        -DCMAKE_INSTALL_PREFIX=${{ env.OCCA_INSTALL_DIR }} \
         -DCMAKE_C_COMPILER=${CC} \
         -DCMAKE_CXX_COMPILER=${CXX} \
         -DCMAKE_Fortran_COMPILER=${FC} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,14 +107,14 @@ jobs:
 
     - name: Compiler info
       if: ${{ !matrix.useCMake }}
-      run: make PREFIX=${{ env.OCCA_INSTALL_DIR }} -j 16 info
+      run: make PREFIX=${OCCA_INSTALL_DIR} -j 16 info
 
     - name: CMake configure
       if: ${{ matrix.useCMake && !matrix.useoneAPI}}
       run: |
         cmake -S . -B build \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-        -DCMAKE_INSTALL_PREFIX=${{ env.OCCA_INSTALL_DIR }} \
+        -DCMAKE_INSTALL_PREFIX=${OCCA_INSTALL_DIR} \
         -DCMAKE_C_COMPILER=${CC} \
         -DCMAKE_CXX_COMPILER=${CXX} \
         -DCMAKE_Fortran_COMPILER=${FC} \
@@ -131,7 +131,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         cmake -S . -B build \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-        -DCMAKE_INSTALL_PREFIX=${{ env.OCCA_INSTALL_DIR }} \
+        -DCMAKE_INSTALL_PREFIX=${OCCA_INSTALL_DIR} \
         -DCMAKE_C_COMPILER=${CC} \
         -DCMAKE_CXX_COMPILER=${CXX} \
         -DCMAKE_Fortran_COMPILER=${FC} \

--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,10 @@ opt
 /.compiledDefines
 /include/occa/defines/compiledDefines.hpp
 /include/occa/scripts
-/include/occa/core/kernelOperators.hpp_codegen
-/src/core/kernelOperators.cpp_codegen
-/src/occa/internal/utils/runFunction.cpp_codegen
-/include/occa/defines/macros.hpp_codegen
+/include/codegen/kernelOperators.cpp_codegen
+/include/codegen/kernelOperators.hpp_codegen
+/include/codegen/macros.hpp_codegen
+/include/codegen/runFunction.cpp_codegen
 
 # Binaries generated to fetch compiler information
 /scripts/compiler/compilerSupportsMPI

--- a/Makefile
+++ b/Makefile
@@ -80,14 +80,14 @@ else
 endif
 #=================================================
 
-PLACE_GENERATED_CODES := $(shell mkdir -p $(OCCA_DIR)/include/occa/core/codegen | \
+PLACE_GENERATED_CODES := $(shell mkdir -p $(OCCA_DIR)/include/codegen | \
                                  mkdir -p $(OCCA_DIR)/src/core/codegen | \
                                  mkdir -p $(OCCA_DIR)/src/occa/internal/utils/codegen | \
                                  mkdir -p $(OCCA_DIR)/include/occa/defines/codegen)
-PLACE_GENERATED_CODES := $(shell cp $(OCCA_DIR)/scripts/codegen/kernelOperators.hpp_codegen.in $(OCCA_DIR)/include/occa/core/codegen/kernelOperators.hpp_codegen | \
-                                 cp $(OCCA_DIR)/scripts/codegen/kernelOperators.cpp_codegen.in $(OCCA_DIR)/src/core/codegen/kernelOperators.cpp_codegen | \
-                                 cp $(OCCA_DIR)/scripts/codegen/runFunction.cpp_codegen.in $(OCCA_DIR)/src/occa/internal/utils/codegen/runFunction.cpp_codegen | \
-                                 cp $(OCCA_DIR)/scripts/codegen/macros.hpp_codegen.in $(OCCA_DIR)/include/occa/defines/codegen/macros.hpp_codegen)
+PLACE_GENERATED_CODES := $(shell cp $(OCCA_DIR)/scripts/codegen/kernelOperators.cpp_codegen.in $(OCCA_DIR)/include/codegen/kernelOperators.cpp_codegen | \
+                                 cp $(OCCA_DIR)/scripts/codegen/kernelOperators.hpp_codegen.in $(OCCA_DIR)/include/codegen/kernelOperators.hpp_codegen | \
+                                 cp $(OCCA_DIR)/scripts/codegen/macros.hpp_codegen.in $(OCCA_DIR)/include/codegen/macros.hpp_codegen | \
+                                 cp $(OCCA_DIR)/scripts/codegen/runFunction.cpp_codegen.in $(OCCA_DIR)/include/codegen/runFunction.cpp_codegen)
 
 #---[ Compile Library ]---------------------------
 # Setup compiled defines and force rebuild if defines changed

--- a/cmake/CodeGen.cmake
+++ b/cmake/CodeGen.cmake
@@ -28,10 +28,16 @@ else()
   endif()
 endif()
 
-#    Set installtion of files required in header
+# Set installtion of files required in header
 install(
-  FILES ${OCCA_BUILD_DIR}/include/codegen/kernelOperators.hpp_codegen
-  DESTINATION include/occa/core/codegen)
+  FILES ${OCCA_BUILD_DIR}/include/codegen/kernelOperators.cpp_codegen
+  DESTINATION include/codegen)
+install(
+ FILES ${OCCA_BUILD_DIR}/include/codegen/kernelOperators.hpp_codegen
+ DESTINATION include/codegen)
 install(
   FILES ${OCCA_BUILD_DIR}/include/codegen/macros.hpp_codegen
-  DESTINATION include/occa/defines/codegen)
+  DESTINATION include/codegen)
+install(
+  FILES ${OCCA_BUILD_DIR}/include/codegen/runFunction.cpp_codegen
+  DESTINATION include/codegen)

--- a/include/occa.hpp
+++ b/include/occa.hpp
@@ -7,5 +7,6 @@
 #include <occa/loops.hpp>
 #include <occa/types.hpp>
 #include <occa/utils.hpp>
+#include <occa/defines.hpp>
 
 #endif


### PR DESCRIPTION
## Description

Currently, when we run OCCA tests,  they use the automatically generated `*_codegen`
files from the build directory. This is because, we do the following two things:

* `-I${OCCA_INSTALL_DIR}` is added to the compile command in `device::buildKernel()`
methods.
* If `OCCA_INSTALL_DIR` is not defined, it defaults to `OCCA_BUILD_DIR`.

Since we never set `OCCA_INSTALL_DIR`, we have always been using `*_codegen` files from
the build directory. When I tried running the tests by setting `OCCA_INSTALL_DIR`, I get
compilation errors since we don't have the required `*_codegen` files at the correct places
in the install directory. This PR fixes this issue.

~PS: I only tested the `CMake` build for now. May need fixes for the `GNU Make` build.~

## Todo
- [x] Run the GitHub CI tests with `OCCA_INSTALL_DIR` set.
