### PR TITLE
Fix `dangling reference to temporary` warning when using gcc >= 13

### DIFF
--- a/src/c/device.cpp
+++ b/src/c/device.cpp
@@ -39,8 +39,7 @@ const char* occaDeviceMode(occaDevice device) {
 }
 
 occaJson occaDeviceGetProperties(occaDevice device) {
-  const occa::json &props = occa::c::device(device).properties();
-  return occa::c::newOccaType(props, false);
+  return occa::c::newOccaType(occa::c::device(device).properties(), false);
 }
 
 const char* occaDeviceArch(occaDevice device) {
@@ -48,18 +47,15 @@ const char* occaDeviceArch(occaDevice device) {
 }
 
 occaJson occaDeviceGetKernelProperties(occaDevice device) {
-  const occa::json &props = occa::c::device(device).kernelProperties();
-  return occa::c::newOccaType(props, false);
+  return occa::c::newOccaType(occa::c::device(device).kernelProperties(), false);
 }
 
 occaJson occaDeviceGetMemoryProperties(occaDevice device) {
-  const occa::json &props = occa::c::device(device).memoryProperties();
-  return occa::c::newOccaType(props, false);
+  return occa::c::newOccaType(occa::c::device(device).memoryProperties(), false);
 }
 
 occaJson occaDeviceGetStreamProperties(occaDevice device) {
-  const occa::json &props = occa::c::device(device).streamProperties();
-  return occa::c::newOccaType(props, false);
+  return occa::c::newOccaType(occa::c::device(device).streamProperties(), false);
 }
 
 occaUDim_t occaDeviceMemorySize(occaDevice device) {

--- a/src/occa/internal/lang/builtins/attributes/atomic.cpp
+++ b/src/occa/internal/lang/builtins/attributes/atomic.cpp
@@ -105,7 +105,7 @@ namespace occa {
       }
 
       bool atomic::isBasicExpression(expressionStatement &exprSmnt) {
-        const opType_t &opType = expr(exprSmnt.expr).opType();
+        const opType_t opType = expr(exprSmnt.expr).opType();
         return opType & (
           operatorType::addEq
           | operatorType::subEq

--- a/src/occa/internal/lang/modes/cuda.cpp
+++ b/src/occa/internal/lang/modes/cuda.cpp
@@ -177,7 +177,7 @@ namespace occa {
 
       bool cudaParser::transformAtomicBasicExpressionStatement(expressionStatement &exprSmnt) {
         // TODO: Create actual statements + expressions, don't just shove strings in
-        const opType_t &opType = expr(exprSmnt.expr).opType();
+        const opType_t opType = expr(exprSmnt.expr).opType();
 
         printer pout;
         if (opType & operatorType::unary) {

--- a/src/occa/internal/lang/modes/dpcpp.cpp
+++ b/src/occa/internal/lang/modes/dpcpp.cpp
@@ -420,7 +420,7 @@ namespace occa
       {
         expressionStatement &atomicSmnt = dynamic_cast<expressionStatement &>(exprSmnt.clone());
 
-        const opType_t &opType = expr(atomicSmnt.expr).opType();
+        const opType_t opType = expr(atomicSmnt.expr).opType();
 
         exprNode *variable_node{nullptr};
         if (opType & operatorType::unary)


### PR DESCRIPTION
Avoid using the temporary variables and capture some variables by value in order to avoid a false positive
warning when compiling with gcc >= 13. Latter might have some performance degradation as the captured
variable is of type `occa::bitfield`. Maybe a different fix is necessary there.