### PR TITLE
Avoid `-fsycl` being added to non-SYCL code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,6 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-include(CheckRequiredCompilerFeatures)
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(OCCA_ENABLE_OPENMP "Build with OpenMP if available" ON)
@@ -244,6 +241,8 @@ if(OCCA_ENABLE_METAL AND APPLE)
   endif()
 endif()
 #=======================================
+
+include(CheckRequiredCompilerFeatures)
   
 if(NOT OCCA_IS_TOP_LEVEL)
 # OCCA is being built as a subdirectory in another project

--- a/cmake/CheckRequiredCompilerFeatures.cmake
+++ b/cmake/CheckRequiredCompilerFeatures.cmake
@@ -13,3 +13,10 @@ int main(int argc, char *argv[]) {
 if (NOT HAS_FILE_SYSTEM)
   message(FATAL_ERROR "CXX compiler doesn't have std::filesystem support !")
 endif()
+
+if (OCCA_DPCPP_ENABLED)
+  check_cxx_compiler_flag("-fsycl" IS_SYCL_SUPPORTED)
+  if (NOT IS_SYCL_SUPPORTED)
+    message(FATAL_ERROR "DPCPP is enabled but the compiler doesn't support \"-fsycl\" flag!")
+  endif()
+endif()

--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -9,7 +9,7 @@ unset(missingDpcppComponents)
 find_path(
   SYCL_INCLUDE_DIRS
   NAMES
-    sycl.hpp
+    sycl/sycl.hpp
   PATHS
     ENV SYCL_ROOT
     /opt/intel/oneapi/compiler/latest/linux
@@ -56,7 +56,7 @@ if(DPCPP_FOUND AND NOT TARGET OCCA::depends::DPCPP)
   separate_arguments(SYCL_FLAGS UNIX_COMMAND "${SYCL_FLAGS}")
   target_compile_options(OCCA::depends::DPCPP INTERFACE ${SYCL_FLAGS})
   set_target_properties(OCCA::depends::DPCPP PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${SYCL_INCLUDE_DIRS}"
+    INTERFACE_INCLUDE_DIRECTORIES "${SYCL_INCLUDE_DIRS};${SYCL_INCLUDE_DIRS}/sycl"
     INTERFACE_LINK_LIBRARIES "${SYCL_LIBRARIES}"
   )
 endif()

--- a/src/occa/internal/modes/dpcpp/polyfill.hpp
+++ b/src/occa/internal/modes/dpcpp/polyfill.hpp
@@ -4,7 +4,7 @@
 #define OCCA_MODES_DPCPP_POLYFILL_HEADER
 
 #if OCCA_DPCPP_ENABLED
-#include <sycl.hpp>
+#include <sycl/sycl.hpp>
 #else
 #include <cstdint>
 #include <vector>


### PR DESCRIPTION
## Description

In the current `development` version, `FindDPCPP.cmake` adds `-fsycl` to the
host (one that is being used to compile OCCA) compiler. This results in compilation
errors if the host compiler doesn't support SYCL. There is no need for the host
compiler to support SYCL to use the OCCA SYCL backend. Users simply has to
set the following variables:

```sh
export OCCA_DPCPP_COMPILER=clang++
export OCCA_DPCPP_COMPILER_FLAGS="-fsycl -fsycl-targets=nvptx64-nvidia-cuda"
```

<!-- Thank you for contributing! -->
