### PR TITLE
cmake: list-separate frameworks in FindMETAL.cmake

### DIFF
--- a/cmake/FindMETAL.cmake
+++ b/cmake/FindMETAL.cmake
@@ -21,6 +21,6 @@ if(METAL_FOUND AND NOT TARGET OCCA::depends::METAL)
   # Put it in the OCCA namespace to make it clear that we created it.
   add_library(OCCA::depends::METAL INTERFACE IMPORTED)
   set_target_properties(OCCA::depends::METAL PROPERTIES
-    INTERFACE_LINK_LIBRARIES "${METAL_LIBRARY} ${CORE_SERVICES} ${APP_KIT}"
+    INTERFACE_LINK_LIBRARIES "${METAL_LIBRARY};${CORE_SERVICES};${APP_KIT}"
   )
 endif()


### PR DESCRIPTION
`INTERFACE_LINK_LIBRARIES` expects a CMake list (semicolon-separated). The space-separated form in [`cmake/FindMETAL.cmake:24`](https://github.com/libocca/occa/blob/65efd39c/cmake/FindMETAL.cmake#L24) makes CMake treat the three framework paths as a single one. On macOS arm64 with a recent Xcode SDK the linker fails:

```
ld: warning: search path '/.../Metal.framework /.../CoreServices.framework /.../Frameworks' not found
Undefined symbols for architecture arm64:
  "_MTLCopyAllDevices", referenced from:
      occa::api::metal::getDeviceCount() in metal.mm.o
ld: symbol(s) not found for architecture arm64
```

One-character fix: replace the spaces with semicolons.
