### PR TITLE
Check if the compiler supports `std::filesystem`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,12 +80,6 @@ if (OCCA_CLANG_BASED_TRANSPILER)
 endif()
 
 include(SetCompilerFlags)
-include(CheckCXXCompilerFlag)
-
-check_cxx_compiler_flag("-fno-strict-aliasing" COMPILER_SUPPORTS_NO_STRICT_ALIASING)
-if(COMPILER_SUPPORTS_NO_STRICT_ALIASING)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
-endif()
 
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPER)
 message("-- System     : ${CMAKE_SYSTEM}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(CheckRequiredCompilerFeatures)
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(OCCA_ENABLE_OPENMP "Build with OpenMP if available" ON)

--- a/cmake/CheckRequiredCompilerFeatures.cmake
+++ b/cmake/CheckRequiredCompilerFeatures.cmake
@@ -1,0 +1,15 @@
+include(CheckCXXCompilerFlag)
+
+check_cxx_source_compiles("
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+int main(int argc, char *argv[]) {
+  return 0;
+}
+" HAS_FILE_SYSTEM)
+
+if (NOT HAS_FILE_SYSTEM)
+  message(FATAL_ERROR "CXX compiler doesn't have std::filesystem support !")
+endif()

--- a/cmake/SetCompilerFlags.cmake
+++ b/cmake/SetCompilerFlags.cmake
@@ -87,3 +87,8 @@ if (OCCA_ENABLE_FORTRAN)
   set_optional_fortran_flag(SUPPORTED_WNO_INTEGER_DIVISION_Fortran_FLAGS "-Wno-integer-division")
 
 endif()
+
+check_cxx_compiler_flag("-fno-strict-aliasing" COMPILER_SUPPORTS_NO_STRICT_ALIASING)
+if(COMPILER_SUPPORTS_NO_STRICT_ALIASING)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
+endif()


### PR DESCRIPTION
## Description

We need `std::filesystem` support in the CXX compiler in order to compile OCCA.
Seems like some gcc versions even with `-std=c++17` set doesn't support `std::filesystem`.


<!-- Thank you for contributing! -->
