### PR TITLE
Add env var to override OCCA HIP compile arch

### DIFF
--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -220,10 +220,15 @@ namespace occa {
 
         std::string archString = kernelProps.get<std::string>("arch", arch);
 
+        // Override the arch if the users requests it
+        if (env::var("OCCA_HIP_OVERRIDE_COMPILE_ARCH").size()) {
+          archString = env::var("OCCA_HIP_OVERRIDE_COMPILE_ARCH");
+        }
+
         std::string archFlag;
         if (startsWith(archString, "sm_")) {
           archFlag = " -arch=" + archString;
-        } else if (startsWith(archString, "gfx")) {
+        } else if (startsWith(archString, "gfx") || startsWith(archString, "amd")) {
           archFlag = " --offload-arch=" + archString;
         } else {
           OCCA_FORCE_ERROR("Unknown HIP arch");

--- a/src/occa/internal/modes/hip/device.cpp
+++ b/src/occa/internal/modes/hip/device.cpp
@@ -221,8 +221,8 @@ namespace occa {
         std::string archString = kernelProps.get<std::string>("arch", arch);
 
         // Override the arch if the users requests it
-        if (env::var("OCCA_HIP_OVERRIDE_COMPILE_ARCH").size()) {
-          archString = env::var("OCCA_HIP_OVERRIDE_COMPILE_ARCH");
+        if (env::var("OCCA_OVERRIDE_COMPILE_ARCH").size()) {
+          archString = env::var("OCCA_OVERRIDE_COMPILE_ARCH");
         }
 
         std::string archFlag;


### PR DESCRIPTION
## Description

This commit teaches OCCA to understand the `OCCA_HIP_OVERRIDE_COMPILE_ARCH` environment variable.  If set, OCCA will ignore the arch set in the kernel properties and try to compile for the architecture provided in the environment variable.

This allows the user to have more control over what targets are JITted for. Usecases are for JITting for generic targets (see [here](https://github.com/llvm/llvm-project/commit/f93aa5157a3317b24cff660ac972814ee9ed4dbc)) and for the (currently beta) amdgcnspirv target (see [here](https://rocm.docs.amd.com/projects/llvm-project/en/latest/conceptual/spirv.html#rocm-support-for-spir-v-beta)).

Unfortunately, the amdgcnspirv target name doesn't start with "gfx", so I added a branch that checks for this case and treats it accordingly.

Comments, criticism, tomatoes, and hecklers are not only welcome but heavily encouraged.

<!-- Thank you for contributing! -->
