### PR TITLE
Declare alias targets, make `examples` & `tests` independent `CMake` projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,20 @@ jobs:
       run: |
         cmake --build build --target install --parallel 16
 
+    - name: CMake build examples as an independent project
+      if: ${{ matrix.useCMake && !matrix.useoneAPI}}
+      run: |
+        export OCCA_DIR=${OCCA_INSTALL_DIR}
+        cd examples
+        cmake -S . -B build
+
+    - name: CMake build tests as an independent project
+      if: ${{ matrix.useCMake && !matrix.useoneAPI}}
+      run: |
+        export OCCA_DIR=${OCCA_INSTALL_DIR}
+        cd tests
+        cmake -S . -B build
+
     - name: CMake build and install
       if: ${{ matrix.useCMake && matrix.useoneAPI}}
       env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,10 +92,13 @@ endif()
 if(OCCA_ENABLE_FORTRAN)
   set(CMAKE_Fortran_MODULE_DIRECTORY ${OCCA_BUILD_DIR}/mod)
 endif()
+
+set(namespace "${PROJECT_NAME}::")
 #=======================================
 
 #---[ libocca.so ]----------------------
 add_library(libocca SHARED)
+add_library(${namespace}libocca ALIAS libocca)
 
 # Without this, CMake will create liblibocca.so
 set_target_properties(libocca PROPERTIES

--- a/README.md
+++ b/README.md
@@ -77,11 +77,18 @@ During installation, the [Env Modules](Env_Modules) file `<install-prefix>/modul
 ### Building an OCCA application
 
 For convenience, OCCA provides CMake package files which are configured during installation. These package files define an imported target, `OCCA::libocca`, and look for all required dependencies.
-
-For example, the CMakeLists.txt of downstream projects using OCCA would include
+For example, downstream projects using OCCA would either have
 ```cmake
 find_package(OCCA REQUIRED)
+```
+or
+```cmake
+add_subdirectory(3rd_party/occa)
+```
+in the project `CMakeLists.txt`.
 
+Then OCCA can be linked to other targets as follows:
+```cmake
 add_executable(downstream-app ...)
 target_link_libraries(downstream-app PRIVATE OCCA::libocca)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ OCCA uses the [CMake] build system. Checkout the [installation guide](INSTALL.md
 
 For convenience, the shell script `configure-cmake.sh` has been provided to drive the CMake build. Compilers, flags, and other build parameters can be adjusted there. By default, this script uses `./build` and `./install` for the build and install directories.
 
-The following demonstrates a typical sequence of shell commands to build, test, and install occa:
+The following demonstrates a typical sequence of shell commands to build, test, and install OCCA:
 ```shell
 $ ./configure-cmake.sh
 $ cmake --build build --parallel <number-of-threads>

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(occa occa.cpp)
+add_executable(${namespace}occa ALIAS occa)
 
 target_link_libraries(occa libocca)
 target_include_directories(occa PRIVATE

--- a/cmake/ExportAndPackageConfig.cmake
+++ b/cmake/ExportAndPackageConfig.cmake
@@ -5,7 +5,6 @@
 
 # Install in subdirectory lib/cmake/PACKAGENAME, which is where cmake expects package config files
 set(PackageConfigInstallLocation lib/cmake/OCCA)
-set(ExportNamespace "OCCA::")
 
 # Set the exportPackageDependencies variable, for use in configuring occaConfig.cmake.in
 # Do this for all our dependencies. In theory, could skip some if they are
@@ -35,8 +34,8 @@ endif()
 # List of what targets are exported, for use in configuring occaConfig.cmake.in
 # Explicit list because unfortunately no easy way to retrieve it through cmake, even though they all are part of the EXPORT occaExport
 set(exportTargets "")
-string(APPEND exportTargets "# ${ExportNamespace}libocca Target to link to for using occa\n")
-string(APPEND exportTargets "# ${ExportNamespace}occa The occa executable, e.g. can be called to get information on supported backends\n")
+string(APPEND exportTargets "# ${namespace}libocca Target to link to for using occa\n")
+string(APPEND exportTargets "# ${namespace}occa The occa executable, e.g. can be called to get information on supported backends\n")
 
 include(CMakePackageConfigHelpers)
 # Create the PackageConfig file, based on the template
@@ -63,7 +62,7 @@ write_basic_package_version_file(
 # Will be used by the PackageConfig to generate the imported targets
 install(
   EXPORT occaExport
-  NAMESPACE ${ExportNamespace}
+  NAMESPACE ${namespace}
   FILE OCCATargets.cmake
   DESTINATION ${PackageConfigInstallLocation}
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,14 @@
+cmake_minimum_required (VERSION 3.21 FATAL_ERROR)
+project(OCCAExamples
+  VERSION 2.0.0
+  DESCRIPTION  "OCCA Examples"
+  HOMEPAGE_URL "https://github.com/libocca/occa"
+  LANGUAGES C CXX)
+
+if (NOT TARGET OCCA::libocca)
+  find_package(OCCA REQUIRED)
+endif()
+
 macro(add_test_with_mode exe mode device)
   add_test(NAME ${exe}-${mode} COMMAND ./${exe} --verbose --device "${device}")
   set_property(TEST ${exe}-${mode} APPEND PROPERTY ENVIRONMENT OCCA_CACHE_DIR=${OCCA_BUILD_DIR}/occa)
@@ -32,7 +43,7 @@ endmacro()
 
 macro(compile_example target file mode)
   add_executable(${target} ${file})
-  target_link_libraries(${target} libocca)
+  target_link_libraries(${target} OCCA::libocca)
   target_include_directories(${target} PRIVATE $<BUILD_INTERFACE:${OCCA_SOURCE_DIR}/src>)
 
   file(RELATIVE_PATH install_dir ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_LIST_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,14 @@
+cmake_minimum_required (VERSION 3.21 FATAL_ERROR)
+project(OCCATests
+  VERSION 2.0.0
+  DESCRIPTION  "OCCA Tests"
+  HOMEPAGE_URL "https://github.com/libocca/occa"
+  LANGUAGES C CXX)
+
+if (NOT TARGET OCCA::libocca)
+  find_package(OCCA REQUIRED)
+endif()
+
 function(add_occa_test test_source)
   # Metadata
   get_filename_component(source_directory ${test_source} DIRECTORY)
@@ -17,7 +28,7 @@ function(add_occa_test test_source)
     RUNTIME_OUTPUT_DIRECTORY ${test_directory})
 
   # Build config
-  target_link_libraries(${cmake_test_target} libocca ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+  target_link_libraries(${cmake_test_target} OCCA::libocca ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
   target_include_directories(${cmake_test_target} PRIVATE
     $<BUILD_INTERFACE:${OCCA_SOURCE_DIR}/src>)
 
@@ -50,7 +61,7 @@ if (OCCA_ENABLE_FORTRAN)
     EXCLUDE REGEX "src/fortran/typedefs_helper.cpp")
 
   add_library(libtypedefs_helper SHARED "src/fortran/typedefs_helper.cpp")
-  target_link_libraries(libtypedefs_helper libocca)
+  target_link_libraries(libtypedefs_helper OCCA::libocca)
 else()
   list(FILTER occa_tests
     EXCLUDE REGEX "src/fortran")


### PR DESCRIPTION
## Description

Unify `find_package()` and `add_directory()` usage of OCCA in downstream projects. 
Without the changes in this PR, we can't do:
```cmake
add_subdirectory(3rd_party/occa)
target_link_libraries(MyTarget OCCA::libocca)
```

as `OCCA::libocca` is only defined in config files generated by CMake during the install.


<!-- Thank you for contributing! -->
